### PR TITLE
Improve boss navigation

### DIFF
--- a/src/features/build-config/BuildConfigPanel.test.tsx
+++ b/src/features/build-config/BuildConfigPanel.test.tsx
@@ -57,6 +57,24 @@ describe('BuildConfigPanel', () => {
     expect(targetRow).toHaveTextContent('945');
   });
 
+  it('keeps equivalent boss versions selected when switching bosses', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(<BuildConfigPanel />);
+
+    await user.selectOptions(screen.getByLabelText(/boss target/i), 'false-knight');
+    await user.selectOptions(
+      screen.getByLabelText(/boss version/i),
+      'false-knight__ascended',
+    );
+
+    await user.selectOptions(screen.getByLabelText(/boss target/i), 'failed-champion');
+
+    expect(screen.getByLabelText(/boss version/i)).toHaveValue(
+      'failed-champion__ascended',
+    );
+  });
+
   it('applies charm presets for common loadouts', async () => {
     const user = userEvent.setup();
 

--- a/src/features/build-config/BuildConfigPanel.tsx
+++ b/src/features/build-config/BuildConfigPanel.tsx
@@ -175,7 +175,11 @@ export const BuildConfigPanel: FC = () => {
     }
 
     const nextBoss = bosses.find((boss) => boss.id === nextBossId);
-    const nextTargetId = nextBoss?.versions[0]?.targetId;
+    const preferredTitle = selectedVersion?.title;
+    const matchingVersion = preferredTitle
+      ? nextBoss?.versions.find((version) => version.title === preferredTitle)
+      : undefined;
+    const nextTargetId = (matchingVersion ?? nextBoss?.versions[0])?.targetId;
     if (nextTargetId) {
       actions.selectBoss(nextTargetId);
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -302,28 +302,56 @@ body {
 
 .sequence-controls {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  align-items: center;
+  align-items: stretch;
+  inline-size: 100%;
 }
 
 .sequence-controls select {
-  flex: 1;
+  flex: 1 1 12rem;
+  min-inline-size: 0;
+  order: 1;
 }
 
 .sequence-controls__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid rgba(255 255 255 / 20%);
   border-radius: 0.5rem;
   background: rgba(255 255 255 / 8%);
   color: inherit;
-  padding: 0.45rem 0.85rem;
+  padding: 0.45rem 0.75rem;
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   cursor: pointer;
+  white-space: nowrap;
   transition:
     background 120ms ease,
     border-color 120ms ease,
     transform 120ms ease;
+}
+
+.sequence-controls__button:first-of-type {
+  order: 0;
+}
+
+.sequence-controls__button:last-of-type {
+  order: 2;
+}
+
+@media (width <= 600px) {
+  .sequence-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sequence-controls__button,
+  .sequence-controls select {
+    inline-size: 100%;
+  }
 }
 
 .sequence-controls__button:hover,


### PR DESCRIPTION
## Summary
- preserved the selected boss version when switching targets and added a regression test to keep Godhome variants aligned across bosses
- refined the sequence navigation controls so the buttons and stage selector wrap cleanly within the available width on all viewports

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cb6fd684832fa2b2626908077428