### PR TITLE
feat: streamline loadout controls and overcharm flow

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -35,8 +35,8 @@ describe('App', () => {
     await user.type(hpInput, '500');
 
     const targetTile = screen
-      .getByText(/target hp/i, { selector: '.summary-tile__label' })
-      .closest('.summary-tile');
+      .getByText(/target hp/i, { selector: '.summary-chip__label' })
+      .closest('.summary-chip');
     expect(targetTile).toHaveTextContent('500');
   });
 
@@ -49,8 +49,8 @@ describe('App', () => {
     await user.selectOptions(versionSelect, 'gruz-mother__ascended');
 
     const targetTile = screen
-      .getByText(/target hp/i, { selector: '.summary-tile__label' })
-      .closest('.summary-tile');
+      .getByText(/target hp/i, { selector: '.summary-chip__label' })
+      .closest('.summary-chip');
     expect(targetTile).toHaveTextContent('945');
   });
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -73,26 +73,30 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
   ]);
 
   return (
-    <header className="app-header">
-      <div className="app-header__top">
-        <div className="app-header__brand">
-          <h1 className="app-header__title">Hollow Knight Damage Tracker</h1>
-          <p className="app-header__subtitle">
+    <div className="encounter-header">
+      <header className="app-navbar">
+        <div className="app-navbar__brand">
+          <h1 className="app-navbar__title">Hollow Knight Damage Tracker</h1>
+          <p className="app-navbar__subtitle">
             Plan your build, log every strike, and monitor fight-ending stats in real
             time.
           </p>
         </div>
-        <div className="app-header__actions">
+        <div className="app-navbar__actions">
           <button type="button" className="header-button" onClick={onOpenModal}>
             Player Loadout
           </button>
         </div>
-      </div>
+      </header>
 
-      <div className="app-header__filters" role="group" aria-label="Encounter selection">
-        <div className="header-stack">
-          <label className="header-field">
-            <span className="header-field__label">Boss sequence</span>
+      <section
+        className="encounter-toolbar"
+        role="group"
+        aria-label="Encounter selection"
+      >
+        <div className="toolbar-stack">
+          <label className="toolbar-field">
+            <span className="toolbar-field__label">Boss sequence</span>
             <select
               value={sequenceSelectValue}
               onChange={(event) => handleSequenceChange(event.target.value)}
@@ -121,8 +125,8 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
               >
                 Prev
               </button>
-              <label className="header-field header-field--compact">
-                <span className="header-field__label">Stage</span>
+              <label className="toolbar-field toolbar-field--compact">
+                <span className="toolbar-field__label">Stage</span>
                 <select
                   value={String(cappedSequenceIndex)}
                   onChange={(event) =>
@@ -149,9 +153,9 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
           ) : null}
         </div>
 
-        <div className="header-stack">
-          <label className="header-field">
-            <span className="header-field__label">Boss target</span>
+        <div className="toolbar-stack">
+          <label className="toolbar-field">
+            <span className="toolbar-field__label">Boss target</span>
             <select
               id="boss-target"
               value={bossSelectValue}
@@ -170,8 +174,8 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
           {!isSequenceActive &&
           selectedBoss &&
           state.selectedBossId !== CUSTOM_BOSS_ID ? (
-            <label className="header-field">
-              <span className="header-field__label">Boss version</span>
+            <label className="toolbar-field">
+              <span className="toolbar-field__label">Boss version</span>
               <select
                 value={state.selectedBossId}
                 onChange={(event) => handleBossVersionChange(event.target.value)}
@@ -186,8 +190,8 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
           ) : null}
 
           {!isSequenceActive && state.selectedBossId === CUSTOM_BOSS_ID ? (
-            <label className="header-field" htmlFor="custom-target-hp">
-              <span className="header-field__label">Custom target HP</span>
+            <label className="toolbar-field" htmlFor="custom-target-hp">
+              <span className="toolbar-field__label">Custom target HP</span>
               <input
                 id="custom-target-hp"
                 type="number"
@@ -200,18 +204,18 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
           ) : null}
 
           {selectedTarget && selectedVersion ? (
-            <div className="header-summary" aria-live="polite">
-              <span className="header-summary__title">Active target</span>
-              <span className="header-summary__value">{selectedTarget.bossName}</span>
-              <span className="header-summary__meta">{selectedVersion.title}</span>
+            <div className="toolbar-summary" aria-live="polite">
+              <span className="toolbar-summary__title">Active target</span>
+              <span className="toolbar-summary__value">{selectedTarget.bossName}</span>
+              <span className="toolbar-summary__meta">{selectedVersion.title}</span>
             </div>
           ) : null}
         </div>
