### PR TITLE
feat: allow removing spells from loadout

### DIFF
--- a/src/features/attack-log/useAttackDefinitions.test.ts
+++ b/src/features/attack-log/useAttackDefinitions.test.ts
@@ -92,6 +92,25 @@ describe('useAttackDefinitions helpers', () => {
     expect(vengefulSpirit?.description).toMatch(/flukenest volley/i);
   });
 
+  it('omits spells that are not yet acquired', () => {
+    const [firstSpell] = spells;
+    if (!firstSpell) {
+      throw new Error('Expected at least one spell fixture');
+    }
+
+    const state = createFightState({
+      build: {
+        spellLevels: { [firstSpell.id]: 'none' },
+      },
+    });
+
+    const groups = buildAttackGroups(state);
+    const spellsGroup = groups.find((group) => group.id === 'spellcasting');
+    const attackIds = spellsGroup?.attacks.map((attack) => attack.id) ?? [];
+
+    expect(attackIds.some((id) => id.startsWith(`${firstSpell.id}-`))).toBe(false);
+  });
+
   it('builds shortcut metadata including hits remaining for each attack', () => {
     const state = createFightState();
     const groups = buildAttackGroups(state);

--- a/src/features/attack-log/useAttackDefinitions.ts
+++ b/src/features/attack-log/useAttackDefinitions.ts
@@ -191,6 +191,9 @@ export const buildAttackGroups = (state: FightState): AttackGroup[] => {
 
   for (const spell of spells) {
     const level = build.spellLevels[spell.id] ?? 'base';
+    if (level === 'none') {
+      continue;
+    }
     const variant = level === 'upgrade' && spell.upgrade ? spell.upgrade : spell.base;
     let baseDamage = getVariantDamage(variant);
     const notes: string[] = [];

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -383,6 +383,16 @@ export const PlayerConfigModal: FC<PlayerConfigModalProps> = ({ isOpen, onClose 
               {spells.map((spell) => (
                 <fieldset key={spell.id} className="spell-card">
                   <legend>{spell.name}</legend>
+                  <label className="spell-card__option spell-card__option--muted">
+                    <input
+                      type="radio"
+                      name={`spell-${spell.id}`}
+                      value="none"
+                      checked={build.spellLevels[spell.id] === 'none'}
+                      onChange={() => setSpellLevel(spell.id, 'none')}
+                    />
+                    <span>Not acquired</span>
+                  </label>
                   <label className="spell-card__option">
                     <input
                       type="radio"

--- a/src/features/fight-state/fightReducer.ts
+++ b/src/features/fight-state/fightReducer.ts
@@ -10,7 +10,7 @@ import {
 import type { BossSequenceEntry } from '../../data';
 
 export type AttackCategory = 'nail' | 'spell' | 'advanced' | 'charm';
-export type SpellLevel = 'base' | 'upgrade';
+export type SpellLevel = 'none' | 'base' | 'upgrade';
 
 export interface AttackEvent {
   id: string;

--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -37,6 +37,7 @@ describe('fight-state persistence', () => {
           activeCharmIds: ['shaman-stone', 'shaman-stone', 17],
           spellLevels: {
             'desolate-dive': 'upgrade',
+            'vengeful-spirit': 'none',
             invalid: 'nope',
           },
           notchLimit: 50,
@@ -101,6 +102,7 @@ describe('fight-state persistence', () => {
     expect(merged.build.activeCharmIds).toEqual(['shaman-stone']);
     expect(merged.build.notchLimit).toBe(MAX_NOTCH_LIMIT);
     expect(merged.build.spellLevels['desolate-dive']).toBe('upgrade');
+    expect(merged.build.spellLevels['vengeful-spirit']).toBe('none');
     expect(Object.values(merged.build.spellLevels)).toContain('base');
 
     expect(merged.damageLog).toHaveLength(1);

--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -70,7 +70,7 @@ export const sanitizeSpellLevels = (
 
   const sanitized: Record<string, SpellLevel> = { ...fallback };
   for (const [spellId, level] of Object.entries(value)) {
-    if (level === 'base' || level === 'upgrade') {
+    if (level === 'none' || level === 'base' || level === 'upgrade') {
       sanitized[spellId] = level;
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -711,6 +711,7 @@ body {
 
 .charm-workbench__grid {
   --charm-size: clamp(2.8rem, 6vw, 4.6rem);
+  --charm-gap: clamp(0.5rem, 0.8vw, 0.8rem);
 
   overflow-x: auto;
   padding-bottom: 0.5rem;
@@ -735,6 +736,7 @@ body {
 @media (width >= 1280px) {
   .charm-workbench__grid {
     --charm-size: 4.9rem;
+    --charm-gap: 0.85rem;
   }
 }
 
@@ -925,18 +927,18 @@ body {
 
 .charm-grid {
   display: grid;
-  gap: 1rem;
+  gap: calc(var(--charm-gap) * 1.1);
   min-width: max-content;
 }
 
 .charm-grid__row {
   display: grid;
   grid-template-columns: repeat(10, var(--charm-size));
-  gap: 0.9rem;
+  gap: var(--charm-gap);
 }
 
 .charm-grid__row--offset {
-  margin-left: calc((var(--charm-size) + 0.9rem) / 2);
+  margin-left: calc((var(--charm-size) + var(--charm-gap)) / 2);
 }
 
 .charm-slot {
@@ -1060,6 +1062,10 @@ body {
   font-size: 0.95rem;
 }
 
+.spell-card__option--muted {
+  color: var(--color-muted);
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -1132,6 +1138,6 @@ body {
   }
 
   .charm-grid__row--offset {
-    margin-left: 2rem;
+    margin-left: calc((var(--charm-size) + var(--charm-gap)) / 1.6);
   }
 }


### PR DESCRIPTION
## Summary
- add a "Not acquired" option to spell loadout controls so players can remove spells they do not have
- ignore removed spells when building attack definitions and persist the new spell state safely
- tighten charm grid spacing so the loadout modal fits without changing charm art sizes

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d61bdc0ed0832faab936aa4d069fee