### PR TITLE
Add boss sequence support with auto progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 ### Feature Highlights
 
 - **Boss presets, Godhome variants, and custom targets:** Quickly switch between Hallownest encounters, Godhome trials (Attuned, Ascended, Radiant), or specify any target for practice sessions.
+- **Pantheon and rush tracking:** Queue up Godhome pantheons or the Black Egg Temple rush, automatically advance to the next boss when HP hits zero, and revisit previous stages with bracket-key shortcuts or on-screen navigation.
 - **Data-driven build controls with charm presets:** Choose nail upgrades, toggle influential charms—including retaliatory vines, summons, and spell conversions—and apply popular loadouts with one click while declaring which spell upgrades are available to tune damage presets.
 - **Charm effects and summons surfaced in combat:** Activating charms such as Flukenest, Thorns of Agony, Sharp Shadow, or Glowing Womb automatically exposes dedicated attack buttons so every damage source (including minions and Fury variants) can be logged accurately.
 - **Categorized attack logging with undo/redo:** A compact grid organizes nail strikes, spell casts, advanced techniques, and charm effects with readable damage summaries that respect build modifiers like Unbreakable Strength or Shaman Stone, while undo/redo controls make correcting mistakes effortless.

--- a/src/data/sequences.json
+++ b/src/data/sequences.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "pantheon-of-the-master",
+    "name": "Pantheon of the Master",
+    "category": "Godhome Pantheons",
+    "entries": [
+      { "boss": "Vengefly King", "version": "Attuned" },
+      { "boss": "Gruz Mother", "version": "Attuned" },
+      { "boss": "False Knight", "version": "Attuned" },
+      { "boss": "Massive Moss Charger", "version": "Attuned" },
+      { "boss": "Hornet (Protector)", "version": "Attuned" },
+      { "boss": "Gorb", "version": "Attuned" },
+      { "boss": "Dung Defender", "version": "Attuned" },
+      { "boss": "Soul Warrior", "version": "Attuned" },
+      { "boss": "Brooding Mawlek", "version": "Attuned" },
+      { "boss": "Brothers Oro & Mato", "version": "Attuned" }
+    ]
+  },
+  {
+    "id": "pantheon-of-the-artist",
+    "name": "Pantheon of the Artist",
+    "category": "Godhome Pantheons",
+    "entries": [
+      { "boss": "Xero", "version": "Attuned" },
+      { "boss": "Crystal Guardian", "version": "Attuned" },
+      { "boss": "Soul Master", "version": "Attuned" },
+      { "boss": "Oblobbles", "version": "Attuned" },
+      { "boss": "Mantis Lords", "version": "Attuned" },
+      { "boss": "Marmu", "version": "Attuned" },
+      { "boss": "Flukemarm", "version": "Attuned" },
+      { "boss": "Broken Vessel", "version": "Attuned" },
+      { "boss": "Galien", "version": "Attuned" },
+      { "boss": "Paintmaster Sheo", "version": "Attuned" }
+    ]
+  },
+  {
+    "id": "pantheon-of-the-sage",
+    "name": "Pantheon of the Sage",
+    "category": "Godhome Pantheons",
+    "entries": [
+      { "boss": "Hive Knight", "version": "Attuned" },
+      { "boss": "Elder Hu", "version": "Attuned" },
+      { "boss": "The Collector", "version": "Attuned" },
+      { "boss": "God Tamer", "version": "Attuned" },
+      { "boss": "Troupe Master Grimm", "version": "Attuned" },
+      { "boss": "Watcher Knight", "version": "Attuned" },
+      { "boss": "Uumuu", "version": "Attuned" },
+      { "boss": "Hornet (Sentinel)", "version": "Attuned" },
+      { "boss": "Great Nailsage Sly", "version": "Attuned" }
+    ]
+  },
+  {
+    "id": "pantheon-of-the-knight",
+    "name": "Pantheon of the Knight",
+    "category": "Godhome Pantheons",
+    "entries": [
+      { "boss": "Enraged Guardian", "version": "Attuned" },
+      { "boss": "Lost Kin", "version": "Attuned" },
+      { "boss": "No Eyes", "version": "Attuned" },
+      { "boss": "Traitor Lord", "version": "Attuned" },
+      { "boss": "White Defender", "version": "Attuned" },
+      { "boss": "Failed Champion", "version": "Attuned" },
+      { "boss": "Markoth", "version": "Attuned" },
+      { "boss": "Watcher Knight", "version": "Attuned" },
+      { "boss": "Soul Tyrant", "version": "Attuned" },
+      { "boss": "Pure Vessel", "version": "Attuned" }
+    ]
+  },
+  {
+    "id": "pantheon-of-hallownest",
+    "name": "Pantheon of Hallownest",
+    "category": "Godhome Pantheons",
+    "entries": [
+      { "boss": "Vengefly King", "version": "Attuned" },
+      { "boss": "Gruz Mother", "version": "Attuned" },
+      { "boss": "False Knight", "version": "Attuned" },
+      { "boss": "Massive Moss Charger", "version": "Attuned" },
+      { "boss": "Hornet (Protector)", "version": "Attuned" },
+      { "boss": "Gorb", "version": "Attuned" },
+      { "boss": "Dung Defender", "version": "Attuned" },
+      { "boss": "Soul Warrior", "version": "Attuned" },
+      { "boss": "Brooding Mawlek", "version": "Attuned" },
+      { "boss": "Brothers Oro & Mato", "version": "Attuned" },
+      { "boss": "Xero", "version": "Attuned" },
+      { "boss": "Crystal Guardian", "version": "Attuned" },
+      { "boss": "Soul Master", "version": "Attuned" },
+      { "boss": "Oblobbles", "version": "Attuned" },
+      { "boss": "Mantis Lords", "version": "Attuned" },
+      { "boss": "Marmu", "version": "Attuned" },
+      { "boss": "Flukemarm", "version": "Attuned" },
+      { "boss": "Broken Vessel", "version": "Attuned" },
+      { "boss": "Galien", "version": "Attuned" },
+      { "boss": "Paintmaster Sheo", "version": "Attuned" },
+      { "boss": "Hive Knight", "version": "Attuned" },
+      { "boss": "Elder Hu", "version": "Attuned" },
+      { "boss": "The Collector", "version": "Attuned" },
+      { "boss": "God Tamer", "version": "Attuned" },
+      { "boss": "Troupe Master Grimm", "version": "Attuned" },
+      { "boss": "Watcher Knight", "version": "Attuned" },
+      { "boss": "Uumuu", "version": "Attuned" },
+      { "boss": "Winged Nosk", "version": "Attuned" },
+      { "boss": "Great Nailsage Sly", "version": "Attuned" },
+      { "boss": "Hornet (Sentinel)", "version": "Attuned" },
+      { "boss": "Enraged Guardian", "version": "Attuned" },
+      { "boss": "Lost Kin", "version": "Attuned" },
+      { "boss": "No Eyes", "version": "Attuned" },
+      { "boss": "Traitor Lord", "version": "Attuned" },
+      { "boss": "White Defender", "version": "Attuned" },
+      { "boss": "Soul Tyrant", "version": "Attuned" },
+      { "boss": "Markoth", "version": "Attuned" },
+      { "boss": "Grey Prince Zote", "version": "Attuned" },
+      { "boss": "Failed Champion", "version": "Attuned" },
+      { "boss": "Nightmare King Grimm", "version": "Attuned" },
+      { "boss": "Pure Vessel", "version": "Attuned" },
+      { "boss": "Absolute Radiance", "version": "Final Boss" }
+    ]
+  },
+  {
+    "id": "black-egg-temple",
+    "name": "Black Egg Temple Rush",
+    "category": "Godhome Rushes",
+    "entries": [
+      { "boss": "The Hollow Knight", "version": "Standard" },
+      { "boss": "The Radiance", "version": "Standard" }
+    ]
+  }
+]

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -72,3 +72,15 @@ export interface BossTarget {
   hp: number;
   version: BossVersion;
 }
+
+export interface BossSequenceEntry {
+  id: string;
+  target: BossTarget;
+}
+
+export interface BossSequence {
+  id: string;
+  name: string;
+  category: string;
+  entries: BossSequenceEntry[];
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -300,6 +300,46 @@ body {
   color: var(--color-muted);
 }
 
+.sequence-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.sequence-controls select {
+  flex: 1;
+}
+
+.sequence-controls__button {
+  border: 1px solid rgba(255 255 255 / 20%);
+  border-radius: 0.5rem;
+  background: rgba(255 255 255 / 8%);
+  color: inherit;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.sequence-controls__button:hover,
+.sequence-controls__button:focus-visible {
+  outline: none;
+  background: rgba(96 204 255 / 15%);
+  border-color: rgba(96 204 255 / 35%);
+  transform: translateY(-1px);
+}
+
+.sequence-controls__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .quick-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a data set for pantheon and rush sequences and expose typed helpers for lookups
- extend fight state to track multi-boss runs with per-stage logs, auto-progression, and navigation actions with keyboard support
- refresh the build configuration panel UI with sequence selection controls, navigation buttons, and styling plus regression tests and README updates

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5bfdc1fd8832fa70036fdbc688ce4