### PR TITLE
feat: add combat time projections

### DIFF
--- a/src/features/combat-stats/CombatStatsPanel.test.tsx
+++ b/src/features/combat-stats/CombatStatsPanel.test.tsx
@@ -1,0 +1,133 @@
+import { act, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useEffect } from 'react';
+
+import { CombatStatsPanel } from './CombatStatsPanel';
+import { type AttackInput, useFightState } from '../fight-state/FightStateContext';
+import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
+import { bossMap, DEFAULT_BOSS_ID, nailUpgrades } from '../../data';
+
+const baseNailDamage = nailUpgrades[0]?.damage ?? 5;
+const defaultBossTarget = bossMap.get(DEFAULT_BOSS_ID);
+
+if (!defaultBossTarget) {
+  throw new Error('Expected default boss target to be defined for tests');
+}
+
+const ActionRegistrar = ({
+  onReady,
+}: {
+  onReady: (logAttack: (input: AttackInput) => void) => void;
+}) => {
+  const {
+    actions: { logAttack },
+  } = useFightState();
+
+  useEffect(() => {
+    onReady(logAttack);
+  }, [logAttack, onReady]);
+
+  return null;
+};
+
+describe('CombatStatsPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('estimates remaining fight time using observed DPS', async () => {
+    let logAttack: ((input: AttackInput) => void) | null = null;
+
+    renderWithFightProvider(
+      <>
+        <ActionRegistrar onReady={(logger) => (logAttack = logger)} />
+        <CombatStatsPanel />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(logAttack).not.toBeNull();
+    });
+
+    const estimateRow = screen
+      .getByText('Estimated Time Remaining')
+      .closest('.data-list__item');
+
+    expect(estimateRow).not.toBeNull();
+    expect(within(estimateRow as HTMLElement).getByText('—')).toBeInTheDocument();
+
+    act(() => {
+      logAttack?.({
+        id: 'test-hit-1',
+        label: 'Test Hit',
+        damage: baseNailDamage,
+        category: 'nail',
+        timestamp: 0,
+      });
+      logAttack?.({
+        id: 'test-hit-2',
+        label: 'Test Hit',
+        damage: baseNailDamage,
+        category: 'nail',
+        timestamp: 3000,
+      });
+    });
+
+    const totalDamage = baseNailDamage * 2;
+    const remainingHp = Math.max(0, defaultBossTarget.hp - totalDamage);
+    const elapsedMs = 3000;
+    const dps = totalDamage / (elapsedMs / 1000);
+    const estimatedMs = Math.round((remainingHp / dps) * 1000);
+    const totalSeconds = Math.floor(estimatedMs / 1000);
+    const expectedMinutes = Math.floor(totalSeconds / 60);
+    const expectedSeconds = (totalSeconds % 60).toString().padStart(2, '0');
+    const expectedLabel = `${expectedMinutes}:${expectedSeconds}`;
+
+    expect(
+      within(estimateRow as HTMLElement).getByText(expectedLabel),
+    ).toBeInTheDocument();
+  });
+
+  it('renders sparklines to visualize damage trends', async () => {
+    let logAttack: ((input: AttackInput) => void) | null = null;
+
+    renderWithFightProvider(
+      <>
+        <ActionRegistrar onReady={(logger) => (logAttack = logger)} />
+        <CombatStatsPanel />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(logAttack).not.toBeNull();
+    });
+
+    act(() => {
+      logAttack?.({
+        id: 'spark-hit-1',
+        label: 'Test Hit',
+        damage: baseNailDamage,
+        category: 'nail',
+        timestamp: 0,
+      });
+      logAttack?.({
+        id: 'spark-hit-2',
+        label: 'Test Hit',
+        damage: baseNailDamage * 2,
+        category: 'nail',
+        timestamp: 5000,
+      });
+    });
+
+    expect(
+      screen.getByRole('img', { name: /total damage dealt per attack/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: /remaining health after each attack/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/combat-stats/Sparkline.tsx
+++ b/src/features/combat-stats/Sparkline.tsx
@@ -1,0 +1,85 @@
+import type { FC } from 'react';
+
+interface SparklineProps {
+  data: number[];
+  ariaLabel: string;
+  className?: string;
+  width?: number;
+  height?: number;
+  padding?: number;
+}
+
+const buildPolylinePoints = (
+  data: number[],
+  width: number,
+  height: number,
+  padding: number,
+) => {
+  const size = data.length;
+
+  if (size === 0) {
+    return '';
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min;
+
+  const innerWidth = width - padding * 2;
+  const innerHeight = height - padding * 2;
+
+  if (innerWidth <= 0 || innerHeight <= 0) {
+    return '';
+  }
+
+  const step = size > 1 ? innerWidth / (size - 1) : innerWidth;
+
+  return data
+    .map((value, index) => {
+      const normalized = range === 0 ? 0.5 : (value - min) / range;
+      const x = padding + index * step;
+      const y = padding + (1 - normalized) * innerHeight;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+};
+
+export const Sparkline: FC<SparklineProps> = ({
+  data,
+  ariaLabel,
+  className,
+  width = 88,
+  height = 28,
+  padding = 2,
+}) => {
+  if (data.length < 2) {
+    return null;
+  }
+
+  const polylinePoints = buildPolylinePoints(data, width, height, padding);
+
+  if (!polylinePoints) {
+    return null;
+  }
+
+  const sparklineClassName = ['sparkline', className].filter(Boolean).join(' ');
+  const areaPoints = `${padding},${height - padding} ${polylinePoints} ${width - padding},${
+    height - padding
+  }`;
+
+  return (
+    <svg
+      className={sparklineClassName}
+      role="img"
+      aria-label={ariaLabel}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+    >
+      <title>{ariaLabel}</title>
+      <polygon className="sparkline__area" points={areaPoints} />
+      <polyline className="sparkline__line" points={polylinePoints} />
+    </svg>
+  );
+};

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -37,6 +37,7 @@ export interface DerivedStats {
   elapsedMs: number | null;
   dps: number | null;
   actionsPerMinute: number | null;
+  estimatedTimeRemainingMs: number | null;
 }
 
 interface FightContextValue {
@@ -84,6 +85,12 @@ const calculateDerivedStats = (state: FightState): DerivedStats => {
   const dps = elapsedMs && elapsedMs > 0 ? totalDamage / (elapsedMs / 1000) : null;
   const actionsPerMinute =
     elapsedMs && elapsedMs > 0 ? attacksLogged / (elapsedMs / 60000) : null;
+  const estimatedTimeRemainingMs =
+    remainingHp === 0
+      ? 0
+      : dps && dps > 0
+        ? Math.round((remainingHp / dps) * 1000)
+        : null;
 
   return {
     targetHp,
@@ -94,6 +101,7 @@ const calculateDerivedStats = (state: FightState): DerivedStats => {
     elapsedMs,
     dps,
     actionsPerMinute,
+    estimatedTimeRemainingMs,
   };
 };
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -526,8 +526,37 @@ body {
 }
 
 .data-list__value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
   font-size: 1.3rem;
   font-weight: 700;
+}
+
+.data-list__value-text {
+  line-height: 1;
+}
+
+.sparkline {
+  width: 88px;
+  height: 28px;
+  color: var(--color-accent);
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.sparkline__area {
+  fill: currentcolor;
+  opacity: 0.18;
+}
+
+.sparkline__line {
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Modal */


### PR DESCRIPTION
## Summary
- add an estimated time remaining metric to the combat overview using observed DPS
- render inline sparklines for damage, remaining HP, average hit, and DPS trends
- cover the new projections and sparklines with dedicated CombatStatsPanel tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d6161c98a0832fbb5d272f7cf43869