### PR TITLE
Implement data-driven damage tracking and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+      - run: pnpm test:e2e
+        env:
+          CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The project is built with [Vite](https://vitejs.dev/) and [React](https://react.
 ### Prerequisites
 
 - Node.js 18.18 or later
-- pnpm 8.7 or later
+- pnpm 9 or later
 
 ### Install dependencies
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,23 @@ A `pre-commit` hook ensures formatting, linting, and unit tests run before each 
 
 ## Current Architecture
 
-The initial UI layout focuses on clarity and accessibility while the underlying damage tracking logic is implemented:
+The UI now wires together real-time combat calculations driven by typed data models:
 
-- `src/app/App.tsx` renders the shell of the application and defines three primary panels: build configuration, attack logging, and combat statistics.
-- Components under `src/features/*` encapsulate early UI scaffolding for each major feature area.
+- `src/data/` stores structured JSON for charms, nail upgrades, spells, and boss health pools, along with helpers that expose typed lookups.
+- `FightStateProvider` (under `src/features/fight-state/`) centralizes build configuration, attack logs, and derived combat statistics that power the UI.
+- `BuildConfigPanel`, `AttackLogPanel`, and `CombatStatsPanel` consume the shared state to surface boss presets, configurable damage presets, and running metrics.
 - Shared layout primitives live in `src/components/` and global theming resides in `src/styles/`.
 
-Vitest (unit tests) and Playwright (e2e tests) validate that core sections render correctly so future iterations can evolve safely.
+Vitest (unit tests) and Playwright (e2e tests) validate that core sections render correctly and that critical interactions—such as selecting bosses or logging attacks—update derived statistics as expected.
+
+### Feature Highlights
+
+- **Boss presets and custom targets:** Quickly switch between lore-accurate boss HP values or specify any target for practice sessions.
+- **Data-driven build controls:** Choose nail upgrades, toggle influential charms, and declare which spell upgrades are available to tune damage presets.
+- **Categorized attack logging:** Nail strikes, spell casts, and advanced techniques each expose context-aware damage values that respect build modifiers like Unbreakable Strength or Shaman Stone.
+- **Live combat analytics:** Remaining HP, DPS, average damage, and actions per minute update instantly as attacks are logged, giving immediate feedback on fight pacing.
+
+Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 
 ## Project Roadmap
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,18 +5,18 @@
 - [x] Scaffold a React + TypeScript project with Vite and configure pnpm workspace settings.
 - [x] Set up ESLint, Prettier, and Stylelint (for future CSS modules) with a shared configuration.
 - [x] Configure Vitest with React Testing Library and establish coverage thresholds.
-- [ ] Add Playwright end-to-end test harness with GitHub Actions integration.
+- [x] Add Playwright end-to-end test harness with GitHub Actions integration.
   - [x] Scaffold local Playwright tests and configuration.
-  - [ ] Add GitHub Actions job to run Playwright in CI.
+  - [x] Add GitHub Actions job to run Playwright in CI.
 - [x] Implement Git hooks via Husky or simple `pnpm` scripts to enforce lint/test on commit.
-- [ ] Create GitHub Actions workflows for linting, unit tests, e2e tests, and deployment to GitHub Pages.
+- [x] Create GitHub Actions workflows for linting, unit tests, e2e tests, and deployment to GitHub Pages.
 
 ## Feature Development
 
-- [ ] Define data models for charms, nail upgrades, and other modifiers.
-- [ ] Build UI for selecting a boss fight or custom target HP.
-- [ ] Implement attack logging buttons grouped by nail attacks, spells, and advanced techniques (e.g., Nail Arts, Shade Soul, Abyss Shriek).
-- [ ] Calculate remaining boss HP, DPS, and action-per-second stats in real time.
+- [x] Define data models for charms, nail upgrades, and other modifiers.
+- [x] Build UI for selecting a boss fight or custom target HP.
+- [x] Implement attack logging buttons grouped by nail attacks, spells, and advanced techniques (e.g., Nail Arts, Shade Soul, Abyss Shriek).
+- [x] Calculate remaining boss HP, DPS, and action-per-second stats in real time.
 - [ ] Provide undo/redo controls and quick reset functionality.
 - [ ] Offer preset builds for popular charm combinations to speed up configuration.
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../components/PageLayout';
 import { AttackLogPanel } from '../features/attack-log/AttackLogPanel';
 import { BuildConfigPanel } from '../features/build-config/BuildConfigPanel';
 import { CombatStatsPanel } from '../features/combat-stats/CombatStatsPanel';
+import { FightStateProvider } from '../features/fight-state/FightStateContext';
 
 const SECTIONS = [
   {
@@ -28,15 +29,17 @@ const SECTIONS = [
 
 export const App: FC = () => {
   return (
-    <PageLayout sections={SECTIONS}>
-      <div>
-        <p className="page__title">Hollow Knight Damage Tracker</p>
-        <p className="page__subtitle">
-          Plan your build, record every strike, and monitor fight-ending damage stats in
-          real time. This early prototype focuses on layout and accessibility while core
-          logic is built out.
-        </p>
-      </div>
-    </PageLayout>
+    <FightStateProvider>
+      <PageLayout sections={SECTIONS}>
+        <div>
+          <p className="page__title">Hollow Knight Damage Tracker</p>
+          <p className="page__subtitle">
+            Plan your build, record every strike, and monitor fight-ending damage stats in
+            real time. This prototype now tracks damage totals with configurable builds
+            and boss targets.
+          </p>
+        </div>
+      </PageLayout>
+    </FightStateProvider>
   );
 };

--- a/src/data/bosses.json
+++ b/src/data/bosses.json
@@ -1,0 +1,60 @@
+{
+  "bosses": [
+    {
+      "id": "gruz-mother",
+      "name": "Gruz Mother",
+      "hp": 120,
+      "location": "Forgotten Crossroads",
+      "notes": "Early game mini-boss often used for warm-up damage checks."
+    },
+    {
+      "id": "false-knight",
+      "name": "False Knight",
+      "hp": 360,
+      "location": "Forgotten Crossroads",
+      "notes": "Arena includes breakable pillars that can interrupt the fight."
+    },
+    {
+      "id": "hornet-protector",
+      "name": "Hornet Protector",
+      "hp": 700,
+      "location": "Greenpath",
+      "notes": "First duel against Hornet with moderate HP pool."
+    },
+    {
+      "id": "mantis-lords",
+      "name": "Mantis Lords",
+      "hp": 640,
+      "location": "Fungal Wastes",
+      "notes": "Combined health for the final tandem phase of the duel."
+    },
+    {
+      "id": "soul-master",
+      "name": "Soul Master",
+      "hp": 920,
+      "location": "City of Tears",
+      "notes": "Includes the second enraged slam phase within the total HP."
+    },
+    {
+      "id": "dung-defender",
+      "name": "Dung Defender",
+      "hp": 1050,
+      "location": "Royal Waterways",
+      "notes": "High HP brawler with short vulnerability windows."
+    },
+    {
+      "id": "broken-vessel",
+      "name": "Broken Vessel",
+      "hp": 680,
+      "location": "Ancient Basin",
+      "notes": "HP total before becoming Lost Kin in Godhome refights."
+    },
+    {
+      "id": "radiance",
+      "name": "The Radiance",
+      "hp": 1700,
+      "location": "Temple of the Black Egg",
+      "notes": "Final boss of the base game including aerial phases."
+    }
+  ]
+}

--- a/src/data/damage.json
+++ b/src/data/damage.json
@@ -696,11 +696,7 @@
           "type": "minion_summon",
           "effect": "Summons a flying minion that attacks enemies.",
           "value": {
-            "damagePerLevel": [
-              5,
-              8,
-              11
-            ]
+            "damagePerLevel": [5, 8, 11]
           },
           "notes": "Damage increases as the charm is upgraded. Attacks every 1.2-1.4 seconds."
         }
@@ -868,4 +864,3 @@
     }
   ]
 }
