### PR TITLE
Add comprehensive charm damage support and refresh attack UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 ### Feature Highlights
 
 - **Boss presets, Godhome variants, and custom targets:** Quickly switch between Hallownest encounters, Godhome trials (Attuned, Ascended, Radiant), or specify any target for practice sessions.
-- **Data-driven build controls with charm presets:** Choose nail upgrades, toggle influential charms, apply popular charm loadouts with one click, and declare which spell upgrades are available to tune damage presets.
-- **Categorized attack logging with undo/redo:** Nail strikes, spell casts, and advanced techniques each expose context-aware damage values that respect build modifiers like Unbreakable Strength or Shaman Stone, while new undo/redo controls make correcting mistakes effortless.
+- **Data-driven build controls with charm presets:** Choose nail upgrades, toggle influential charms—including retaliatory vines, summons, and spell conversions—and apply popular loadouts with one click while declaring which spell upgrades are available to tune damage presets.
+- **Charm effects and summons surfaced in combat:** Activating charms such as Flukenest, Thorns of Agony, Sharp Shadow, or Glowing Womb automatically exposes dedicated attack buttons so every damage source (including minions and Fury variants) can be logged accurately.
+- **Categorized attack logging with undo/redo:** A compact grid organizes nail strikes, spell casts, advanced techniques, and charm effects with readable damage summaries that respect build modifiers like Unbreakable Strength or Shaman Stone, while undo/redo controls make correcting mistakes effortless.
 - **Keyboard shortcuts and finishing guidance:** Each attack button surfaces the remaining hits required to reach zero HP if you relied solely on that move, and keyboard shortcuts (number row followed by QWERTY order) allow spectators to log attacks or press <kbd>Esc</kbd> for a quick reset without leaving the action.
 - **Live combat analytics:** Remaining HP, DPS, average damage, and actions per minute update instantly as attacks are logged, giving immediate feedback on fight pacing.
 - **Automatic session persistence:** Build selections, logged attacks, and boss progress are stored locally so the tracker survives accidental refreshes or browser restarts.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -43,7 +43,18 @@ const toSlug = (value: string) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)+/g, '');
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const toNumberEntries = (value: unknown) =>
+  isRecord(value)
+    ? Object.entries(value).filter(
+        (entry): entry is [string, number] => typeof entry[1] === 'number',
+      )
+    : [];
+
 export const charms = rawDamage.charms as Charm[];
+export const charmMap = new Map(charms.map((charm) => [charm.id, charm]));
 export const nailUpgrades = rawDamage.nailUpgrades as NailUpgrade[];
 export const spells = rawDamage.spells.map((spell) => ({
   ...spell,
@@ -126,13 +137,24 @@ const defaultBossTarget =
 export const DEFAULT_BOSS_ID = defaultBossTarget?.id ?? defaultBossTargetId;
 export const DEFAULT_CUSTOM_HP = 2100;
 
-export const keyCharmIds = [
+export const supportedCharmIds = [
   'fragile-strength',
   'unbreakable-strength',
+  'fury-of-the-fallen',
   'shaman-stone',
   'spell-twister',
   'quick-slash',
-];
+  'grubberflys-elegy',
+  'flukenest',
+  'thorns-of-agony',
+  'sharp-shadow',
+  'dreamshield',
+  'defenders-crest',
+  'spore-shroom',
+  'glowing-womb',
+  'weaversong',
+  'grimmchild',
+] as const;
 
 export const strengthCharmIds = new Set(['fragile-strength', 'unbreakable-strength']);
 
@@ -140,10 +162,4 @@ const shamanStoneEffect = charms
   .find((charm) => charm.id === 'shaman-stone')
   ?.effects.find((effect) => effect.type === 'spell_damage_multiplier');
 
-export const shamanStoneMultipliers = new Map(
-  shamanStoneEffect &&
-  shamanStoneEffect.value &&
-  typeof shamanStoneEffect.value === 'object'
-    ? Object.entries(shamanStoneEffect.value)
-    : [],
-);
+export const shamanStoneMultipliers = new Map(toNumberEntries(shamanStoneEffect?.value));

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,7 +1,7 @@
 export interface CharmEffect {
   type: string;
   effect: string;
-  value: number | Record<string, number> | null;
+  value?: unknown;
   notes?: string;
 }
 

--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -46,7 +46,7 @@ describe('AttackLogPanel', () => {
       </>,
     );
 
-    await user.click(screen.getByLabelText(/shade soul/i));
+    await user.click(screen.getByRole('radio', { name: /shade soul/i }));
 
     const shadeSoulButtons = screen.getAllByRole('button', { name: /shade soul/i });
     expect(shadeSoulButtons.length).toBeGreaterThan(0);
@@ -152,5 +152,47 @@ describe('AttackLogPanel', () => {
 
     damageRow = screen.getByText('Damage Logged').closest('.data-list__item');
     expect(within(damageRow as HTMLElement).getByText('0')).toBeInTheDocument();
+  });
+
+  it('shows charm effect attacks when enabling damage charms', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <BuildConfigPanel />
+        <AttackLogPanel />
+      </>,
+    );
+
+    await user.click(screen.getByLabelText(/thorns of agony/i));
+    await user.click(screen.getByLabelText(/glowing womb/i));
+
+    expect(screen.getByRole('heading', { name: /charm effects/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /thorns of agony burst/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hatchling impact/i })).toBeInTheDocument();
+  });
+
+  it('replaces vengeful spirit with Flukenest damage when equipped', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <BuildConfigPanel />
+        <AttackLogPanel />
+      </>,
+    );
+
+    const vengefulSpiritButton = screen.getByRole('button', {
+      name: /^vengeful spirit/i,
+    });
+    const damageDisplay = within(vengefulSpiritButton).getByLabelText(/damage per hit/i);
+    expect(damageDisplay).toHaveTextContent('15');
+
+    await user.click(screen.getByLabelText(/flukenest/i));
+
+    expect(damageDisplay).toHaveTextContent('36');
+    expect(vengefulSpiritButton).toHaveTextContent(/flukenest volley/i);
   });
 });

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -6,7 +6,7 @@ import {
   useFightState,
   type AttackCategory,
 } from '../fight-state/FightStateContext';
