### PR TITLE
ci: parallelize Playwright e2e job per browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,14 @@ jobs:
       - run: pnpm test
 
   e2e-tests:
-    runs-on: ubuntu-latest
     needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    container:
+      image: mcr.microsoft.com/playwright:v1.46.1-jammy
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -49,8 +55,6 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
-      - run: pnpm test:e2e
+      - run: pnpm test:e2e -- --project=${{ matrix.browser }}
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test:e2e -- --project=${{ matrix.browser }}
+      - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         browser: [chromium, firefox, webkit]
     container:
       image: mcr.microsoft.com/playwright:v1.55.1-jammy
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     container:
-      image: mcr.microsoft.com/playwright:v1.46.1-jammy
+      image: mcr.microsoft.com/playwright:v1.55.1-jammy
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary
- run the Playwright end-to-end workflow on the official Playwright container image to skip the manual browser installation step
- split the e2e workflow into a browser matrix with fail-fast disabled so each browser executes in parallel on separate runners

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d5e4a8a1d0832f981cbf8a05841347