-

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,63 @@
+import rawDamage from './damage.json';
+import rawBosses from './bosses.json';
+import type { Boss, Charm, NailUpgrade, Spell, SpellVariant } from './types';
+
+export type { Boss, Charm, NailUpgrade, Spell, SpellVariant } from './types';
+
+const toVariantKey = (name: string) =>
+  name
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((segment, index) =>
+      index === 0
+        ? segment.toLowerCase()
+        : segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase(),
+    )
+    .join('');
+
+const mapVariant = (variant: Omit<SpellVariant, 'key'>): SpellVariant => ({
+  ...variant,
+  key: toVariantKey(variant.name),
+});
+
+export const charms = rawDamage.charms as Charm[];
+export const nailUpgrades = rawDamage.nailUpgrades as NailUpgrade[];
+export const spells = rawDamage.spells.map((spell) => ({
+  ...spell,
+  base: mapVariant(spell.base),
+  upgrade: spell.upgrade ? mapVariant(spell.upgrade) : undefined,
+})) as Spell[];
+
+export const bosses = rawBosses.bosses as Boss[];
+
+export const bossMap = new Map(bosses.map((boss) => [boss.id, boss]));
+export const nailUpgradeMap = new Map(
+  nailUpgrades.map((upgrade) => [upgrade.id, upgrade]),
+);
+export const spellMap = new Map(spells.map((spell) => [spell.id, spell]));
+
+export const DEFAULT_BOSS_ID = 'false-knight';
+export const DEFAULT_CUSTOM_HP = 2100;
+
+export const keyCharmIds = [
+  'fragile-strength',
+  'unbreakable-strength',
+  'shaman-stone',
+  'spell-twister',
+  'quick-slash',
+];
+
+export const strengthCharmIds = new Set(['fragile-strength', 'unbreakable-strength']);
+
+const shamanStoneEffect = charms
+  .find((charm) => charm.id === 'shaman-stone')
+  ?.effects.find((effect) => effect.type === 'spell_damage_multiplier');
+
+export const shamanStoneMultipliers = new Map(
+  shamanStoneEffect &&
+  shamanStoneEffect.value &&
+  typeof shamanStoneEffect.value === 'object'
+    ? Object.entries(shamanStoneEffect.value)
+    : [],
+);

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,56 @@
+export interface CharmEffect {
+  type: string;
+  effect: string;
+  value: number | Record<string, number> | null;
+  notes?: string;
+}
+
+export interface Charm {
+  id: string;
+  name: string;
+  cost: number;
+  description: string;
+  origin: string;
+  effects: CharmEffect[];
+}
+
+export interface NailUpgradeCost {
+  geo: number;
+  pale_ore: number;
+}
+
+export interface NailUpgrade {
+  id: string;
+  name: string;
+  damage: number;
+  cost: NailUpgradeCost;
+  origin: string;
+}
+
+export interface SpellVariant {
+  name: string;
+  key: string;
+  damage?: number;
+  totalDamage?: number;
+  hits?: number;
+  notes?: string;
+  origin?: string;
+  damageBreakdown?: Array<{ source: string; damage: number }>;
+}
+
+export interface Spell {
+  id: string;
+  name: string;
+  soulCost: number;
+  origin: string;
+  base: SpellVariant;
+  upgrade?: SpellVariant;
+}
+
+export interface Boss {
+  id: string;
+  name: string;
+  hp: number;
+  location: string;
+  notes?: string;
+}