-import { nailUpgrades, shamanStoneMultipliers, spells } from '../../data';
+import { charmMap, nailUpgrades, shamanStoneMultipliers, spells } from '../../data';
 
 type AttackDefinition = {
   id: string;
@@ -85,6 +85,35 @@ const NAIL_ART_MULTIPLIERS: Record<string, number> = {
   'cyclone-slash-hit': 1,
 };
 
+const FURY_MULTIPLIER = 1.75;
+const GRUBBERFLY_BEAM_MULTIPLIER = 0.5;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const toNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const toNumberArray = (value: unknown): number[] | null =>
+  Array.isArray(value) && value.every((item) => typeof item === 'number')
+    ? (value as number[])
+    : null;
+
+const getNailArtLabel = (id: string) =>
+  id === 'cyclone-slash-hit'
+    ? 'Cyclone Slash (per hit)'
+    : id === 'dash-slash'
+      ? 'Dash Slash'
+      : 'Great Slash';
+
+const getCharmEffect = (charmId: string, effectType: string) =>
+  charmMap.get(charmId)?.effects.find((effect) => effect.type === effectType);
+
+const getCharmEffectRecord = (charmId: string, effectType: string) => {
+  const effect = getCharmEffect(charmId, effectType);
+  return effect && isRecord(effect.value) ? effect.value : null;
+};
+
 const getVariantDamage = (variant: (typeof spells)[number]['base']) => {
   if (typeof variant.damage === 'number') {
     return variant.damage;
@@ -106,10 +135,17 @@ const buildAttackGroups = (
   const nailUpgrade =
     nailUpgrades.find((upgrade) => upgrade.id === build.nailUpgradeId) ?? nailUpgrades[0];
   const hasStrength = hasStrengthCharm(build.activeCharmIds);
-  const baseNailDamage = nailUpgrade?.damage ?? 0;
-  const nailDamage = Math.round(baseNailDamage * (hasStrength ? 1.5 : 1));
+  const hasFury = build.activeCharmIds.includes('fury-of-the-fallen');
   const hasShamanStone = build.activeCharmIds.includes('shaman-stone');
   const hasSpellTwister = build.activeCharmIds.includes('spell-twister');
+  const hasFlukenest = build.activeCharmIds.includes('flukenest');
+
+  const baseNailDamage = nailUpgrade?.damage ?? 0;
+  const strengthMultiplier = hasStrength ? 1.5 : 1;
+  const nailDamageExact = baseNailDamage * strengthMultiplier;
+  const nailDamage = Math.round(nailDamageExact);
+  const furyMultiplier = hasFury ? FURY_MULTIPLIER : 1;
+  const furyNailDamageExact = nailDamageExact * furyMultiplier;
   const soulDiscount = hasSpellTwister ? 9 : 0;
 
   const nailAttacks: AttackDefinition[] = [
@@ -118,27 +154,37 @@ const buildAttackGroups = (
       label: 'Nail Strike',
       damage: nailDamage,
       category: 'nail',
-      description: hasStrength ? 'Includes Strength charm bonus.' : undefined,
+      description:
+        [
+          hasStrength ? 'Includes Strength charm bonus.' : null,
+          hasFury ? 'Use the Fury variant below when at 1 HP.' : null,
+        ]
+          .filter(Boolean)
+          .join(' ') || undefined,
     },
   ];
 
   const advancedAttacks: AttackDefinition[] = Object.entries(NAIL_ART_MULTIPLIERS).map(
     ([id, multiplier]) => {
-      const baseLabel =
-        id === 'cyclone-slash-hit'
-          ? 'Cyclone Slash (per hit)'
-          : id === 'dash-slash'
-            ? 'Dash Slash'
-            : 'Great Slash';
+      const baseLabel = getNailArtLabel(id);
+      const notes: string[] = [];
+      if (id === 'cyclone-slash-hit') {
+        notes.push('Log each Cyclone Slash hit individually.');
+      } else {
+        notes.push('Nail Art damage.');
+      }
+      if (hasStrength) {
+        notes.push('Includes Strength charm bonus.');
+      }
+      if (hasFury) {
+        notes.push('Use Fury variants from Charm Effects at 1 HP.');
+      }
       return {
         id,
         label: baseLabel,
-        damage: Math.round(nailDamage * multiplier),
+        damage: Math.round(nailDamageExact * multiplier),
         category: 'advanced',
-        description:
-          id === 'cyclone-slash-hit'
-            ? 'Log each Cyclone Slash hit individually.'
-            : 'Nail Art damage.',
+        description: notes.join(' '),
       };
     },
   );
@@ -149,19 +195,52 @@ const buildAttackGroups = (
   for (const spell of spells) {
     const level = build.spellLevels[spell.id] ?? 'base';
     const variant = level === 'upgrade' && spell.upgrade ? spell.upgrade : spell.base;
-    const baseDamage = getVariantDamage(variant);
+    let baseDamage = getVariantDamage(variant);
+    const notes: string[] = [];
+
+    if (hasFlukenest && spell.id === 'vengeful-spirit') {
+      const replacements = getCharmEffectRecord(
+        'flukenest',
+        'spell_replacement',
+      ) as Record<string, unknown> | null;
+      if (replacements && isRecord(replacements[variant.key])) {
+        const replacement = replacements[variant.key] as Record<string, unknown>;
+        const totalDamage = toNumber(replacement.totalDamage);
+        const projectiles = toNumber(replacement.projectiles);
+        const damagePerProjectile = toNumber(replacement.damagePerProjectile);
+        if (totalDamage !== null) {
+          baseDamage = totalDamage;
+          const detailParts: string[] = [];
+          if (projectiles !== null) {
+            detailParts.push(`${projectiles} projectiles`);
+          }
+          if (damagePerProjectile !== null) {
+            detailParts.push(`${damagePerProjectile} dmg each`);
+          }
+          const details = detailParts.length > 0 ? ` (${detailParts.join(' • ')})` : '';
+          notes.push(`Flukenest volley${details}.`);
+        }
+      }
+    }
+
     const multiplier = hasShamanStone
       ? (shamanStoneMultipliers.get(variant.key) ?? 1)
       : 1;
+    if (hasShamanStone) {
+      notes.push('Shaman Stone bonus applied.');
+    }
     const damage = Math.round(baseDamage * multiplier);
     const soulCost = Math.max(0, spell.soulCost - soulDiscount);
+    if (hasSpellTwister && soulDiscount > 0) {
+      notes.push('Spell Twister reduces SOUL cost.');
+    }
     const attack: AttackDefinition = {
       id: `${spell.id}-${variant.key}`,
       label: variant.name,
       damage,
       category: 'spell',
       soulCost,
-      description: hasShamanStone ? 'Shaman Stone bonus applied.' : undefined,
+      description: notes.length > 0 ? notes.join(' ') : undefined,
     };
     spellAttacks.push(attack);
 
@@ -170,6 +249,228 @@ const buildAttackGroups = (
         ...attack,
         category: 'advanced',
       });
+    }
+  }
+
+  const charmAttacks: AttackDefinition[] = [];
+
+  const addCharmAttack = (attack: AttackDefinition) => {
+    if (attack.damage <= 0) {
+      return;
+    }
+    charmAttacks.push(attack);
+  };
+
+  const addNailScaledCharmAttack = (
+    id: string,
+    label: string,
+    damageExact: number,
+    baseDescription: string,
+    { includeFuryVariant = false }: { includeFuryVariant?: boolean } = {},
+  ) => {
+    addCharmAttack({
+      id,
+      label,
+      damage: Math.round(damageExact),
+      category: 'charm',
+      description: baseDescription,
+    });
+
+    if (includeFuryVariant && hasFury) {
+      addCharmAttack({
+        id: `${id}-fury`,
+        label: `${label} (Fury)`,
+        damage: Math.round(damageExact * furyMultiplier),
+        category: 'charm',
+        description: 'Requires 1 HP for Fury of the Fallen to trigger.',
+      });
+    }
+  };
+
+  for (const charmId of build.activeCharmIds) {
+    switch (charmId) {
+      case 'fury-of-the-fallen': {
+        if (hasFury) {
+          addCharmAttack({
+            id: 'nail-strike-fury',
+            label: 'Nail Strike (Fury)',
+            damage: Math.round(furyNailDamageExact),
+            category: 'charm',
+            description: 'Requires 1 HP for Fury of the Fallen to trigger.',
+          });
+
+          for (const [artId, multiplier] of Object.entries(NAIL_ART_MULTIPLIERS)) {
+            addCharmAttack({
+              id: `${artId}-fury`,
+              label: `${getNailArtLabel(artId)} (Fury)`,
+              damage: Math.round(nailDamageExact * multiplier * furyMultiplier),
+              category: 'charm',
+              description: 'Requires 1 HP for Fury of the Fallen to trigger.',
+            });
+          }
+        }
+        break;
+      }
+      case 'grubberflys-elegy': {
+        addCharmAttack({
+          id: 'grubberflys-elegy-beam',
+          label: "Grubberfly's Elegy Beam",
+          damage: Math.round(nailDamageExact * GRUBBERFLY_BEAM_MULTIPLIER),
+          category: 'charm',
+          description: 'Full-health nail beam. Log each projectile that connects.',
+        });
+        break;
+      }
+      case 'thorns-of-agony': {
+        addNailScaledCharmAttack(
+          'thorns-of-agony',
+          'Thorns of Agony Burst',
+          nailDamageExact,
+          'Retaliation burst equal to current nail damage.',
+          { includeFuryVariant: true },
+        );
+        break;
+      }
+      case 'sharp-shadow': {
+        addNailScaledCharmAttack(
+          'sharp-shadow',
+          'Sharp Shadow Dash',
+          nailDamageExact,
+          'Shadow dash contact damage equal to current nail damage.',
+          { includeFuryVariant: true },
+        );
+        break;
+      }
+      case 'dreamshield': {
+        addNailScaledCharmAttack(
+          'dreamshield',
+          'Dreamshield Hit',
+          nailDamageExact,
+          'Orbiting shield contact damage equal to current nail damage.',
+          { includeFuryVariant: true },
+        );
+        break;
+      }
+      case 'defenders-crest': {
+        const auraData = getCharmEffectRecord('defenders-crest', 'damage_aura') as {
+          minDamage?: unknown;
+          maxDamage?: unknown;
+          tickRateSeconds?: unknown;
+        } | null;
+        if (auraData) {
+          const minDamage = toNumber(auraData.minDamage);
+          const maxDamage = toNumber(auraData.maxDamage);
+          const tickRate = toNumber(auraData.tickRateSeconds) ?? 0.25;
+          const averageDamage =
+            minDamage !== null && maxDamage !== null
+              ? (minDamage + maxDamage) / 2
+              : (maxDamage ?? minDamage);
+          if (averageDamage !== null) {
+            addCharmAttack({
+              id: 'defenders-crest',
+              label: "Defender's Crest Tick",
+              damage: Math.round(averageDamage * 100) / 100,
+              category: 'charm',
+              description: `Toxic cloud tick (~${tickRate.toFixed(2)}s cadence, ${
+                minDamage ?? '?'
+              }-${maxDamage ?? '?'} damage).`,
+            });
+          }
+        }
+        break;
+      }
+      case 'spore-shroom': {
+        const sporeData = getCharmEffectRecord('spore-shroom', 'focus_damage_cloud') as {
+          totalDamage?: unknown;
+          durationSeconds?: unknown;
+        } | null;
+        if (sporeData) {
+          const totalDamage = toNumber(sporeData.totalDamage);
+          const duration = toNumber(sporeData.durationSeconds);
+          if (totalDamage !== null) {
+            const parts = ['Full spore cloud damage.'];
+            if (duration !== null) {
+              parts.push(`${duration.toFixed(1)}s duration.`);
+            }
+            parts.push('Log partial ticks proportionally if needed.');
+            addCharmAttack({
+              id: 'spore-shroom',
+              label: 'Spore Shroom Cloud',
+              damage: totalDamage,
+              category: 'charm',
+              description: parts.join(' '),
+            });
+          }
+        }
+        break;
+      }
+      case 'glowing-womb': {
+        const wombData = getCharmEffectRecord('glowing-womb', 'minion_summon') as {
+          damage?: unknown;
+          soulCost?: unknown;
+        } | null;
+        if (wombData) {
+          const damage = toNumber(wombData.damage);
+          const soulCost = toNumber(wombData.soulCost) ?? undefined;
+          if (damage !== null) {
+            addCharmAttack({
+              id: 'glowing-womb',
+              label: 'Hatchling Impact',
+              damage,
+              category: 'charm',
+              soulCost,
+              description: 'Each hatchling kamikaze deals this damage.',
+            });
+          }
+        }
+        break;
+      }
+      case 'weaversong': {
+        const weaverData = getCharmEffectRecord('weaversong', 'minion_summon') as {
+          count?: unknown;
+          damage?: unknown;
+        } | null;
+        if (weaverData) {
+          const damage = toNumber(weaverData.damage);
+          const count = toNumber(weaverData.count);
+          if (damage !== null) {
+            const info = ['Per weaverling strike.'];
+            if (count !== null) {
+              info.push(`${count} weaverlings active.`);
+            }
+            addCharmAttack({
+              id: 'weaversong',
+              label: 'Weaverling Hit',
+              damage,
+              category: 'charm',
+              description: info.join(' '),
+            });
+          }
+        }
+        break;
+      }
+      case 'grimmchild': {
+        const grimmchildData = getCharmEffectRecord('grimmchild', 'minion_summon') as {
+          damagePerLevel?: unknown;
+        } | null;
+        if (grimmchildData) {
+          const damagePerLevel = toNumberArray(grimmchildData.damagePerLevel);
+          if (damagePerLevel) {
+            damagePerLevel.forEach((damage, index) => {
+              addCharmAttack({
+                id: `grimmchild-level-${index + 1}`,
+                label: `Grimmchild Lv.${index + 1}`,
+                damage,
+                category: 'charm',
+                description: 'Per Grimmchild fireball hit.',
+              });
+            });
+          }
+        }
+        break;
+      }
+      default:
+        break;
     }
   }
 
@@ -182,6 +483,10 @@ const buildAttackGroups = (
       attacks: [...advancedAttacks, ...spellUpgrades],
     },
   ];
+
+  if (charmAttacks.length > 0) {
+    groups.push({ id: 'charm-effects', label: 'Charm Effects', attacks: charmAttacks });
+  }
 
   return groups;
 };

--- a/src/features/build-config/BuildConfigPanel.test.tsx
+++ b/src/features/build-config/BuildConfigPanel.test.tsx
@@ -75,4 +75,11 @@ describe('BuildConfigPanel', () => {
     expect(screen.getByLabelText(/shaman stone/i)).not.toBeChecked();
     expect(screen.getByLabelText(/spell twister/i)).not.toBeChecked();
   });
+
+  it('surfaces extended damage charms such as Thorns of Agony', () => {
+    renderWithFightProvider(<BuildConfigPanel />);
+
+    expect(screen.getByLabelText(/thorns of agony/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/glowing womb/i)).toBeInTheDocument();
+  });
 });

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -93,7 +93,12 @@ const sanitizeAttackEvents = (value: unknown, fallback: AttackEvent[]): AttackEv
       continue;
     }
 
