### PR TITLE
feat: debounce fight state persistence writes

### DIFF
--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -270,6 +270,36 @@ export const FightStateProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }, [state.fightEndTimestamp, flushPersist]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        flushPersist();
+      }
+    };
+
+    const handlePageHide = () => {
+      flushPersist();
+    };
+
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handlePageHide);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handlePageHide);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      }
+    };
+  }, [flushPersist]);
+
   useIsomorphicLayoutEffect(
     () => () => {
       flushPersist();

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useReducer,
   useRef,
@@ -88,6 +89,9 @@ interface DerivedStatsStore {
 
 const FightStateContext = createContext<FightContextValue | undefined>(undefined);
 const FightDerivedStatsContext = createContext<DerivedStatsStore | undefined>(undefined);
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 type IdleCallbackOptions = { timeout?: number };
 type IdleDeadline = { didTimeout: boolean; timeRemaining: () => number };
@@ -225,7 +229,7 @@ export const FightStateProvider: FC<PropsWithChildren> = ({ children }) => {
     } satisfies DerivedStatsStore;
   }
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     stateRef.current = state;
     schedulePersist();
     notifyDerived();
@@ -266,7 +270,7 @@ export const FightStateProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }, [state.fightEndTimestamp, flushPersist]);
 
-  useEffect(
+  useIsomorphicLayoutEffect(
     () => () => {
       flushPersist();
     },


### PR DESCRIPTION
## Summary
- debounce fight state persistence using an idle callback and ensure the latest state is flushed on fight end or provider teardown
- keep a live state ref while cancelling pending writes to avoid stale data hitting storage
- add persistence tests covering batched writes, unmount flushes, and fight-end persistence

## Testing
- pnpm test -- src/features/fight-state/persistence.test.ts src/features/fight-state/FightStateContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d78c0e16f8832f92606d772e24172b