### PR TITLE
ci: automate simulated fight screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,34 @@ jobs:
       - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           CI: true
+
+  fight-screenshots:
+    if: github.event_name == 'pull_request'
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.1-jammy
+    env:
+      HOME: /root
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright test tests/e2e/simulated-fight-screenshot.spec.ts --project=${{ matrix.browser }}
+        env:
+          CI: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: simulated-fight-${{ matrix.browser }}
+          path: test-results/simulated-fight/${{ matrix.browser }}-simulated-fight.png
+          if-no-files-found: error

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 bosses.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 
+## Automated simulated fight screenshots
+
+- Pull requests trigger a `fight-screenshots` GitHub Actions job that executes `tests/e2e/simulated-fight-screenshot.spec.ts` against Chromium, Firefox, and WebKit. Each run hydrates a deterministic combat log, captures the resulting UI, and uploads a browser-specific PNG artifact.
+
+### Incorporating screenshots into the README
+
+To surface the latest simulated fight image automatically, add a follow-up workflow that downloads the `simulated-fight-*` artifacts and updates the repository:
+
+1. Use a `workflow_run` trigger that fires after `fight-screenshots` completes (or reuse `pull_request_target` for trusted branches).
+2. Download the artifacts with [`actions/download-artifact`](https://github.com/actions/download-artifact) and move a canonical image (for example, `docs/assets/simulated-fight.png`) into the repository.
+3. Apply a templated README update that references the canonical file (e.g., embed the image in a "Latest simulation" section).
+4. Commit the change with [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) for preview during the PR, or push directly on `workflow_run` events targeting `main` once the PR merges.
+
+This pattern keeps the README current without granting workflows permission to modify contributor branches directly.
+
 ## Project Roadmap
 
 1. **Scaffolding:** Initialize the frontend project, configure TypeScript, linting, formatting, and unit test tooling.

--- a/tests/e2e/simulated-fight-screenshot.spec.ts
+++ b/tests/e2e/simulated-fight-screenshot.spec.ts
@@ -1,0 +1,199 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { test, expect } from '@playwright/test';
+
+type AttackCategory = 'nail' | 'spell' | 'advanced' | 'charm';
+
+type AttackEvent = {
+  id: string;
+  label: string;
+  damage: number;
+  category: AttackCategory;
+  timestamp: number;
+  soulCost?: number;
+};
+
+type PersistedFightState = {
+  selectedBossId: string;
+  customTargetHp: number;
+  build: {
+    nailUpgradeId: string;
+    activeCharmIds: string[];
+    spellLevels: Record<string, 'none' | 'base' | 'upgrade'>;
+    notchLimit: number;
+  };
+  damageLog: AttackEvent[];
+  redoStack: AttackEvent[];
+  activeSequenceId: string | null;
+  sequenceIndex: number;
+  sequenceLogs: Record<string, AttackEvent[]>;
+  sequenceRedoStacks: Record<string, AttackEvent[]>;
+  sequenceConditions: Record<string, Record<string, boolean>>;
+};
+
+const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
+
+const SIMULATED_DAMAGE_LOG: AttackEvent[] = [
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 0,
+  },
+  {
+    id: 'great-slash',
+    label: 'Great Slash',
+    damage: 79,
+    category: 'advanced',
+    timestamp: 2400,
+  },
+  {
+    id: 'vengeful-spirit-shadeSoul',
+    label: 'Shade Soul',
+    damage: 40,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 4100,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 1)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 6300,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 2)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 6650,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 3)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 7000,
+  },
+  {
+    id: 'desolate-dive-descendingDark',
+    label: 'Descending Dark',
+    damage: 91,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 9400,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 11300,
+  },
+  {
+    id: 'dash-slash',
+    label: 'Dash Slash',
+    damage: 63,
+    category: 'advanced',
+    timestamp: 13500,
+  },
+  {
+    id: 'howling-wraiths-abyssShriek',
+    label: 'Abyss Shriek',
+    damage: 120,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 16800,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 19100,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 21500,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 24200,
+  },
+];
+
+const SIMULATED_STATE: PersistedFightState = {
+  selectedBossId: 'the-radiance__standard',
+  customTargetHp: 3000,
+  build: {
+    nailUpgradeId: 'pure-nail',
+    activeCharmIds: ['unbreakable-strength', 'quick-slash', 'shaman-stone'],
+    spellLevels: {
+      'vengeful-spirit': 'upgrade',
+      'desolate-dive': 'upgrade',
+      'howling-wraiths': 'upgrade',
+    },
+    notchLimit: 11,
+  },
+  damageLog: SIMULATED_DAMAGE_LOG,
+  redoStack: [],
+  activeSequenceId: null,
+  sequenceIndex: 0,
+  sequenceLogs: {},
+  sequenceRedoStacks: {},
+  sequenceConditions: {},
+};
+
+test.describe('Simulated fight screenshot', () => {
+  test('captures a deterministic combat overview', async ({ page }, testInfo) => {
+    await page.addInitScript(
+      ({ state, storageKey }) => {
+        window.localStorage.clear();
+        window.localStorage.setItem(storageKey, JSON.stringify(state));
+      },
+      { state: SIMULATED_STATE, storageKey: STORAGE_KEY },
+    );
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByRole('heading', { name: 'Hollow Knight Damage Tracker' }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText('Damage Logged').locator('..').locator('.data-list__value-text'),
+    ).toHaveText('649');
+    await expect(
+      page.getByText('Attacks Logged').locator('..').locator('.data-list__value-text'),
+    ).toHaveText('13');
+
+    const screenshotDirectory = path.resolve('test-results/simulated-fight');
+    await mkdir(screenshotDirectory, { recursive: true });
+
+    const screenshotPath = path.join(
+      screenshotDirectory,
+      `${testInfo.project.name}-simulated-fight.png`,
+    );
+
+    const screenshot = await page.screenshot({
+      path: screenshotPath,
+      fullPage: true,
+      animations: 'disabled',
+    });
+
+    await testInfo.attach(`simulated-fight-${testInfo.project.name}`, {
+      body: screenshot,
+      contentType: 'image/png',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic Playwright scenario that hydrates a simulated Radiance fight and captures screenshots per browser
- extend CI with a pull-request-only `fight-screenshots` matrix job that runs the scenario for Chromium, Firefox, and WebKit while uploading artifacts
- document the new automation and suggest a README embedding workflow, while preventing Prettier from reformatting the lockfile

## Testing
- `pnpm test`
- ⚠️ `pnpm exec playwright test tests/e2e/simulated-fight-screenshot.spec.ts --project=chromium` *(fails locally because Playwright browsers need additional system dependencies in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61fd30a04832fa2bcaeb94c456982