### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '08:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      prod-dependencies:
+        dependency-type: 'production'
+      dev-dependencies:
+        dependency-type: 'development'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '08:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'


### PR DESCRIPTION
## Summary
- add Dependabot configuration to manage pnpm dependencies with weekly grouped updates
- configure Dependabot to maintain GitHub Actions with consistent commit conventions

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d617129c1c832f922e37c5989aa8dd