### PR TITLE
Add keyboard shortcuts and hits remaining indicators to attack log

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 - **Boss presets, Godhome variants, and custom targets:** Quickly switch between Hallownest encounters, Godhome trials (Attuned, Ascended, Radiant), or specify any target for practice sessions.
 - **Data-driven build controls with charm presets:** Choose nail upgrades, toggle influential charms, apply popular charm loadouts with one click, and declare which spell upgrades are available to tune damage presets.
 - **Categorized attack logging with undo/redo:** Nail strikes, spell casts, and advanced techniques each expose context-aware damage values that respect build modifiers like Unbreakable Strength or Shaman Stone, while new undo/redo controls make correcting mistakes effortless.
+- **Keyboard shortcuts and finishing guidance:** Each attack button surfaces the remaining hits required to reach zero HP if you relied solely on that move, and keyboard shortcuts (number row followed by QWERTY order) allow spectators to log attacks or press <kbd>Esc</kbd> for a quick reset without leaving the action.
 - **Live combat analytics:** Remaining HP, DPS, average damage, and actions per minute update instantly as attacks are logged, giving immediate feedback on fight pacing.
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -139,6 +139,14 @@ body {
   gap: 0.5rem;
 }
 
+.button-grid__header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
 .button-grid__button:hover,
 .button-grid__button:focus-visible {
   outline: none;
@@ -151,9 +159,21 @@ body {
   font-size: 1rem;
 }
 
+.button-grid__hotkey {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255 255 255 / 18%);
+  color: var(--color-muted);
+  background: rgba(255 255 255 / 8%);
+}
+
 .button-grid__meta {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
   color: var(--color-muted);
@@ -166,6 +186,12 @@ body {
 }
 
 .button-grid__soul {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.button-grid__hits {
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -193,6 +219,18 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--color-muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .data-list {


### PR DESCRIPTION
## Summary
- assign sequential keyboard shortcuts to attack buttons and hook Esc to quick reset
- surface hits-to-finish metadata and hotkey labels on each attack button with accessibility helpers
- document the shortcuts and extend coverage with new interaction tests

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e10ecaf0832f94f86642af699f2f