### PR TITLE
Persist fight configuration across reloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 - **Categorized attack logging with undo/redo:** Nail strikes, spell casts, and advanced techniques each expose context-aware damage values that respect build modifiers like Unbreakable Strength or Shaman Stone, while new undo/redo controls make correcting mistakes effortless.
 - **Keyboard shortcuts and finishing guidance:** Each attack button surfaces the remaining hits required to reach zero HP if you relied solely on that move, and keyboard shortcuts (number row followed by QWERTY order) allow spectators to log attacks or press <kbd>Esc</kbd> for a quick reset without leaving the action.
 - **Live combat analytics:** Remaining HP, DPS, average damage, and actions per minute update instantly as attacks are logged, giving immediate feedback on fight pacing.
+- **Automatic session persistence:** Build selections, logged attacks, and boss progress are stored locally so the tracker survives accidental refreshes or browser restarts.
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -21,7 +21,7 @@ describe('App', () => {
     render(<App />);
 
     expect(
-      screen.getByText(/hollow knight damage tracker/i, { selector: 'p' }),
+      screen.getByRole('heading', { name: /hollow knight damage tracker/i, level: 1 }),
     ).toBeInTheDocument();
     expect(screen.getByText(/plan your build/i)).toBeVisible();
   });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,7 +32,7 @@ export const App: FC = () => {
     <FightStateProvider>
       <PageLayout sections={SECTIONS}>
         <div>
-          <p className="page__title">Hollow Knight Damage Tracker</p>
+          <h1 className="page__title">Hollow Knight Damage Tracker</h1>
           <p className="page__subtitle">
             Plan your build, record every strike, and monitor fight-ending damage stats in
             real time. This prototype now tracks damage totals with configurable builds

--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -7,6 +7,14 @@ import { CombatStatsPanel } from '../combat-stats/CombatStatsPanel';
 import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
 
 describe('AttackLogPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
   it('updates nail damage when upgrading the nail and activating strength charms', async () => {
     const user = userEvent.setup();
 

--- a/src/features/build-config/BuildConfigPanel.test.tsx
+++ b/src/features/build-config/BuildConfigPanel.test.tsx
@@ -6,6 +6,14 @@ import { CombatStatsPanel } from '../combat-stats/CombatStatsPanel';
 import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
 
 describe('BuildConfigPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
   it('allows selecting a custom boss target and updates stats', async () => {
     const user = userEvent.setup();
 

--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CUSTOM_BOSS_ID, FightStateProvider, useFightState } from './FightStateContext';
+
+const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
+
+describe('FightStateProvider persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates state from localStorage when data is available', () => {
+    const persistedState = {
+      version: 1,
+      state: {
+        selectedBossId: CUSTOM_BOSS_ID,
+        customTargetHp: 3333.7,
+        build: {
+          nailUpgradeId: 'pure-nail',
+          activeCharmIds: ['shaman-stone', 'quick-slash'],
+          spellLevels: {
+            'vengeful-spirit': 'upgrade',
+          },
+        },
+        damageLog: [
+          {
+            id: 'spell-vengeful-1',
+            label: 'Vengeful Spirit',
+            damage: 45,
+            category: 'spell',
+            timestamp: 1700000000000,
+            soulCost: 33,
+          },
+        ],
+        redoStack: [],
+      },
+    } satisfies Record<string, unknown>;
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persistedState));
+
+    const Consumer = () => {
+      const { state } = useFightState();
+      return (
+        <div>
+          <span data-testid="selected-boss">{state.selectedBossId}</span>
+          <span data-testid="custom-hp">{state.customTargetHp}</span>
+          <span data-testid="nail-upgrade">{state.build.nailUpgradeId}</span>
+          <span data-testid="charms">{state.build.activeCharmIds.join(',')}</span>
+          <span data-testid="spell-level">
+            {state.build.spellLevels['vengeful-spirit']}
+          </span>
+          <span data-testid="logged-attacks">{state.damageLog.length}</span>
+        </div>
+      );
+    };
+
+    render(
+      <FightStateProvider>
+        <Consumer />
+      </FightStateProvider>,
+    );
+
+    expect(screen.getByTestId('selected-boss').textContent).toBe(CUSTOM_BOSS_ID);
+    expect(screen.getByTestId('custom-hp').textContent).toBe('3334');
+    expect(screen.getByTestId('nail-upgrade').textContent).toBe('pure-nail');
+    expect(screen.getByTestId('charms').textContent).toBe('shaman-stone,quick-slash');
+    expect(screen.getByTestId('spell-level').textContent).toBe('upgrade');
+    expect(screen.getByTestId('logged-attacks').textContent).toBe('1');
+  });
+
+  it('persists updates to localStorage whenever state changes', async () => {
+    const user = userEvent.setup();
+
+    const Consumer = () => {
+      const { actions, state } = useFightState();
+      return (
+        <button type="button" onClick={() => actions.setCustomTargetHp(4321)}>
+          {state.customTargetHp}
+        </button>
+      );
+    };
+
+    render(
+      <FightStateProvider>
+        <Consumer />
+      </FightStateProvider>,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      if (!stored) {
+        throw new Error('Expected persisted fight state');
+      }
+
+      const parsed = JSON.parse(stored) as {
+        version: number;
+        state: { selectedBossId: string; customTargetHp: number };
+      };
+      expect(parsed.version).toBe(1);
+      expect(parsed.state.selectedBossId).toBe(CUSTOM_BOSS_ID);
+      expect(parsed.state.customTargetHp).toBe(4321);
+    });
+  });
+});

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -13,4 +13,31 @@ test.describe('Landing page', () => {
     await expect(page.getByRole('heading', { name: 'Log Attacks' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Combat Overview' })).toBeVisible();
   });
+
+  test('restores build configuration and logs after a reload', async ({ page }) => {
+    await page.goto('/');
+
+    await page.selectOption('#boss-target', 'custom');
+    const customTargetInput = page.locator('#custom-target-hp');
+    await customTargetInput.fill('3333');
+
+    await page.selectOption('#nail-level', 'pure-nail');
+    await page.getByRole('button', { name: 'Strength & Quick Slash' }).click();
+    await page.getByRole('button', { name: 'Nail Strike' }).click();
+
+    const attacksLoggedValue = page
+      .locator('.data-list__item')
+      .filter({ hasText: 'Attacks Logged' })
+      .locator('.data-list__value');
+    await expect(attacksLoggedValue).toHaveText('1');
+
+    await page.reload();
+
+    await expect(page.locator('#boss-target')).toHaveValue('custom');
+    await expect(customTargetInput).toHaveValue('3333');
+    await expect(page.locator('#nail-level')).toHaveValue('pure-nail');
+    await expect(page.locator('#charm-unbreakable-strength')).toBeChecked();
+    await expect(page.locator('#charm-quick-slash')).toBeChecked();
+    await expect(attacksLoggedValue).toHaveText('1');
+  });
 });


### PR DESCRIPTION
## Summary
- persist the fight state in localStorage with validation, restoring saved builds and logs on load
- add persistence-focused unit tests and ensure other specs reset localStorage between runs
- convert the landing title to a semantic heading, extend the Playwright suite to cover reload behavior, and note the feature in the README

## Testing
- pnpm lint
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d4e49fc8e4832fb4ba1ebaf4d30a36