### PR TITLE
fix: add json import assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,34 @@ jobs:
       - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           CI: true
+
+  screenshots:
+    if: github.event_name == 'pull_request'
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.1-jammy
+    env:
+      HOME: /root
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright test tests/e2e/simulated-fight-screenshot.spec.ts --project=${{ matrix.browser }}
+        env:
+          CI: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: simulated-fight-${{ matrix.browser }}
+          path: test-results/simulated-fight/${{ matrix.browser }}-simulated-fight.png
+          if-no-files-found: error

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 bosses.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 
+## Automated simulated fight screenshots
+
+- Pull requests trigger a `screenshots` GitHub Actions job that executes `tests/e2e/simulated-fight-screenshot.spec.ts` against Chromium, Firefox, and WebKit. Each run hydrates a deterministic combat log, captures the resulting UI, and uploads a browser-specific PNG artifact.
+
 ## Project Roadmap
 
 1. **Scaffolding:** Initialize the frontend project, configure TypeScript, linting, formatting, and unit test tooling.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,6 @@
-import rawDamage from './damage.json';
-import rawBosses from './bosses.json';
-import rawSequences from './sequences.json';
+import rawDamage from './damage.json' assert { type: 'json' };
+import rawBosses from './bosses.json' assert { type: 'json' };
+import rawSequences from './sequences.json' assert { type: 'json' };
 import type {
   Boss,
   BossSequence,

--- a/tests/e2e/simulated-fight-screenshot.spec.ts
+++ b/tests/e2e/simulated-fight-screenshot.spec.ts
@@ -1,0 +1,181 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import type {
+  AttackEvent,
+  FightState,
+} from '../../src/features/fight-state/FightStateContext';
+import { STORAGE_KEY, STORAGE_VERSION } from '../../src/features/fight-state/persistence';
+
+const SIMULATED_DAMAGE_LOG: AttackEvent[] = [
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 0,
+  },
+  {
+    id: 'great-slash',
+    label: 'Great Slash',
+    damage: 79,
+    category: 'advanced',
+    timestamp: 2400,
+  },
+  {
+    id: 'vengeful-spirit-shadeSoul',
+    label: 'Shade Soul',
+    damage: 40,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 4100,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 1)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 6300,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 2)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 6650,
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (Hit 3)',
+    damage: 32,
+    category: 'advanced',
+    timestamp: 7000,
+  },
+  {
+    id: 'desolate-dive-descendingDark',
+    label: 'Descending Dark',
+    damage: 91,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 9400,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 11300,
+  },
+  {
+    id: 'dash-slash',
+    label: 'Dash Slash',
+    damage: 63,
+    category: 'advanced',
+    timestamp: 13500,
+  },
+  {
+    id: 'howling-wraiths-abyssShriek',
+    label: 'Abyss Shriek',
+    damage: 120,
+    category: 'spell',
+    soulCost: 33,
+    timestamp: 16800,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 19100,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 21500,
+  },
+  {
+    id: 'nail-strike',
+    label: 'Nail Strike',
+    damage: 32,
+    category: 'nail',
+    timestamp: 24200,
+  },
+];
+
+const SIMULATED_STATE: FightState = {
+  selectedBossId: 'the-radiance__standard',
+  customTargetHp: 3000,
+  build: {
+    nailUpgradeId: 'pure-nail',
+    activeCharmIds: ['unbreakable-strength', 'quick-slash', 'shaman-stone'],
+    spellLevels: {
+      'vengeful-spirit': 'upgrade',
+      'desolate-dive': 'upgrade',
+      'howling-wraiths': 'upgrade',
+    },
+    notchLimit: 11,
+  },
+  damageLog: SIMULATED_DAMAGE_LOG,
+  redoStack: [],
+  activeSequenceId: null,
+  sequenceIndex: 0,
+  sequenceLogs: {},
+  sequenceRedoStacks: {},
+  sequenceConditions: {},
+};
+
+test.describe('Simulated fight screenshot', () => {
+  test('captures a deterministic combat overview', async ({ page }, testInfo) => {
+    await page.addInitScript(
+      ({ state, storageKey, storageVersion }) => {
+        window.localStorage.clear();
+        window.localStorage.setItem(
+          storageKey,
+          JSON.stringify({ version: storageVersion, state }),
+        );
+      },
+      {
+        state: SIMULATED_STATE,
+        storageKey: STORAGE_KEY,
+        storageVersion: STORAGE_VERSION,
+      },
+    );
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByRole('heading', { name: 'Hollow Knight Damage Tracker' }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText('Damage Logged').locator('..').locator('.data-list__value-text'),
+    ).toHaveText('649');
+    await expect(
+      page.getByText('Attacks Logged').locator('..').locator('.data-list__value-text'),
+    ).toHaveText('13');
+
+    const screenshotDirectory = path.resolve('test-results/simulated-fight');
+    await mkdir(screenshotDirectory, { recursive: true });
+
+    const screenshotPath = path.join(
+      screenshotDirectory,
+      `${testInfo.project.name}-simulated-fight.png`,
+    );
+
+    const screenshot = await page.screenshot({
+      path: screenshotPath,
+      fullPage: true,
+      animations: 'disabled',
+    });
+
+    await testInfo.attach(`simulated-fight-${testInfo.project.name}`, {
+      body: screenshot,
+      contentType: 'image/png',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add JSON import assertions for the data module so Vite serves the resources with the required attributes during Playwright runs

## Testing
- pnpm lint
- pnpm test
- pnpm exec playwright test tests/e2e/simulated-fight-screenshot.spec.ts --project=chromium *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61fd30a04832fa2bcaeb94c456982