-    if (category !== 'nail' && category !== 'spell' && category !== 'advanced') {
+    if (
+      category !== 'nail' &&
+      category !== 'spell' &&
+      category !== 'advanced' &&
+      category !== 'charm'
+    ) {
       continue;
     }
 
@@ -114,7 +119,7 @@ const sanitizeAttackEvents = (value: unknown, fallback: AttackEvent[]): AttackEv
   return events;
 };
 
-export type AttackCategory = 'nail' | 'spell' | 'advanced';
+export type AttackCategory = 'nail' | 'spell' | 'advanced' | 'charm';
 export type SpellLevel = 'base' | 'upgrade';
 
 export interface AttackEvent {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,8 +117,8 @@ body {
 
 .button-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.6rem;
 }
 
 .button-grid__button {
@@ -126,17 +126,18 @@ body {
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  border: 1px solid rgba(255 255 255 / 10%);
-  border-radius: 0.75rem;
-  background: rgba(255 255 255 / 6%);
-  padding: 0.75rem;
+  border: 1px solid rgba(255 255 255 / 12%);
+  border-radius: 0.65rem;
+  background: rgba(255 255 255 / 5%);
+  padding: 0.65rem 0.7rem;
   font-weight: 600;
   letter-spacing: 0.01em;
   color: inherit;
   transition:
     transform 120ms ease,
-    background 120ms ease;
-  gap: 0.5rem;
+    background 120ms ease,
+    border-color 120ms ease;
+  gap: 0.35rem;
 }
 
 .button-grid__header {
@@ -150,51 +151,59 @@ body {
 .button-grid__button:hover,
 .button-grid__button:focus-visible {
   outline: none;
-  transform: translateY(-2px);
-  background: rgba(96 204 255 / 15%);
-  border-color: rgba(96 204 255 / 40%);
+  transform: translateY(-1px);
+  background: rgba(96 204 255 / 14%);
+  border-color: rgba(96 204 255 / 42%);
 }
 
 .button-grid__label {
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 .button-grid__hotkey {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: 0.1rem 0.35rem;
   border-radius: 0.4rem;
-  border: 1px solid rgba(255 255 255 / 18%);
+  border: 1px solid rgba(255 255 255 / 16%);
   color: var(--color-muted);
-  background: rgba(255 255 255 / 8%);
+  background: rgba(255 255 255 / 10%);
 }
 
 .button-grid__meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.4rem;
+  justify-content: space-between;
+  gap: 0.35rem;
+  width: 100%;
   font-size: 0.85rem;
   color: var(--color-muted);
 }
 
 .button-grid__damage {
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: 700;
   color: var(--color-text);
 }
 
 .button-grid__soul {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(255 255 255 / 12%);
 }
 
 .button-grid__hits {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(255 255 255 / 12%);
 }
 
 .button-grid__description {
@@ -332,11 +341,59 @@ body {
   gap: 0.5rem;
 }
 
+.choice-groups {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.choice-section {
+  border: 1px solid rgba(255 255 255 / 10%);
+  border-radius: 0.6rem;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.choice-section__legend {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  padding: 0;
+}
+
+.choice-section__description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
 .choice-list__option {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.45rem;
   align-items: flex-start;
+}
+
+.choice-list--columns {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.choice-list--columns .choice-list__option {
+  border: 1px solid rgba(255 255 255 / 8%);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.55rem;
+  background: rgba(255 255 255 / 3%);
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.choice-list--columns .choice-list__option:hover,
+.choice-list--columns .choice-list__option:focus-within {
+  border-color: rgba(96 204 255 / 35%);
+  background: rgba(96 204 255 / 12%);
 }
 
 .choice-list__option input[type='checkbox'],
@@ -353,6 +410,7 @@ body {
 
 .choice-list__label {
   font-weight: 600;
+  font-size: 0.95rem;
 }
 
 .choice-list__description {


### PR DESCRIPTION
## Summary
- expose all damage-affecting charms with grouped selectors and refreshed quick actions
- extend attack logging to cover charm-based damage, Fury variants, and Flukenest spell replacements
- polish attack button styling, update documentation, and expand unit coverage

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4ead8902c832f9a6ad800ab26adc6