-      </div>
+      </section>
 
       {activeSequence && activeSequence.conditions.length > 0 ? (
-        <div className="app-header__conditions">
-          <h4 className="app-header__conditions-title">Sequence conditions</h4>
+        <section className="sequence-conditions-panel">
+          <h4 className="sequence-conditions-panel__title">Sequence conditions</h4>
           <div
             className="sequence-conditions"
             role="group"
@@ -242,41 +246,41 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
               );
             })}
           </div>
-        </div>
+        </section>
       ) : null}
 
-      <div className="app-header__summary" aria-live="polite">
-        <div className="summary-tile">
-          <span className="summary-tile__label">Target HP</span>
-          <span className="summary-tile__value">{derived.targetHp.toLocaleString()}</span>
+      <section className="encounter-summary" aria-live="polite">
+        <div className="summary-chip">
+          <span className="summary-chip__label">Target HP</span>
+          <span className="summary-chip__value">{derived.targetHp.toLocaleString()}</span>
         </div>
-        <div className="summary-tile">
-          <span className="summary-tile__label">Damage Logged</span>
-          <span className="summary-tile__value">
+        <div className="summary-chip">
+          <span className="summary-chip__label">Damage Logged</span>
+          <span className="summary-chip__value">
             {derived.totalDamage.toLocaleString()}
           </span>
         </div>
-        <div className="summary-tile">
-          <span className="summary-tile__label">Remaining</span>
-          <span className="summary-tile__value">
+        <div className="summary-chip">
+          <span className="summary-chip__label">Remaining</span>
+          <span className="summary-chip__value">
             {derived.remainingHp.toLocaleString()}
           </span>
         </div>
         {currentSequenceEntry ? (
-          <div className="summary-tile">
-            <span className="summary-tile__label">Current Stage</span>
-            <span className="summary-tile__value">
+          <div className="summary-chip">
+            <span className="summary-chip__label">Current Stage</span>
+            <span className="summary-chip__value">
               {currentSequenceEntry.target.bossName}
             </span>
           </div>
         ) : selectedTarget ? (
-          <div className="summary-tile">
-            <span className="summary-tile__label">Arena</span>
-            <span className="summary-tile__value">{selectedTarget.location}</span>
+          <div className="summary-chip">
+            <span className="summary-chip__label">Arena</span>
+            <span className="summary-chip__value">{selectedTarget.location}</span>
           </div>
         ) : null}
-      </div>
-    </header>
+      </section>
+    </div>
   );
 };
 

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -5,6 +5,7 @@ import {
   useFightState,
   type SpellLevel,
 } from '../fight-state/FightStateContext';