--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -1,0 +1,67 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AttackLogPanel } from './AttackLogPanel';
+import { BuildConfigPanel } from '../build-config/BuildConfigPanel';
+import { CombatStatsPanel } from '../combat-stats/CombatStatsPanel';
+import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
+
+describe('AttackLogPanel', () => {
+  it('updates nail damage when upgrading the nail and activating strength charms', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <BuildConfigPanel />
+        <AttackLogPanel />
+      </>,
+    );
+
+    const nailStrikeButton = screen.getByRole('button', { name: /nail strike/i });
+    expect(nailStrikeButton).toHaveTextContent(/5/);
+
+    await user.selectOptions(screen.getByLabelText(/nail upgrade/i), 'pure-nail');
+    expect(nailStrikeButton).toHaveTextContent(/21/);
+
+    await user.click(screen.getByLabelText(/unbreakable strength/i));
+    expect(nailStrikeButton).toHaveTextContent(/32/);
+  });
+
+  it('surfaces spell upgrades in the advanced group when unlocked', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <BuildConfigPanel />
+        <AttackLogPanel />
+      </>,
+    );
+
+    await user.click(screen.getByLabelText(/shade soul/i));
+
+    const shadeSoulButtons = screen.getAllByRole('button', { name: /shade soul/i });
+    expect(shadeSoulButtons.length).toBeGreaterThan(0);
+  });
+
+  it('logs damage and updates combat statistics', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <AttackLogPanel />
+        <CombatStatsPanel />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /nail strike/i }));
+
+    const damageRow = screen.getByText('Damage Logged').closest('.data-list__item');
+    expect(within(damageRow as HTMLElement).getByText('5')).toBeInTheDocument();
+
+    const remainingRow = screen.getByText('Remaining HP').closest('.data-list__item');
+    expect(within(remainingRow as HTMLElement).getByText('355')).toBeInTheDocument();
+
+    const actionsRow = screen.getByText('Attacks Logged').closest('.data-list__item');
+    expect(within(actionsRow as HTMLElement).getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -1,26 +1,186 @@
 import type { FC } from 'react';
+import { useMemo } from 'react';
 
-const attackPresets = [
-  { id: 'nail-swing', label: 'Nail Swing', damage: 13 },
-  { id: 'dash-slash', label: 'Dash Slash', damage: 17 },
-  { id: 'great-slash', label: 'Great Slash', damage: 20 },
-  { id: 'shade-soul', label: 'Shade Soul', damage: 30 },
-  { id: 'abyss-shriek', label: 'Abyss Shriek', damage: 80 },
-];
+import {
+  hasStrengthCharm,
+  useFightState,
+  type AttackCategory,
+} from '../fight-state/FightStateContext';
+import { nailUpgrades, shamanStoneMultipliers, spells } from '../../data';
+
+type AttackDefinition = {
+  id: string;
+  label: string;
+  damage: number;
+  category: AttackCategory;
+  soulCost?: number;
+  description?: string;
+};
+
+type AttackGroup = {
+  id: string;
+  label: string;
+  attacks: AttackDefinition[];
+};
+
+const NAIL_ART_MULTIPLIERS: Record<string, number> = {
+  'great-slash': 2.5,
+  'dash-slash': 2,
+  'cyclone-slash-hit': 1,
+};
+
+const getVariantDamage = (variant: (typeof spells)[number]['base']) => {
+  if (typeof variant.damage === 'number') {
+    return variant.damage;
+  }
+  if (typeof variant.totalDamage === 'number') {
+    return variant.totalDamage;
+  }
+  if (Array.isArray(variant.damageBreakdown)) {
+    return variant.damageBreakdown.reduce((total, hit) => total + hit.damage, 0);
+  }
+  return 0;
+};
+
+const buildAttackGroups = (
+  state: ReturnType<typeof useFightState>['state'],
+): AttackGroup[] => {
+  const { build } = state;
+
+  const nailUpgrade =
+    nailUpgrades.find((upgrade) => upgrade.id === build.nailUpgradeId) ?? nailUpgrades[0];
+  const hasStrength = hasStrengthCharm(build.activeCharmIds);
+  const baseNailDamage = nailUpgrade?.damage ?? 0;
+  const nailDamage = Math.round(baseNailDamage * (hasStrength ? 1.5 : 1));
+  const hasShamanStone = build.activeCharmIds.includes('shaman-stone');
+  const hasSpellTwister = build.activeCharmIds.includes('spell-twister');
+  const soulDiscount = hasSpellTwister ? 9 : 0;
+
+  const nailAttacks: AttackDefinition[] = [
+    {
+      id: 'nail-strike',
+      label: 'Nail Strike',
+      damage: nailDamage,
+      category: 'nail',
+      description: hasStrength ? 'Includes Strength charm bonus.' : undefined,
+    },
+  ];
+
+  const advancedAttacks: AttackDefinition[] = Object.entries(NAIL_ART_MULTIPLIERS).map(
+    ([id, multiplier]) => {
+      const baseLabel =
+        id === 'cyclone-slash-hit'
+          ? 'Cyclone Slash (per hit)'
+          : id === 'dash-slash'
+            ? 'Dash Slash'
+            : 'Great Slash';
+      return {
+        id,
+        label: baseLabel,
+        damage: Math.round(nailDamage * multiplier),
+        category: 'advanced',
+        description:
+          id === 'cyclone-slash-hit'
+            ? 'Log each Cyclone Slash hit individually.'
+            : 'Nail Art damage.',
+      };
+    },
+  );
+
+  const spellAttacks: AttackDefinition[] = [];
+  const spellUpgrades: AttackDefinition[] = [];
+
+  for (const spell of spells) {
+    const level = build.spellLevels[spell.id] ?? 'base';
+    const variant = level === 'upgrade' && spell.upgrade ? spell.upgrade : spell.base;
+    const baseDamage = getVariantDamage(variant);
+    const multiplier = hasShamanStone
+      ? (shamanStoneMultipliers.get(variant.key) ?? 1)
+      : 1;
+    const damage = Math.round(baseDamage * multiplier);
+    const soulCost = Math.max(0, spell.soulCost - soulDiscount);
+    const attack: AttackDefinition = {
+      id: `${spell.id}-${variant.key}`,
+      label: variant.name,
+      damage,
+      category: 'spell',
+      soulCost,
+      description: hasShamanStone ? 'Shaman Stone bonus applied.' : undefined,
+    };
+    spellAttacks.push(attack);
+
+    if (level === 'upgrade' && spell.upgrade) {
+      spellUpgrades.push({
+        ...attack,
+        category: 'advanced',
+      });
+    }
+  }
+
+  const groups: AttackGroup[] = [
+    { id: 'nail-attacks', label: 'Nail Attacks', attacks: nailAttacks },
+    { id: 'spellcasting', label: 'Spells', attacks: spellAttacks },
+    {
+      id: 'advanced-techniques',
+      label: 'Advanced Techniques',
+      attacks: [...advancedAttacks, ...spellUpgrades],
+    },
+  ];
+
+  return groups;
+};
 
 export const AttackLogPanel: FC = () => {
+  const fight = useFightState();
+  const { actions } = fight;
+
+  const attackGroups = useMemo(() => buildAttackGroups(fight.state), [fight.state]);
+
   return (
     <div>
       <p className="section__description">
-        Log each successful hit to reduce the boss health target. The real-time log and
-        undo controls will be implemented in the next milestone.
+        Log each successful hit to reduce the boss health target. Use the buttons below to
+        record standard swings, spells, and advanced techniques with the appropriate
+        modifiers applied.
       </p>
-      <div className="button-grid" role="group" aria-label="Record an attack">
-        {attackPresets.map((attack) => (
-          <button key={attack.id} type="button" className="button-grid__button">
-            <span>{attack.label}</span>
-            <span aria-hidden="true">{attack.damage}</span>
-          </button>
+      <div className="attack-groups">
+        {attackGroups.map((group) => (
+          <section key={group.id} className="attack-group">
+            <h3 className="attack-group__title">{group.label}</h3>
+            <div className="button-grid" role="group" aria-label={group.label}>
+              {group.attacks.map((attack) => (
+                <button
+                  key={attack.id}
+                  type="button"
+                  className="button-grid__button"
+                  onClick={() =>
+                    actions.logAttack({
+                      id: attack.id,
+                      label: attack.label,
+                      damage: attack.damage,
+                      category: attack.category,
+                      soulCost: attack.soulCost,
+                    })
+                  }
+                >
+                  <span className="button-grid__label">{attack.label}</span>
+                  <span className="button-grid__meta">
+                    <span className="button-grid__damage" aria-hidden="true">
+                      {attack.damage}
+                    </span>
+                    {typeof attack.soulCost === 'number' ? (
+                      <span className="button-grid__soul" aria-label="Soul cost">
+                        {attack.soulCost} SOUL
+                      </span>
+                    ) : null}
+                  </span>
+                  {attack.description ? (
+                    <span className="button-grid__description">{attack.description}</span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+          </section>
         ))}
       </div>
     </div>

--- a/src/features/build-config/BuildConfigPanel.test.tsx
+++ b/src/features/build-config/BuildConfigPanel.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BuildConfigPanel } from './BuildConfigPanel';
+import { CombatStatsPanel } from '../combat-stats/CombatStatsPanel';
+import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
+
+describe('BuildConfigPanel', () => {
+  it('allows selecting a custom boss target and updates stats', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <BuildConfigPanel />
+        <CombatStatsPanel />
+      </>,
+    );
+
+    await user.selectOptions(screen.getByLabelText(/boss target/i), 'custom');
+    const input = screen.getByLabelText(/custom target hp/i);
+    await user.clear(input);
+    await user.type(input, '500');
+
+    const targetRow = screen.getByText('Target HP').closest('.data-list__item');
+    expect(targetRow).toHaveTextContent('500');
+  });
+});

--- a/src/features/build-config/BuildConfigPanel.tsx
+++ b/src/features/build-config/BuildConfigPanel.tsx
@@ -1,55 +1,184 @@
-import type { FC } from 'react';
+import type { ChangeEvent, FC } from 'react';
+import { useMemo } from 'react';
 
-const charmOptions = [
-  'Unbreakable Strength',
-  'Quick Slash',
-  'Shaman Stone',
-  'Spell Twister',
-];
+import {
+  CUSTOM_BOSS_ID,
+  useFightState,
+  type SpellLevel,
+} from '../fight-state/FightStateContext';
+import { bosses, charms, keyCharmIds, nailUpgrades, spells } from '../../data';
 
-const nailLevels = [
-  'Base Nail',
-  'Sharpened Nail',
-  'Channeled Nail',
-  'Coiled Nail',
-  'Pure Nail',
-];
+const orderCharmIds = (selected: string[]) =>
+  keyCharmIds.filter((charmId) => selected.includes(charmId));
 
 export const BuildConfigPanel: FC = () => {
+  const {
+    state: { selectedBossId, customTargetHp, build },
+    actions,
+  } = useFightState();
+
+  const charmOptions = useMemo(
+    () =>
+      keyCharmIds
+        .map((id) => charms.find((charm) => charm.id === id))
+        .filter((charm): charm is NonNullable<typeof charm> => Boolean(charm)),
+    [],
+  );
+
+  const selectedBoss = useMemo(
+    () => bosses.find((boss) => boss.id === selectedBossId),
+    [selectedBossId],
+  );
+
+  const handleBossChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextBoss = event.target.value;
+    actions.selectBoss(nextBoss);
+  };
+
+  const handleCustomHpChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const parsed = Number.parseInt(event.target.value, 10);
+    if (Number.isNaN(parsed)) {
+      return;
+    }
+    actions.setCustomTargetHp(parsed);
+  };
+
+  const handleNailChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    actions.setNailUpgrade(event.target.value);
+  };
+
+  const toggleCharm = (charmId: string) => {
+    const isActive = build.activeCharmIds.includes(charmId);
+    const nextIds = isActive
+      ? build.activeCharmIds.filter((id) => id !== charmId)
+      : [...build.activeCharmIds, charmId];
+    actions.setActiveCharms(orderCharmIds(nextIds));
+  };
+
+  const handleSpellLevelChange = (spellId: string, level: SpellLevel) => {
+    actions.setSpellLevel(spellId, level);
+  };
+
   return (
     <form className="form-grid" aria-describedby="build-config-description">
       <p id="build-config-description" className="section__description">
-        Configure a quick approximation of your build so damage buttons can reflect your
-        modifiers. Detailed configuration will arrive in later milestones.
+        Configure your encounter target and upgrades so the tracker can calculate damage
+        values that match your build.
       </p>
+
+      <div className="form-field">
+        <label htmlFor="boss-target">Boss Target</label>
+        <select id="boss-target" value={selectedBossId} onChange={handleBossChange}>
+          {bosses.map((boss) => (
+            <option key={boss.id} value={boss.id}>
+              {boss.name}
+            </option>
+          ))}
+          <option value={CUSTOM_BOSS_ID}>Custom target</option>
+        </select>
+        <small>
+          {selectedBossId === CUSTOM_BOSS_ID
+            ? 'Set an exact HP amount for practice or race scenarios.'
+            : `${selectedBoss?.location ?? 'Unknown arena'} • ${selectedBoss?.hp ?? '?'} HP`}
+        </small>
+      </div>
+
+      {selectedBossId === CUSTOM_BOSS_ID ? (
+        <div className="form-field">
+          <label htmlFor="custom-target-hp">Custom Target HP</label>
+          <input
+            id="custom-target-hp"
+            type="number"
+            min={1}
+            step={10}
+            value={customTargetHp}
+            onChange={handleCustomHpChange}
+          />
+          <small>Adjust this value to match boss variants or modded fights.</small>
+        </div>
+      ) : null}
+
       <div className="form-field">
         <label htmlFor="nail-level">Nail Upgrade</label>
-        <select id="nail-level" defaultValue={nailLevels[0]}>
-          {nailLevels.map((level) => (
-            <option key={level}>{level}</option>
+        <select id="nail-level" value={build.nailUpgradeId} onChange={handleNailChange}>
+          {nailUpgrades.map((upgrade) => (
+            <option key={upgrade.id} value={upgrade.id}>
+              {upgrade.name}
+            </option>
           ))}
         </select>
         <small>Damage values adjust to the selected nail tier.</small>
       </div>
+
       <div className="form-field">
-        <label htmlFor="spell-upgrade">Spell Upgrade</label>
-        <select id="spell-upgrade" defaultValue="None">
-          <option>None</option>
-          <option>Vengeful Spirit</option>
-          <option>Shade Soul</option>
-          <option>Howling Wraiths</option>
-          <option>Abyss Shriek</option>
-        </select>
-        <small>Higher tiers increase spell damage presets.</small>
-      </div>
-      <div className="form-field">
-        <label htmlFor="active-charms">Key Charms</label>
-        <select id="active-charms" multiple size={Math.min(charmOptions.length, 5)}>
-          {charmOptions.map((charm) => (
-            <option key={charm}>{charm}</option>
-          ))}
-        </select>
+        <span className="form-field__label">Key Charms</span>
+        <div className="choice-list" role="group" aria-label="Select key charms">
+          {charmOptions.map((charm) => {
+            const summary = charm.effects.map((effect) => effect.effect).join(' ');
+            const checkboxId = `charm-${charm.id}`;
+            return (
+              <div key={charm.id} className="choice-list__option">
+                <input
+                  id={checkboxId}
+                  type="checkbox"
+                  checked={build.activeCharmIds.includes(charm.id)}
+                  onChange={() => toggleCharm(charm.id)}
+                />
+                <label htmlFor={checkboxId} className="choice-list__option-label">
+                  <span className="choice-list__label">{charm.name}</span>
+                  <span className="choice-list__description">{summary}</span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
         <small>Select the charms influencing your combat style.</small>
+      </div>
+
+      <div className="form-field">
+        <span className="form-field__label">Spell Focus</span>
+        <div className="choice-list" role="group" aria-label="Select spell upgrades">
+          {spells.map((spell) => (
+            <fieldset key={spell.id} className="choice-list__fieldset">
+              <legend>{spell.name}</legend>
+              <div className="choice-list__option">
+                <input
+                  id={`spell-${spell.id}-base`}
+                  type="radio"
+                  name={`spell-${spell.id}`}
+                  value="base"
+                  checked={build.spellLevels[spell.id] === 'base'}
+                  onChange={() => handleSpellLevelChange(spell.id, 'base')}
+                />
+                <label
+                  htmlFor={`spell-${spell.id}-base`}
+                  className="choice-list__option-label"
+                >
+                  <span className="choice-list__label">{spell.base.name}</span>
+                </label>
+              </div>
+              {spell.upgrade ? (
+                <div className="choice-list__option">
+                  <input
+                    id={`spell-${spell.id}-upgrade`}
+                    type="radio"
+                    name={`spell-${spell.id}`}
+                    value="upgrade"
+                    checked={build.spellLevels[spell.id] === 'upgrade'}
+                    onChange={() => handleSpellLevelChange(spell.id, 'upgrade')}
+                  />
+                  <label
+                    htmlFor={`spell-${spell.id}-upgrade`}
+                    className="choice-list__option-label"
+                  >
+                    <span className="choice-list__label">{spell.upgrade.name}</span>
+                  </label>
+                </div>
+              ) : null}
+            </fieldset>
+          ))}
+        </div>
+        <small>Choose the spell variants available in your current run.</small>
       </div>
     </form>
   );

--- a/src/features/combat-stats/CombatStatsPanel.tsx
+++ b/src/features/combat-stats/CombatStatsPanel.tsx
@@ -1,22 +1,55 @@
 import type { FC } from 'react';
 
-const placeholderStats = [
-  { label: 'Target HP', value: '2,100' },
-  { label: 'Damage Logged', value: '0' },
-  { label: 'Remaining HP', value: '2,100' },
-  { label: 'Average Damage', value: '—' },
-  { label: 'DPS', value: '—' },
-  { label: 'Actions / Min', value: '—' },
-];
+import { useFightState } from '../fight-state/FightStateContext';
+
+const formatInteger = (value: number) => value.toLocaleString();
+
+const formatDecimal = (value: number | null, fractionDigits = 1) =>
+  value == null ? '—' : value.toFixed(fractionDigits);
+
+const formatDuration = (elapsedMs: number | null) => {
+  if (!elapsedMs || elapsedMs <= 0) {
+    return '—';
+  }
+
+  const totalSeconds = Math.floor(elapsedMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
 
 export const CombatStatsPanel: FC = () => {
+  const {
+    derived: {
+      targetHp,
+      totalDamage,
+      remainingHp,
+      attacksLogged,
+      averageDamage,
+      dps,
+      actionsPerMinute,
+      elapsedMs,
+    },
+  } = useFightState();
+
+  const stats = [
+    { label: 'Target HP', value: formatInteger(targetHp) },
+    { label: 'Damage Logged', value: formatInteger(totalDamage) },
+    { label: 'Remaining HP', value: formatInteger(remainingHp) },
+    { label: 'Attacks Logged', value: attacksLogged.toString() },
+    { label: 'Average Damage', value: formatDecimal(averageDamage) },
+    { label: 'DPS', value: formatDecimal(dps) },
+    { label: 'Actions / Min', value: formatDecimal(actionsPerMinute) },
+    { label: 'Elapsed', value: formatDuration(elapsedMs) },
+  ];
+
   return (
     <div className="data-list" aria-live="polite">
       <p className="section__description">
-        This summary will update as soon as attack logging is wired to persistent state.
-        For now it describes the metrics we will surface.
+        These stats update automatically as you log damage. Use them to verify if a build
+        can close the gap before enrage timers or stagger opportunities end.
       </p>
-      {placeholderStats.map((stat) => (
+      {stats.map((stat) => (
         <div key={stat.label} className="data-list__item">
           <span className="data-list__label">{stat.label}</span>
           <span className="data-list__value">{stat.value}</span>

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -1,0 +1,284 @@
+import type { FC, PropsWithChildren } from 'react';
+import { createContext, useContext, useMemo, useReducer } from 'react';
+
+import {
+  DEFAULT_BOSS_ID,
+  DEFAULT_CUSTOM_HP,
+  bossMap,
+  nailUpgrades,
+  spells,
+  strengthCharmIds,
+} from '../../data';
+
+export type AttackCategory = 'nail' | 'spell' | 'advanced';
+export type SpellLevel = 'base' | 'upgrade';
+
+export interface AttackEvent {
+  id: string;
+  label: string;
+  damage: number;
+  category: AttackCategory;
+  timestamp: number;
+  soulCost?: number;
+}
+
+export interface BuildState {
+  nailUpgradeId: string;
+  activeCharmIds: string[];
+  spellLevels: Record<string, SpellLevel>;
+}
+
+export interface FightState {
+  selectedBossId: string;
+  customTargetHp: number;
+  build: BuildState;
+  damageLog: AttackEvent[];
+}
+
+export interface AttackInput {
+  id: string;
+  label: string;
+  damage: number;
+  category: AttackCategory;
+  soulCost?: number;
+  timestamp?: number;
+}
+
+export interface DerivedStats {
+  targetHp: number;
+  totalDamage: number;
+  remainingHp: number;
+  attacksLogged: number;
+  averageDamage: number | null;
+  elapsedMs: number | null;
+  dps: number | null;
+  actionsPerMinute: number | null;
+}
+
+interface FightContextValue {
+  state: FightState;
+  derived: DerivedStats;
+  actions: {
+    selectBoss: (bossId: string) => void;
+    setCustomTargetHp: (hp: number) => void;
+    setNailUpgrade: (nailUpgradeId: string) => void;
+    setActiveCharms: (charmIds: string[]) => void;
+    setSpellLevel: (spellId: string, level: SpellLevel) => void;
+    logAttack: (input: AttackInput) => void;
+    undoLastAttack: () => void;
+    resetLog: () => void;
+  };
+}
+
+export const CUSTOM_BOSS_ID = 'custom';
+
+const initialSpellLevels = (): Record<string, SpellLevel> => {
+  const levels: Record<string, SpellLevel> = {};
+  for (const spell of spells) {
+    levels[spell.id] = 'base';
+  }
+  return levels;
+};
+
+const createInitialState = (): FightState => ({
+  selectedBossId: DEFAULT_BOSS_ID,
+  customTargetHp: DEFAULT_CUSTOM_HP,
+  build: {
+    nailUpgradeId: nailUpgrades[0]?.id ?? 'old-nail',
+    activeCharmIds: [],
+    spellLevels: initialSpellLevels(),
+  },
+  damageLog: [],
+});
+
+const isCustomBoss = (bossId: string) => bossId === CUSTOM_BOSS_ID;
+
+const fightReducer = (state: FightState, action: FightAction): FightState => {
+  switch (action.type) {
+    case 'selectBoss':
+      return {
+        ...state,
+        selectedBossId: action.bossId,
+      };
+    case 'setCustomTargetHp':
+      return {
+        ...state,
+        selectedBossId: CUSTOM_BOSS_ID,
+        customTargetHp: Math.max(1, Math.round(action.hp)),
+      };
+    case 'setNailUpgrade':
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          nailUpgradeId: action.nailUpgradeId,
+        },
+      };
+    case 'setActiveCharms':
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          activeCharmIds: Array.from(new Set(action.charmIds)),
+        },
+      };
+    case 'setSpellLevel':
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          spellLevels: {
+            ...state.build.spellLevels,
+            [action.spellId]: action.level,
+          },
+        },
+      };
+    case 'logAttack':
+      return {
+        ...state,
+        damageLog: [
+          ...state.damageLog,
+          {
+            id: `${action.id}-${action.timestamp}`,
+            label: action.label,
+            damage: action.damage,
+            category: action.category,
+            timestamp: action.timestamp,
+            soulCost: action.soulCost,
+          },
+        ],
+      };
+    case 'undoLastAttack': {
+      if (state.damageLog.length === 0) {
+        return state;
+      }
+      return {
+        ...state,
+        damageLog: state.damageLog.slice(0, -1),
+      };
+    }
+    case 'resetLog':
+      return {
+        ...state,
+        damageLog: [],
+      };
+    default:
+      return state;
+  }
+};
+
+const FightStateContext = createContext<FightContextValue | undefined>(undefined);
+
+type FightAction =
+  | { type: 'selectBoss'; bossId: string }
+  | { type: 'setCustomTargetHp'; hp: number }
+  | { type: 'setNailUpgrade'; nailUpgradeId: string }
+  | { type: 'setActiveCharms'; charmIds: string[] }
+  | { type: 'setSpellLevel'; spellId: string; level: SpellLevel }
+  | {
+      type: 'logAttack';
+      timestamp: number;
+      label: string;
+      id: string;
+      damage: number;
+      category: AttackCategory;
+      soulCost?: number;
+    }
+  | { type: 'undoLastAttack' }
+  | { type: 'resetLog' };
+
+const calculateDerivedStats = (state: FightState): DerivedStats => {
+  const { damageLog, selectedBossId, customTargetHp } = state;
+  const targetHp = isCustomBoss(selectedBossId)
+    ? Math.max(1, Math.round(customTargetHp))
+    : (bossMap.get(selectedBossId)?.hp ?? DEFAULT_CUSTOM_HP);
+  const totalDamage = damageLog.reduce((total, event) => total + event.damage, 0);
+  const attacksLogged = damageLog.length;
+  const remainingHp = Math.max(0, targetHp - totalDamage);
+  const averageDamage = attacksLogged === 0 ? null : totalDamage / attacksLogged;
+  const elapsedMs =
+    attacksLogged < 2
+      ? null
+      : damageLog[damageLog.length - 1].timestamp - damageLog[0].timestamp;
+  const dps = elapsedMs && elapsedMs > 0 ? totalDamage / (elapsedMs / 1000) : null;
+  const actionsPerMinute =
+    elapsedMs && elapsedMs > 0 ? attacksLogged / (elapsedMs / 60000) : null;
+
+  return {
+    targetHp,
+    totalDamage,
+    remainingHp,
+    attacksLogged,
+    averageDamage,
+    elapsedMs,
+    dps,
+    actionsPerMinute,
+  };
+};
+
+const ensureSpellLevels = (state: FightState): FightState => {
+  if (Object.keys(state.build.spellLevels).length > 0) {
+    return state;
+  }
+
+  return {
+    ...state,
+    build: {
+      ...state.build,
+      spellLevels: initialSpellLevels(),
+    },
+  };
+};
+
+export const FightStateProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [state, dispatch] = useReducer(fightReducer, undefined, () =>
+    ensureSpellLevels(createInitialState()),
+  );
+
+  const derived = useMemo(() => calculateDerivedStats(state), [state]);
+
+  const actions = useMemo<FightContextValue['actions']>(
+    () => ({
+      selectBoss: (bossId) => dispatch({ type: 'selectBoss', bossId }),
+      setCustomTargetHp: (hp) => dispatch({ type: 'setCustomTargetHp', hp }),
+      setNailUpgrade: (nailUpgradeId) =>
+        dispatch({ type: 'setNailUpgrade', nailUpgradeId }),
+      setActiveCharms: (charmIds) => dispatch({ type: 'setActiveCharms', charmIds }),
+      setSpellLevel: (spellId, level) =>
+        dispatch({ type: 'setSpellLevel', spellId, level }),
+      logAttack: ({ id, label, damage, category, soulCost, timestamp }) =>
+        dispatch({
+          type: 'logAttack',
+          id,
+          label,
+          damage,
+          category,
+          soulCost,
+          timestamp: timestamp ?? Date.now(),
+        }),
+      undoLastAttack: () => dispatch({ type: 'undoLastAttack' }),
+      resetLog: () => dispatch({ type: 'resetLog' }),
+    }),
+    [],
+  );
+
+  const value = useMemo<FightContextValue>(
+    () => ({ state, derived, actions }),
+    [state, derived, actions],
+  );
+
+  return (
+    <FightStateContext.Provider value={value}>{children}</FightStateContext.Provider>
+  );
+};
+
+export const useFightState = () => {
+  const context = useContext(FightStateContext);
+  if (!context) {
+    throw new Error('useFightState must be used within a FightStateProvider');
+  }
+  return context;
+};
+
+export const hasStrengthCharm = (charmIds: string[]) =>
+  charmIds.some((id) => strengthCharmIds.has(id));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -123,8 +123,9 @@ body {
 
 .button-grid__button {
   display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
   border: 1px solid rgba(255 255 255 / 10%);
   border-radius: 0.75rem;
   background: rgba(255 255 255 / 6%);
@@ -135,6 +136,7 @@ body {
   transition:
     transform 120ms ease,
     background 120ms ease;
+  gap: 0.5rem;
 }
 
 .button-grid__button:hover,
@@ -143,6 +145,54 @@ body {
   transform: translateY(-2px);
   background: rgba(96 204 255 / 15%);
   border-color: rgba(96 204 255 / 40%);
+}
+
+.button-grid__label {
+  font-size: 1rem;
+}
+
+.button-grid__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.button-grid__damage {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.button-grid__soul {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.button-grid__description {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.attack-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.attack-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.attack-group__title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
 }
 
 .data-list {
@@ -185,6 +235,11 @@ body {
   font-weight: 600;
 }
 
+.form-field__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .form-field select,
 .form-field input {
   border-radius: 0.5rem;
@@ -196,4 +251,53 @@ body {
 
 .form-field small {
   color: var(--color-muted);
+}
+
+.choice-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.choice-list__option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.45rem;
+  align-items: flex-start;
+}
+
+.choice-list__option input[type='checkbox'],
+.choice-list__option input[type='radio'] {
+  margin-top: 0.2rem;
+}
+
+.choice-list__option-label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.choice-list__label {
+  font-weight: 600;
+}
+
+.choice-list__description {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.choice-list__fieldset {
+  border: 1px solid rgba(255 255 255 / 10%);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.choice-list__fieldset legend {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+  text-transform: uppercase;
 }

--- a/src/test-utils/renderWithFightProvider.tsx
+++ b/src/test-utils/renderWithFightProvider.tsx
@@ -1,0 +1,7 @@
+import type { ReactElement } from 'react';
+import { render } from '@testing-library/react';
+
+import { FightStateProvider } from '../features/fight-state/FightStateContext';
+
+export const renderWithFightProvider = (ui: ReactElement) =>
+  render(<FightStateProvider>{ui}</FightStateProvider>);


### PR DESCRIPTION
## Summary
- add typed game data modules and a fight-state context to drive boss presets, build configuration, and derived combat metrics
- rework build configuration, attack logging, and combat stats panels to use shared state with dynamic damage calculations, plus accompanying unit tests
- introduce GitHub Actions workflows for linting, unit tests, end-to-end tests, and GitHub Pages deployment while updating documentation and TODOs

## Testing
- pnpm lint
- pnpm test
- pnpm test:e2e *(fails: host is missing required Playwright system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d1d3c5b4832f83025263b8a572dd