### PR TITLE
feat: separate fight derived stats store

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import { CombatStatsPanel } from '../features/combat-stats/CombatStatsPanel';
 import {
   CUSTOM_BOSS_ID,
   FightStateProvider,
+  useFightDerivedStats,
 } from '../features/fight-state/FightStateContext';
 
 type HeaderBarProps = {
@@ -40,8 +41,8 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
     activeSequence,
     sequenceConditionValues,
     handleSequenceConditionToggle,
-    derived,
   } = useBuildConfiguration();
+  const derived = useFightDerivedStats();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -1,12 +1,13 @@
 import type { FC } from 'react';
 import { useEffect } from 'react';
 
-import { useFightState } from '../fight-state/FightStateContext';
+import { useFightDerivedStats, useFightState } from '../fight-state/FightStateContext';
 import { RESET_SHORTCUT_KEY, useAttackDefinitions } from './useAttackDefinitions';
 
 export const AttackLogPanel: FC = () => {
   const fight = useFightState();
-  const { actions, state, derived } = fight;
+  const derived = useFightDerivedStats();
+  const { actions, state } = fight;
   const { damageLog, redoStack } = state;
   const canEndFight = derived.fightStartTimestamp != null && !derived.isFightComplete;
 

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -96,8 +96,7 @@ export const charmGridLayout = [
 ] as const;
 
 export const useBuildConfiguration = () => {
-  const fight = useFightState();
-  const { state, actions, derived } = fight;
+  const { state, actions } = useFightState();
   const {
     selectedBossId,
     customTargetHp,
@@ -335,7 +334,6 @@ export const useBuildConfiguration = () => {
   return {
     state,
     actions,
-    derived,
     bosses,
     bossMap,
     bossSequences,

--- a/src/features/combat-stats/CombatStatsPanel.tsx
+++ b/src/features/combat-stats/CombatStatsPanel.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import { useFightState } from '../fight-state/FightStateContext';
+import { useFightDerivedStats, useFightState } from '../fight-state/FightStateContext';
 import { Sparkline, type SparklinePoint } from './Sparkline';
 
 const FRAMES_PER_SECOND = 60;
@@ -95,21 +95,21 @@ const toSparklineSeries = (
 export const CombatStatsPanel: FC = () => {
   const {
     state: { damageLog },
-    derived: {
-      targetHp,
-      totalDamage,
-      remainingHp,
-      attacksLogged,
-      averageDamage,
-      dps,
-      actionsPerMinute,
-      elapsedMs,
-      estimatedTimeRemainingMs,
-      fightEndTimestamp,
-      fightStartTimestamp,
-      frameTimestamp,
-    },
   } = useFightState();
+  const {
+    targetHp,
+    totalDamage,
+    remainingHp,
+    attacksLogged,
+    averageDamage,
+    dps,
+    actionsPerMinute,
+    elapsedMs,
+    estimatedTimeRemainingMs,
+    fightEndTimestamp,
+    fightStartTimestamp,
+    frameTimestamp,
+  } = useFightDerivedStats();
 
   const timelineEndTimestamp =
     fightEndTimestamp ?? (fightStartTimestamp != null ? frameTimestamp : null);


### PR DESCRIPTION
## Summary
- move fight derived metrics into a dedicated useSyncExternalStore-powered context and keep the base fight context limited to state and actions
- update build configuration, attack log, combat stats, and app header to read live metrics through the new useFightDerivedStats hook
- add unit tests covering the derived stats subscription flow and requestAnimationFrame cleanup

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d78535fec4832f9653ee98bd81621a