+import { MAX_OVERCHARM_OVERFLOW } from '../fight-state/fightReducer';
 import type { Charm } from '../../data';
 import {
   bossMap,
@@ -165,6 +166,7 @@ export const useBuildConfiguration = () => {
     () => calculateCharmCost(activeCharmIds),
     [activeCharmIds],
   );
+  const isOvercharmed = activeCharmCost > notchLimit;
 
   const setNailUpgrade = useCallback(
     (nailUpgradeId: string) => {
@@ -225,14 +227,20 @@ export const useBuildConfiguration = () => {
       if (activeCharmIds.includes(charmId)) {
         return true;
       }
+
+      if (isOvercharmed) {
+        return false;
+      }
+
       const conflict = REPLACEABLE_CHARMS.get(charmId);
       const withoutConflict = conflict
         ? activeCharmIds.filter((id) => id !== conflict)
         : activeCharmIds;
       const candidate = [...withoutConflict, charmId];
-      return calculateCharmCost(candidate) <= notchLimit;
+      const cost = calculateCharmCost(candidate);
+      return cost <= notchLimit || cost <= notchLimit + MAX_OVERCHARM_OVERFLOW;
     },
-    [activeCharmIds, notchLimit],
+    [activeCharmIds, notchLimit, isOvercharmed],
   );
 
   const handleSequenceChange = useCallback(
@@ -365,5 +373,6 @@ export const useBuildConfiguration = () => {
     nailUpgrades,
     spells,
     charmDetails,
+    isOvercharmed,
   };
 };

--- a/src/features/fight-state/fightReducer.test.ts
+++ b/src/features/fight-state/fightReducer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { charmMap } from '../../data';
 import {
   MAX_NOTCH_LIMIT,
+  MAX_OVERCHARM_OVERFLOW,
   MIN_NOTCH_LIMIT,
   createInitialState,
   fightReducer,
@@ -32,8 +33,15 @@ describe('fightReducer notch limits', () => {
       0,
     );
 
-    expect(totalCost).toBeLessThanOrEqual(5);
-    expect(tightened.build.activeCharmIds).toEqual(['shaman-stone', 'spell-twister']);
+    expect(totalCost).toBeLessThanOrEqual(5 + MAX_OVERCHARM_OVERFLOW);
+    expect(tightened.build.activeCharmIds).toEqual(richSelection);
+
+    const overstuffed = fightReducer(tightened, {
+      type: 'setActiveCharms',
+      charmIds: [...richSelection, 'lifeblood-heart'],
+    });
+
+    expect(overstuffed.build.activeCharmIds).toEqual(richSelection);
   });
 
   it('respects the minimum and maximum notch limits', () => {

--- a/src/features/fight-state/fightReducer.ts
+++ b/src/features/fight-state/fightReducer.ts
@@ -96,6 +96,7 @@ export const initialSpellLevels = (): Record<string, SpellLevel> => {
 
 export const MIN_NOTCH_LIMIT = 3;
 export const MAX_NOTCH_LIMIT = 11;
+export const MAX_OVERCHARM_OVERFLOW = 5;
 
 const clampNotchLimit = (value: number) =>
   Math.min(MAX_NOTCH_LIMIT, Math.max(MIN_NOTCH_LIMIT, Math.round(value)));
@@ -110,14 +111,20 @@ const clampCharmSelection = (charmIds: string[], notchLimit: number) => {
   const uniqueOrdered = charmIds.filter((id, index) => charmIds.indexOf(id) === index);
   const selected: string[] = [];
   let totalCost = 0;
+  let hasOverflow = false;
 
   for (const id of uniqueOrdered) {
     const cost = getCharmCost(id);
-    if (totalCost + cost > notchLimit) {
-      continue;
+    const nextCost = totalCost + cost;
+    if (nextCost > notchLimit) {
+      if (hasOverflow || nextCost > notchLimit + MAX_OVERCHARM_OVERFLOW) {
+        continue;
+      }
+      hasOverflow = true;
     }
+
     selected.push(id);
-    totalCost += cost;
+    totalCost = nextCost;
   }
 
   return selected;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,7 +21,7 @@
   --color-overcharm: #ff6edb;
   --color-overcharm-glow: rgba(255 110 219 / 45%);
   --color-card-bg: rgba(14 18 38 / 78%);
-  --header-gap: clamp(1rem, 2vw, 2rem);
+  --header-gap: clamp(0.75rem, 1.6vw, 1.5rem);
   --panel-radius: 22px;
 
   background-color: var(--color-bg);
@@ -49,44 +49,50 @@ body {
   width: min(100%, 1220px);
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 2rem);
-  padding: clamp(1.25rem, 3vw, 3rem);
+  gap: clamp(1rem, 2vw, 1.6rem);
+  padding: clamp(1.25rem, 3vw, 2.5rem);
 }
 
 .app-header {
   display: flex;
   flex-direction: column;
   gap: var(--header-gap);
-  padding: clamp(1.5rem, 2.5vw, 2.25rem);
+  padding: clamp(1.1rem, 2vw, 1.8rem);
   border-radius: var(--panel-radius);
   background: linear-gradient(165deg, var(--color-surface), rgba(11 14 30 / 94%));
   border: 1px solid var(--color-border);
-  box-shadow: 0 28px 80px rgba(5 8 30 / 45%);
+  box-shadow: 0 22px 60px rgba(5 8 30 / 38%);
 }
 
-.app-header__row {
+.app-header__top {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .app-header__brand {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .app-header__title {
   margin: 0;
-  font-size: clamp(2.1rem, 4vw, 3rem);
+  font-size: clamp(1.9rem, 3.2vw, 2.6rem);
   font-weight: 700;
   letter-spacing: 0.02em;
 }
 
 .app-header__subtitle {
   margin: 0;
-  max-width: 60ch;
-  color: var(--color-muted);
+  max-width: 54ch;
+  color: rgba(240 243 255 / 60%);
+  font-size: 0.95rem;
+}
+
+.app-header__actions {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .header-button {
@@ -113,18 +119,22 @@ body {
   border-color: rgba(130 207 255 / 60%);
 }
 
-.app-header__controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  align-items: flex-start;
+.app-header__filters {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.header-stack {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
 }
 
 .header-field {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  min-width: min(16rem, 100%);
 }
 
 .header-field--compact {
@@ -147,6 +157,43 @@ body {
   color: inherit;
   padding: 0.55rem 0.85rem;
   font-size: 0.95rem;
+  width: 100%;
+}
+
+.header-field input[type='number'] {
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border-subtle);
+  background: rgba(10 12 26 / 70%);
+  color: inherit;
+  padding: 0.55rem 0.85rem;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.header-summary {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255 255 255 / 10%);
+  background: rgba(12 16 32 / 75%);
+  padding: 0.65rem 0.9rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.header-summary__title {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.header-summary__value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.header-summary__meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .sequence-toolbar {
@@ -185,6 +232,23 @@ body {
   transform: none;
 }
 
+.app-header__conditions {
+  border-radius: 1rem;
+  border: 1px solid rgba(255 255 255 / 12%);
+  background: rgba(10 14 28 / 75%);
+  padding: 0.75rem 1rem 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.app-header__conditions-title {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
 .app-header__summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -219,13 +283,19 @@ body {
   gap: clamp(1rem, 2vw, 1.5rem);
 }
 
-@media (width >= 1024px) {
-  .app-header__row {
+@media (width >= 768px) {
+  .app-header__top {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
   }
 
+  .app-header__actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (width >= 1024px) {
   .app-main {
     display: grid;
     grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
@@ -599,7 +669,7 @@ body {
   gap: 1.25rem;
 }
 
-.charm-workbench__sidebar {
+.charm-workbench__overview {
   display: grid;
   gap: 1rem;
 }
@@ -620,10 +690,10 @@ body {
   border-radius: 999px;
 }
 
-@media (width >= 960px) {
-  .charm-workbench {
-    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-    align-items: start;
+@media (width >= 900px) {
+  .charm-workbench__overview {
+    grid-template-columns: minmax(0, 1.1fr) minmax(240px, 0.9fr);
+    align-items: stretch;
   }
 }
 
@@ -765,6 +835,31 @@ body {
   margin: 0;
   font-size: 0.82rem;
   color: var(--color-muted);
+}
+
+.overcharm-banner {
+  border-radius: 14px;
+  border: 1px solid rgba(255 110 219 / 55%);
+  background: linear-gradient(120deg, rgba(255 110 219 / 35%), rgba(255 110 219 / 15%));
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  align-items: baseline;
+  color: var(--color-overcharm);
+  box-shadow: 0 16px 36px rgba(255 110 219 / 18%);
+}
+
+.overcharm-banner__label {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.overcharm-banner__message {
+  font-size: 0.88rem;
+  color: rgba(255 221 246 / 85%);
 }
 
 .notch-panel--overcharmed {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,55 +45,53 @@ body {
 }
 
 .app-shell {
-  flex: 1;
-  width: min(100%, 1220px);
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: clamp(0.85rem, 2vw, 1.35rem);
   padding: clamp(1.1rem, 2.5vw, 2rem);
+  width: min(100%, 1220px);
 }
 
-.app-header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--header-gap);
-  padding: clamp(0.85rem, 1.7vw, 1.3rem) clamp(1rem, 2vw, 1.6rem);
-  border-radius: var(--panel-radius);
-  background: linear-gradient(165deg, var(--color-surface), rgba(11 14 30 / 94%));
-  border: 1px solid var(--color-border);
-  box-shadow: 0 18px 48px rgba(5 8 30 / 32%);
+.encounter-header {
+  display: grid;
+  gap: clamp(0.55rem, 1.4vw, 0.95rem);
 }
 
-.app-header__top {
+.app-navbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: clamp(0.5rem, 1.2vw, 1rem);
-  flex-wrap: wrap;
+  gap: clamp(0.6rem, 1.4vw, 1rem);
+  padding: 0.55rem clamp(0.75rem, 2vw, 1.4rem);
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgba(18 26 52 / 88%), rgba(12 17 36 / 92%));
+  border: 1px solid rgba(130 207 255 / 32%);
+  box-shadow: 0 16px 36px rgba(5 8 24 / 28%);
 }
 
-.app-header__brand {
+.app-navbar__brand {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  min-width: min(100%, 240px);
+  gap: 0.15rem;
+  min-width: min(100%, 220px);
 }
 
-.app-header__title {
+.app-navbar__title {
   margin: 0;
-  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  font-size: clamp(1.05rem, 1.8vw, 1.4rem);
   font-weight: 700;
   letter-spacing: 0.01em;
 }
 
-.app-header__subtitle {
+.app-navbar__subtitle {
   margin: 0;
-  max-width: 52ch;
-  color: rgba(240 243 255 / 56%);
-  font-size: clamp(0.78rem, 1.1vw, 0.88rem);
+  color: rgba(240 243 255 / 60%);
+  font-size: clamp(0.68rem, 1vw, 0.78rem);
+  max-width: 46ch;
 }
 
-.app-header__actions {
+.app-navbar__actions {
   display: flex;
   align-items: center;
   flex-shrink: 0;
@@ -106,9 +104,9 @@ body {
   background: rgba(130 207 255 / 18%);
   color: var(--color-text);
   font-weight: 600;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   letter-spacing: 0.03em;
-  padding: 0.5rem 1.05rem;
+  padding: 0.45rem 1rem;
   cursor: pointer;
   transition:
     transform 120ms ease,
@@ -124,104 +122,98 @@ body {
   border-color: rgba(130 207 255 / 60%);
 }
 
-.app-header__filters {
+.encounter-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: clamp(0.65rem, 1.2vw, 0.9rem);
   align-items: flex-end;
+  gap: clamp(0.55rem, 1.1vw, 0.85rem);
+  padding: 0.6rem clamp(0.7rem, 2vw, 1.3rem);
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255 255 255 / 12%);
+  background: rgba(9 12 24 / 72%);
+  backdrop-filter: blur(12px);
 }
 
-.header-stack {
+.toolbar-stack {
   display: flex;
+  flex: 1 1 260px;
   flex-wrap: wrap;
-  gap: clamp(0.6rem, 1vw, 0.85rem);
   align-items: flex-end;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
 }
 
-.header-field {
+.toolbar-field {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.25rem;
+  flex: 1 1 190px;
 }
 
-.header-stack .header-field {
-  flex: 1 1 210px;
+.toolbar-field--compact {
+  min-width: 8.5rem;
+  flex: 0 1 8.5rem;
 }
 
-.header-field--compact {
-  min-width: 9rem;
-  flex: 0 1 9rem;
-}
-
-.header-field__label {
-  font-size: 0.78rem;
+.toolbar-field__label {
+  font-size: 0.74rem;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
-.header-field select {
+.toolbar-field select,
+.toolbar-field input[type='number'] {
   appearance: none;
-  border-radius: 0.65rem;
+  border-radius: 0.6rem;
   border: 1px solid var(--color-border-subtle);
-  background: rgba(10 12 26 / 72%);
+  background: rgba(10 12 26 / 76%);
   color: inherit;
-  padding: 0.48rem 0.75rem;
-  font-size: 0.9rem;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.88rem;
   width: 100%;
 }
 
-.header-field input[type='number'] {
-  border-radius: 0.65rem;
-  border: 1px solid var(--color-border-subtle);
-  background: rgba(10 12 26 / 72%);
-  color: inherit;
-  padding: 0.48rem 0.75rem;
-  font-size: 0.9rem;
-  width: 100%;
-}
-
-.header-summary {
+.toolbar-summary {
   border-radius: 0.75rem;
-  border: 1px solid rgba(255 255 255 / 10%);
-  background: rgba(12 16 32 / 75%);
-  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(255 255 255 / 12%);
+  background: rgba(12 16 32 / 74%);
+  padding: 0.5rem 0.75rem;
   display: grid;
-  gap: 0.15rem;
-  min-width: 200px;
+  gap: 0.1rem;
+  min-width: 190px;
 }
 
-.header-summary__title {
-  font-size: 0.7rem;
+.toolbar-summary__title {
+  font-size: 0.68rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
-.header-summary__value {
+.toolbar-summary__value {
   font-weight: 600;
-  font-size: 0.98rem;
+  font-size: 0.95rem;
 }
 
-.header-summary__meta {
-  font-size: 0.8rem;
+.toolbar-summary__meta {
+  font-size: 0.78rem;
   color: var(--color-muted);
 }
 
 .sequence-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.38rem;
 }
 
 .sequence-toolbar__button {
-  border-radius: 0.65rem;
+  border-radius: 0.6rem;
   border: 1px solid var(--color-border-subtle);
   background: rgba(130 207 255 / 18%);
   color: inherit;
-  padding: 0.42rem 0.7rem;
-  font-size: 0.78rem;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.76rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   cursor: pointer;
@@ -245,67 +237,67 @@ body {
   transform: none;
 }
 
-.app-header__conditions {
-  border-radius: 0.9rem;
+.sequence-conditions-panel {
+  border-radius: 1.1rem;
   border: 1px solid rgba(255 255 255 / 12%);
-  background: rgba(10 14 28 / 75%);
-  padding: 0.65rem 0.75rem 0.8rem;
+  background: rgba(9 12 24 / 70%);
+  padding: 0.6rem clamp(0.75rem, 2vw, 1.2rem) 0.75rem;
   display: grid;
-  gap: 0.45rem;
+  gap: 0.4rem;
 }
 
-.app-header__conditions-title {
+.sequence-conditions-panel__title {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
-.app-header__summary {
+.encounter-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: clamp(0.55rem, 1vw, 0.8rem);
+  gap: clamp(0.45rem, 0.9vw, 0.75rem);
 }
 
-.summary-tile {
-  border-radius: 0.85rem;
-  padding: 0.6rem 0.85rem;
-  background: rgba(9 12 24 / 72%);
-  border: 1px solid rgba(255 255 255 / 8%);
+.summary-chip {
+  border-radius: 0.75rem;
+  padding: 0.45rem 0.75rem;
+  background: rgba(9 12 24 / 62%);
+  border: 1px solid rgba(255 255 255 / 10%);
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
-  min-width: 130px;
+  gap: 0.1rem;
+  min-width: 120px;
 }
 
-.summary-tile__label {
-  font-size: 0.72rem;
+.summary-chip__label {
+  font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
-.summary-tile__value {
-  font-size: 1.08rem;
+.summary-chip__value {
+  font-size: 1.02rem;
   font-weight: 700;
 }
 
 .app-main {
-  display: flex;
-  flex-direction: column;
   gap: clamp(0.9rem, 1.9vw, 1.35rem);
 }
 
 @media (width >= 768px) {
-  .app-header__top {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+  .app-navbar {
+    padding-inline: clamp(1rem, 2.2vw, 1.65rem);
   }
 
-  .app-header__actions {
-    justify-content: flex-end;
+  .toolbar-stack {
+    flex-wrap: nowrap;
+  }
+
+  .toolbar-summary {
+    min-width: 210px;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,7 +21,7 @@
   --color-overcharm: #ff6edb;
   --color-overcharm-glow: rgba(255 110 219 / 45%);
   --color-card-bg: rgba(14 18 38 / 78%);
-  --header-gap: clamp(0.75rem, 1.6vw, 1.5rem);
+  --header-gap: clamp(0.55rem, 1.1vw, 0.9rem);
   --panel-radius: 22px;
 
   background-color: var(--color-bg);
@@ -49,50 +49,54 @@ body {
   width: min(100%, 1220px);
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 1.6rem);
-  padding: clamp(1.25rem, 3vw, 2.5rem);
+  gap: clamp(0.85rem, 2vw, 1.35rem);
+  padding: clamp(1.1rem, 2.5vw, 2rem);
 }
 
 .app-header {
   display: flex;
   flex-direction: column;
   gap: var(--header-gap);
-  padding: clamp(1.1rem, 2vw, 1.8rem);
+  padding: clamp(0.85rem, 1.7vw, 1.3rem) clamp(1rem, 2vw, 1.6rem);
   border-radius: var(--panel-radius);
   background: linear-gradient(165deg, var(--color-surface), rgba(11 14 30 / 94%));
   border: 1px solid var(--color-border);
-  box-shadow: 0 22px 60px rgba(5 8 30 / 38%);
+  box-shadow: 0 18px 48px rgba(5 8 30 / 32%);
 }
 
 .app-header__top {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.5rem, 1.2vw, 1rem);
+  flex-wrap: wrap;
 }
 
 .app-header__brand {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
+  min-width: min(100%, 240px);
 }
 
 .app-header__title {
   margin: 0;
-  font-size: clamp(1.9rem, 3.2vw, 2.6rem);
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
 .app-header__subtitle {
   margin: 0;
-  max-width: 54ch;
-  color: rgba(240 243 255 / 60%);
-  font-size: 0.95rem;
+  max-width: 52ch;
+  color: rgba(240 243 255 / 56%);
+  font-size: clamp(0.78rem, 1.1vw, 0.88rem);
 }
 
 .app-header__actions {
   display: flex;
-  justify-content: flex-start;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .header-button {
@@ -102,8 +106,9 @@ body {
   background: rgba(130 207 255 / 18%);
   color: var(--color-text);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  padding: 0.55rem 1.2rem;
+  font-size: 0.92rem;
+  letter-spacing: 0.03em;
+  padding: 0.5rem 1.05rem;
   cursor: pointer;
   transition:
     transform 120ms ease,
@@ -120,67 +125,75 @@ body {
 }
 
 .app-header__filters {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.65rem, 1.2vw, 0.9rem);
+  align-items: flex-end;
 }
 
 .header-stack {
-  display: grid;
-  gap: 0.75rem;
-  align-content: start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.6rem, 1vw, 0.85rem);
+  align-items: flex-end;
 }
 
 .header-field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
+}
+
+.header-stack .header-field {
+  flex: 1 1 210px;
 }
 
 .header-field--compact {
-  min-width: 10rem;
+  min-width: 9rem;
+  flex: 0 1 9rem;
 }
 
 .header-field__label {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
 .header-field select {
   appearance: none;
-  border-radius: 0.75rem;
+  border-radius: 0.65rem;
   border: 1px solid var(--color-border-subtle);
-  background: rgba(10 12 26 / 70%);
+  background: rgba(10 12 26 / 72%);
   color: inherit;
-  padding: 0.55rem 0.85rem;
-  font-size: 0.95rem;
+  padding: 0.48rem 0.75rem;
+  font-size: 0.9rem;
   width: 100%;
 }
 
 .header-field input[type='number'] {
-  border-radius: 0.75rem;
+  border-radius: 0.65rem;
   border: 1px solid var(--color-border-subtle);
-  background: rgba(10 12 26 / 70%);
+  background: rgba(10 12 26 / 72%);
   color: inherit;
-  padding: 0.55rem 0.85rem;
-  font-size: 0.95rem;
+  padding: 0.48rem 0.75rem;
+  font-size: 0.9rem;
   width: 100%;
 }
 
 .header-summary {
-  border-radius: 0.85rem;
+  border-radius: 0.75rem;
   border: 1px solid rgba(255 255 255 / 10%);
   background: rgba(12 16 32 / 75%);
-  padding: 0.65rem 0.9rem;
+  padding: 0.55rem 0.75rem;
   display: grid;
-  gap: 0.2rem;
+  gap: 0.15rem;
+  min-width: 200px;
 }
 
 .header-summary__title {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
@@ -188,18 +201,18 @@ body {
 
 .header-summary__value {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.98rem;
 }
 
 .header-summary__meta {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--color-muted);
 }
 
 .sequence-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .sequence-toolbar__button {
@@ -207,8 +220,8 @@ body {
   border: 1px solid var(--color-border-subtle);
   background: rgba(130 207 255 / 18%);
   color: inherit;
-  padding: 0.45rem 0.8rem;
-  font-size: 0.85rem;
+  padding: 0.42rem 0.7rem;
+  font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   cursor: pointer;
@@ -233,54 +246,55 @@ body {
 }
 
 .app-header__conditions {
-  border-radius: 1rem;
+  border-radius: 0.9rem;
   border: 1px solid rgba(255 255 255 / 12%);
   background: rgba(10 14 28 / 75%);
-  padding: 0.75rem 1rem 1rem;
+  padding: 0.65rem 0.75rem 0.8rem;
   display: grid;
-  gap: 0.6rem;
+  gap: 0.45rem;
 }
 
 .app-header__conditions-title {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
 .app-header__summary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.55rem, 1vw, 0.8rem);
 }
 
 .summary-tile {
-  border-radius: 1rem;
-  padding: 0.75rem 1rem;
-  background: rgba(9 12 24 / 70%);
+  border-radius: 0.85rem;
+  padding: 0.6rem 0.85rem;
+  background: rgba(9 12 24 / 72%);
   border: 1px solid rgba(255 255 255 / 8%);
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.15rem;
+  min-width: 130px;
 }
 
 .summary-tile__label {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
 
 .summary-tile__value {
-  font-size: 1.25rem;
+  font-size: 1.08rem;
   font-weight: 700;
 }
 
 .app-main {
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 1.5rem);
+  gap: clamp(0.9rem, 1.9vw, 1.35rem);
 }
 
 @media (width >= 768px) {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -17,13 +17,13 @@ test.describe('Landing page', () => {
     await page.goto('/');
 
     await page.selectOption('#boss-target', 'custom');
+    const customTargetInput = page.locator('#custom-target-hp');
+    await customTargetInput.fill('3333');
+
     await page.getByRole('button', { name: 'Player Loadout' }).click();
 
     const modal = page.getByRole('dialog', { name: 'Player Loadout' });
     await expect(modal).toBeVisible();
-
-    const customTargetInput = modal.locator('#custom-target-hp');
-    await customTargetInput.fill('3333');
 
     await modal.locator('#nail-level').selectOption('pure-nail');
     await modal.getByRole('button', { name: 'Strength & Quick Slash' }).click();
@@ -41,12 +41,12 @@ test.describe('Landing page', () => {
     await page.reload();
 
     await expect(page.locator('#boss-target')).toHaveValue('custom');
+    await expect(page.locator('#custom-target-hp')).toHaveValue('3333');
 
     await page.getByRole('button', { name: 'Player Loadout' }).click();
     const reopenedModal = page.getByRole('dialog', { name: 'Player Loadout' });
     await expect(reopenedModal).toBeVisible();
 
-    await expect(reopenedModal.locator('#custom-target-hp')).toHaveValue('3333');
     await expect(reopenedModal.locator('#nail-level')).toHaveValue('pure-nail');
     await expect(
       reopenedModal.getByRole('button', { name: /^Unbreakable Strength/ }),


### PR DESCRIPTION
## Summary
- reorganize the loadout modal so notch status sits above the grid, presets below it, and show an overcharm banner
- move boss version, custom HP, and sequence condition controls into the main header while tightening the header layout
- allow one overcharmed charm via the reducer and update app tests accordingly

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5fcd0e150832f96dbe1b41cb455ae