### PR TITLE
feat: reorganize attack log categories

### DIFF
--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -54,7 +54,7 @@ describe('AttackLogPanel', () => {
     expect(damageDisplay).toHaveTextContent('32');
   });
 
-  it('surfaces spell upgrades in the advanced group when unlocked', async () => {
+  it('surfaces spell upgrades in the spell group without duplicates', async () => {
     const user = userEvent.setup();
 
     renderWithFightProvider(
@@ -64,10 +64,17 @@ describe('AttackLogPanel', () => {
       </>,
     );
 
-    await user.click(screen.getByRole('radio', { name: /shade soul/i }));
+    await user.click(
+      screen.getByRole('radio', {
+        name: /shade soul/i,
+      }),
+    );
 
-    const shadeSoulButtons = screen.getAllByRole('button', { name: /shade soul/i });
-    expect(shadeSoulButtons.length).toBeGreaterThan(0);
+    const spellsGroup = screen.getByRole('group', { name: /spells/i });
+    const shadeSoulButtons = within(spellsGroup).getAllByRole('button', {
+      name: /shade soul/i,
+    });
+    expect(shadeSoulButtons).toHaveLength(1);
   });
 
   it('logs damage and updates combat statistics', async () => {

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -77,7 +77,7 @@ export const AttackLogPanel: FC = () => {
     <div>
       <p className="section__description">
         Log each successful hit to reduce the boss health target. Use the buttons below to
-        record standard swings, spells, and advanced techniques with the appropriate
+        record nail strikes, nail arts, spells, and charm effects with the appropriate
         modifiers applied.
       </p>
       <div className="quick-actions" role="group" aria-label="Attack log controls">

--- a/src/features/attack-log/attackData.ts
+++ b/src/features/attack-log/attackData.ts
@@ -1,0 +1,31 @@
+export type NailArtId = 'great-slash' | 'dash-slash' | 'cyclone-slash-hit';
+
+export interface NailArtConfig {
+  id: NailArtId;
+  label: string;
+  multiplier: number;
+  baseDescription: string;
+}
+
+export const NAIL_ARTS: readonly NailArtConfig[] = [
+  {
+    id: 'great-slash',
+    label: 'Great Slash',
+    multiplier: 2.5,
+    baseDescription: 'Nail Art damage.',
+  },
+  {
+    id: 'dash-slash',
+    label: 'Dash Slash',
+    multiplier: 2,
+    baseDescription: 'Nail Art damage.',
+  },
+  {
+    id: 'cyclone-slash-hit',
+    label: 'Cyclone Slash (per hit)',
+    multiplier: 1,
+    baseDescription: 'Log each Cyclone Slash hit individually.',
+  },
+] as const;
+
+export const NAIL_ART_IDS = new Set<NailArtId>(NAIL_ARTS.map((art) => art.id));

--- a/src/features/attack-log/useAttackDefinitions.test.ts
+++ b/src/features/attack-log/useAttackDefinitions.test.ts
@@ -92,6 +92,22 @@ describe('useAttackDefinitions helpers', () => {
     expect(vengefulSpirit?.description).toMatch(/flukenest volley/i);
   });
 
+  it('groups nail arts separately from standard nail attacks', () => {
+    const state = createFightState();
+
+    const groups = buildAttackGroups(state);
+    const nailArtsGroup = groups.find((group) => group.id === 'nail-arts');
+
+    expect(nailArtsGroup).toBeDefined();
+    expect(nailArtsGroup?.attacks.map((attack) => attack.id)).toEqual(
+      expect.arrayContaining(['great-slash', 'dash-slash', 'cyclone-slash-hit']),
+    );
+    const allCategoriesAreNailArts = nailArtsGroup?.attacks.every(
+      (attack) => attack.category === 'nail-art',
+    );
+    expect(allCategoriesAreNailArts).toBe(true);
+  });
+
   it('omits spells that are not yet acquired', () => {
     const [firstSpell] = spells;
     if (!firstSpell) {

--- a/src/features/fight-state/fightReducer.ts
+++ b/src/features/fight-state/fightReducer.ts
@@ -10,7 +10,7 @@ import {
 } from '../../data';
 import type { BossSequenceEntry } from '../../data';
 
-export type AttackCategory = 'nail' | 'spell' | 'advanced' | 'charm';
+export type AttackCategory = 'nail' | 'spell' | 'nail-art' | 'charm';
 export type SpellLevel = 'none' | 'base' | 'upgrade';
 
 export interface AttackEvent {

--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -14,11 +14,39 @@ import {
   mergePersistedState,
   persistStateToStorage,
   restorePersistedState,
+  sanitizeAttackEvents,
 } from './persistence';
 
 describe('fight-state persistence', () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  it('converts legacy advanced categories to modern equivalents', () => {
+    const events = sanitizeAttackEvents(
+      [
+        {
+          id: 'great-slash',
+          label: 'Great Slash',
+          damage: 100,
+          category: 'advanced',
+          timestamp: 1,
+        },
+        {
+          id: 'vengeful-spirit-upgrade',
+          label: 'Shade Soul',
+          damage: 30,
+          category: 'advanced',
+          timestamp: 2,
+        },
+      ],
+      [],
+    );
+
+    expect(events).toEqual([
+      expect.objectContaining({ id: 'great-slash', category: 'nail-art' }),
+      expect.objectContaining({ id: 'vengeful-spirit-upgrade', category: 'spell' }),
+    ]);
   });
 
   it('sanitizes persisted payloads before merging them into state', () => {

--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -1,4 +1,5 @@
 import {
+  AttackCategory,
   AttackEvent,
   FightState,
   MAX_NOTCH_LIMIT,
@@ -7,6 +8,10 @@ import {
   ensureSequenceState,
   ensureSpellLevels,
 } from './fightReducer';
+import { NAIL_ART_IDS } from '../attack-log/attackData';
+import type { NailArtId } from '../attack-log/attackData';
+
+const isNailArtId = (id: string): id is NailArtId => NAIL_ART_IDS.has(id as NailArtId);
 
 export const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
 export const STORAGE_VERSION = 3;
@@ -109,12 +114,19 @@ export const sanitizeAttackEvents = (
       continue;
     }
 
+    let sanitizedCategory: AttackCategory | null = null;
     if (
-      category !== 'nail' &&
-      category !== 'spell' &&
-      category !== 'advanced' &&
-      category !== 'charm'
+      category === 'nail' ||
+      category === 'spell' ||
+      category === 'nail-art' ||
+      category === 'charm'
     ) {
+      sanitizedCategory = category;
+    } else if (category === 'advanced') {
+      sanitizedCategory = isNailArtId(id) ? 'nail-art' : 'spell';
+    }
+
+    if (!sanitizedCategory) {
       continue;
     }
 
@@ -126,7 +138,7 @@ export const sanitizeAttackEvents = (
       id,
       label,
       damage,
-      category,
+      category: sanitizedCategory,
       timestamp,
       soulCost,
     });


### PR DESCRIPTION
## Summary
- create a dedicated nail art dataset and surface it as its own attack group alongside spells and charms
- update attack definitions, UI text, and persistence logic to stop duplicating spells in advanced techniques while remapping legacy data
- expand coverage to confirm the new grouping and persistence migration behavior

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d780903cd0832fbb9d88f8aa62371b