### PR TITLE
feat: add fight state selectors for configuration ui

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,8 +16,8 @@ type HeaderBarProps = {
 
 const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
   const {
-    state,
     bosses,
+    selectedBossId,
     bossSelectValue,
     handleBossChange,
     bossSequences,
@@ -172,13 +172,11 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
             </select>
           </label>
 
-          {!isSequenceActive &&
-          selectedBoss &&
-          state.selectedBossId !== CUSTOM_BOSS_ID ? (
+          {!isSequenceActive && selectedBoss && selectedBossId !== CUSTOM_BOSS_ID ? (
             <label className="toolbar-field">
               <span className="toolbar-field__label">Boss version</span>
               <select
-                value={state.selectedBossId}
+                value={selectedBossId}
                 onChange={(event) => handleBossVersionChange(event.target.value)}
               >
                 {selectedBoss.versions.map((version) => (
@@ -190,7 +188,7 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
             </label>
           ) : null}
 
-          {!isSequenceActive && state.selectedBossId === CUSTOM_BOSS_ID ? (
+          {!isSequenceActive && selectedBossId === CUSTOM_BOSS_ID ? (
             <label className="toolbar-field" htmlFor="custom-target-hp">
               <span className="toolbar-field__label">Custom target HP</span>
               <input

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -78,7 +78,6 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
   onClose,
 }) => {
   const {
-    state,
     notchLimit,
     activeCharmIds,
     activeCharmCost,
@@ -92,12 +91,12 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
     setSpellLevel,
     charmDetails,
     isOvercharmed,
+    build,
   } = useBuildConfiguration();
 
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const charmIconMap = useMemo(createCharmIconMap, []);
 
-  const { build } = state;
   const notchUsage = `${activeCharmCost}/${notchLimit}`;
   const equippedCharms = useMemo(
     () =>

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -2,7 +2,8 @@ import { useCallback, useMemo } from 'react';
 
 import {
   CUSTOM_BOSS_ID,
-  useFightState,
+  useFightActions,
+  useFightStateSelector,
   type SpellLevel,
 } from '../fight-state/FightStateContext';
 import { MAX_OVERCHARM_OVERFLOW } from '../fight-state/fightReducer';
@@ -96,15 +97,13 @@ export const charmGridLayout = [
 ] as const;
 
 export const useBuildConfiguration = () => {
-  const { state, actions } = useFightState();
-  const {
-    selectedBossId,
-    customTargetHp,
-    build,
-    activeSequenceId,
-    sequenceIndex,
-    sequenceConditions,
-  } = state;
+  const actions = useFightActions();
+  const selectedBossId = useFightStateSelector((state) => state.selectedBossId);
+  const customTargetHp = useFightStateSelector((state) => state.customTargetHp);
+  const build = useFightStateSelector((state) => state.build);
+  const activeSequenceId = useFightStateSelector((state) => state.activeSequenceId);
+  const sequenceIndex = useFightStateSelector((state) => state.sequenceIndex);
+  const sequenceConditions = useFightStateSelector((state) => state.sequenceConditions);
 
   const selectedTarget = useMemo(() => bossMap.get(selectedBossId), [selectedBossId]);
 
@@ -332,8 +331,8 @@ export const useBuildConfiguration = () => {
   }, []);
 
   return {
-    state,
     actions,
+    selectedBossId,
     bosses,
     bossMap,
     bossSequences,
@@ -359,6 +358,7 @@ export const useBuildConfiguration = () => {
     handleCustomHpChange,
     customTargetHp,
     isSequenceActive,
+    build,
     notchLimit,
     activeCharmIds,
     activeCharmCost,


### PR DESCRIPTION
## Summary
- add a selector-driven fight state store with dedicated hooks for actions and state slices
- update build configuration consumers to rely on selectors instead of the full reducer state
- cover the selector behavior with a new test and isolate derived stats tests from persisted state

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d79aa80e88832faff08be53b8ae585