### PR TITLE
Capture initial state screenshots in Playwright e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,12 @@ jobs:
       - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           CI: true
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ matrix.browser }}-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: warn

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,10 +7,14 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['html', { open: 'never' }]],
   use: {
     baseURL: 'http://127.0.0.1:4173',
-    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    trace: 'on',
+    video: 'retain-on-failure',
   },
   webServer: {
     command: 'pnpm dev --host 127.0.0.1 --port 4173 --strictPort',

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -4,9 +4,12 @@ test.describe('Landing page', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     await page.goto('/');
 
-    const initialStateScreenshot = await page.screenshot({ fullPage: true });
+    const screenshotPath = testInfo.outputPath(
+      `initial-state-${testInfo.project.name}.png`,
+    );
+    await page.screenshot({ fullPage: true, path: screenshotPath });
     await testInfo.attach(`initial-state-${testInfo.project.name}`, {
-      body: initialStateScreenshot,
+      path: screenshotPath,
       contentType: 'image/png',
     });
   });

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,9 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Landing page', () => {
-  test('displays the core sections', async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
     await page.goto('/');
 
+    const initialStateScreenshot = await page.screenshot({ fullPage: true });
+    await testInfo.attach(`initial-state-${testInfo.project.name}`, {
+      body: initialStateScreenshot,
+      contentType: 'image/png',
+    });
+  });
+
+  test('displays the core sections', async ({ page }) => {
     await expect(
       page.getByRole('heading', { name: 'Hollow Knight Damage Tracker' }),
     ).toBeVisible();
@@ -14,8 +22,6 @@ test.describe('Landing page', () => {
   });
 
   test('restores build configuration and logs after a reload', async ({ page }) => {
-    await page.goto('/');
-
     await page.selectOption('#boss-target', 'custom');
     const customTargetInput = page.locator('#custom-target-hp');
     await customTargetInput.fill('3333');


### PR DESCRIPTION
## Summary
- capture the initial landing page state before each e2e test run
- attach the initial state screenshot to the Playwright report for every browser

## Testing
- pnpm test:unit
- pnpm test:e2e *(fails locally: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d78865ca7c832f88a96c4ed8f39a87