### PR TITLE
feat: redesign encounter hud layout

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -29,29 +29,37 @@ describe('App', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.selectOptions(screen.getByLabelText(/boss target/i), 'custom');
-    const hpInput = screen.getByLabelText(/custom target hp/i);
+    const optionsToggle = screen.getByRole('button', {
+      name: /advanced target options/i,
+    });
+    await user.click(optionsToggle);
+    await user.click(screen.getByRole('radio', { name: /custom/i }));
+    const hpInput = await screen.findByLabelText(/custom target hp/i);
     await user.clear(hpInput);
     await user.type(hpInput, '500');
 
-    const targetTile = screen
-      .getByText(/target hp/i, { selector: '.summary-chip__label' })
-      .closest('.summary-chip');
-    expect(targetTile).toHaveTextContent('500');
+    const targetMetric = screen
+      .getByText(/target hp/i, { selector: '.scoreboard-metric__label' })
+      .closest('.scoreboard-metric');
+    expect(targetMetric).toHaveTextContent('500');
   });
 
   it('switches boss versions to reflect Godhome health pools', async () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.selectOptions(screen.getByLabelText(/boss target/i), 'gruz-mother');
+    await user.click(screen.getByRole('radio', { name: /gruz mother/i }));
+    const optionsToggle = screen.getByRole('button', {
+      name: /advanced target options/i,
+    });
+    await user.click(optionsToggle);
     const versionSelect = await screen.findByLabelText(/boss version/i);
     await user.selectOptions(versionSelect, 'gruz-mother__ascended');
 
-    const targetTile = screen
-      .getByText(/target hp/i, { selector: '.summary-chip__label' })
-      .closest('.summary-chip');
-    expect(targetTile).toHaveTextContent('945');
+    const targetMetric = screen
+      .getByText(/target hp/i, { selector: '.scoreboard-metric__label' })
+      .closest('.scoreboard-metric');
+    expect(targetMetric).toHaveTextContent('945');
   });
 
   it('applies charm presets and enforces overcharm limits', async () => {
@@ -95,10 +103,7 @@ describe('App', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.selectOptions(
-      screen.getByLabelText(/boss sequence/i),
-      'pantheon-of-the-sage',
-    );
+    await user.selectOptions(screen.getByLabelText(/encounter/i), 'pantheon-of-the-sage');
 
     const conditionsGroup = await screen.findByRole('group', {
       name: /sequence conditions/i,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from 'react';
+import { useEffect, useMemo, useState, type FC } from 'react';
 
 import { AttackLogPanel } from '../features/attack-log/AttackLogPanel';
 import { PlayerConfigModal } from '../features/build-config/PlayerConfigModal';
@@ -9,6 +9,295 @@ import {
   FightStateProvider,
   useFightDerivedStats,
 } from '../features/fight-state/FightStateContext';
+
+type EncounterBrandProps = {
+  readonly onOpenModal: () => void;
+};
+
+const EncounterBrand: FC<EncounterBrandProps> = ({ onOpenModal }) => (
+  <div className="hud-brand">
+    <div className="hud-brand__copy">
+      <h1 className="hud-brand__title">Hollow Knight Damage Tracker</h1>
+      <p className="hud-brand__subtitle">
+        Plan your build, log every strike, and monitor fight-ending stats in real time.
+      </p>
+    </div>
+    <div className="hud-brand__actions">
+      <button type="button" className="header-button" onClick={onOpenModal}>
+        Player Loadout
+      </button>
+    </div>
+  </div>
+);
+
+type StageTimelineProps = {
+  readonly bossSequences: ReturnType<typeof useBuildConfiguration>['bossSequences'];
+  readonly sequenceSelectValue: string;
+  readonly onSequenceChange: (value: string) => void;
+  readonly isSequenceActive: boolean;
+  readonly sequenceEntries: ReturnType<typeof useBuildConfiguration>['sequenceEntries'];
+  readonly cappedSequenceIndex: number;
+  readonly onStageSelect: (index: number) => void;
+  readonly onAdvance: () => void;
+  readonly onRewind: () => void;
+  readonly hasNext: boolean;
+  readonly hasPrevious: boolean;
+};
+
+const StageTimeline: FC<StageTimelineProps> = ({
+  bossSequences,
+  sequenceSelectValue,
+  onSequenceChange,
+  isSequenceActive,
+  sequenceEntries,
+  cappedSequenceIndex,
+  onStageSelect,
+  onAdvance,
+  onRewind,
+  hasNext,
+  hasPrevious,
+}) => (
+  <section className="stage-timeline" aria-label="Stage navigation">
+    <label className="stage-timeline__select">
+      <span className="stage-timeline__label">Encounter</span>
+      <select
+        value={sequenceSelectValue}
+        onChange={(event) => onSequenceChange(event.target.value)}
+      >
+        <option value="">Single target practice</option>
+        {bossSequences.map((sequence) => (
+          <option key={sequence.id} value={sequence.id}>
+            {sequence.name}
+          </option>
+        ))}
+      </select>
+    </label>
+
+    {isSequenceActive ? (
+      <div className="stage-timeline__rail">
+        <button
+          type="button"
+          className="stage-timeline__nav"
+          onClick={onRewind}
+          disabled={!hasPrevious}
+          aria-keyshortcuts="["
+        >
+          Prev
+        </button>
+        <ol className="stage-timeline__stages">
+          {sequenceEntries.map((entry, index) => {
+            const isCurrent = index === cappedSequenceIndex;
+            return (
+              <li key={entry.id} className="stage-timeline__stage">
+                <button
+                  type="button"
+                  onClick={() => onStageSelect(index)}
+                  className="stage-timeline__stage-button"
+                  aria-current={isCurrent ? 'step' : undefined}
+                  aria-pressed={isCurrent}
+                >
+                  <span className="stage-timeline__stage-index">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span className="stage-timeline__stage-name">
+                    {entry.target.bossName}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+        <button
+          type="button"
+          className="stage-timeline__nav"
+          onClick={onAdvance}
+          disabled={!hasNext}
+          aria-keyshortcuts="]"
+        >
+          Next
+        </button>
+      </div>
+    ) : (
+      <p className="stage-timeline__empty" aria-live="polite">
+        Practice a single target or switch to a Godhome sequence to plan multi-fight runs.
+      </p>
+    )}
+  </section>
+);
+
+type TargetScoreboardProps = {
+  readonly targetHp: number;
+  readonly totalDamage: number;
+  readonly remainingHp: number;
+  readonly currentStageName: string | null;
+  readonly arenaName: string | null;
+};
+
+const TargetScoreboard: FC<TargetScoreboardProps> = ({
+  targetHp,
+  totalDamage,
+  remainingHp,
+  currentStageName,
+  arenaName,
+}) => {
+  const metrics = useMemo(
+    () =>
+      [
+        { label: 'Target HP', value: targetHp.toLocaleString() },
+        { label: 'Damage Logged', value: totalDamage.toLocaleString() },
+        { label: 'Remaining', value: remainingHp.toLocaleString() },
+        currentStageName
+          ? { label: 'Current Stage', value: currentStageName }
+          : arenaName
+            ? { label: 'Arena', value: arenaName }
+            : null,
+      ].filter((metric): metric is { label: string; value: string } => metric !== null),
+    [arenaName, currentStageName, remainingHp, targetHp, totalDamage],
+  );
+
+  return (
+    <section className="target-scoreboard" aria-live="polite">
+      {metrics.map((metric) => (
+        <div key={metric.label} className="scoreboard-metric">
+          <span className="scoreboard-metric__label">{metric.label}</span>
+          <span className="scoreboard-metric__value">{metric.value}</span>
+        </div>
+      ))}
+    </section>
+  );
+};
+
+type TargetSelectorProps = {
+  readonly bosses: ReturnType<typeof useBuildConfiguration>['bosses'];
+  readonly bossSelectValue: string;
+  readonly onBossChange: (value: string) => void;
+  readonly isSequenceActive: boolean;
+  readonly selectedBoss: ReturnType<typeof useBuildConfiguration>['selectedBoss'];
+  readonly selectedBossId: string | null;
+  readonly onBossVersionChange: (value: string) => void;
+  readonly selectedTarget: ReturnType<typeof useBuildConfiguration>['selectedTarget'];
+  readonly selectedVersion: ReturnType<typeof useBuildConfiguration>['selectedVersion'];
+  readonly customTargetHp: number;
+  readonly onCustomHpChange: (value: string) => void;
+};
+
+const TargetSelector: FC<TargetSelectorProps> = ({
+  bosses,
+  bossSelectValue,
+  onBossChange,
+  isSequenceActive,
+  selectedBoss,
+  selectedBossId,
+  onBossVersionChange,
+  selectedTarget,
+  selectedVersion,
+  customTargetHp,
+  onCustomHpChange,
+}) => {
+  const [isOptionsOpen, setOptionsOpen] = useState(false);
+  const toggleOptions = () => setOptionsOpen((open) => !open);
+
+  return (
+    <section className="target-selector" aria-label="Target selection">
+      <div className="target-selector__primary">
+        <div className="target-selector__header">
+          <span className="target-selector__label">Boss target</span>
+          <button
+            type="button"
+            className="target-selector__options-toggle"
+            onClick={toggleOptions}
+            aria-expanded={isOptionsOpen}
+            aria-controls="target-advanced-options"
+          >
+            ⚙️
+            <span className="sr-only">Advanced target options</span>
+          </button>
+        </div>
+        <div
+          className="segmented-control"
+          role="radiogroup"
+          aria-label="Boss target"
+          aria-disabled={isSequenceActive}
+        >
+          {bosses.map((boss) => {
+            const isSelected = bossSelectValue === boss.id;
+            return (
+              <button
+                key={boss.id}
+                type="button"
+                className="segmented-control__option"
+                data-selected={isSelected}
+                onClick={() => onBossChange(boss.id)}
+                disabled={isSequenceActive}
+                role="radio"
+                aria-checked={isSelected}
+              >
+                {boss.name}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            className="segmented-control__option"
+            data-selected={bossSelectValue === CUSTOM_BOSS_ID}
+            onClick={() => onBossChange(CUSTOM_BOSS_ID)}
+            disabled={isSequenceActive}
+            role="radio"
+            aria-checked={bossSelectValue === CUSTOM_BOSS_ID}
+          >
+            Custom
+          </button>
+        </div>
+      </div>
+
+      <div
+        id="target-advanced-options"
+        className="target-selector__tray"
+        hidden={!isOptionsOpen}
+      >
+        {!isSequenceActive && selectedBoss && selectedBossId !== CUSTOM_BOSS_ID ? (
+          <label className="target-selector__field">
+            <span className="target-selector__field-label">Boss version</span>
+            <select
+              value={selectedBossId ?? ''}
+              onChange={(event) => onBossVersionChange(event.target.value)}
+            >
+              {selectedBoss.versions.map((version) => (
+                <option key={version.targetId} value={version.targetId}>
+                  {`${version.title} • ${version.hp.toLocaleString()} HP`}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {!isSequenceActive && selectedBossId === CUSTOM_BOSS_ID ? (
+          <label className="target-selector__field" htmlFor="custom-target-hp">
+            <span className="target-selector__field-label">Custom target HP</span>
+            <input
+              id="custom-target-hp"
+              type="number"
+              min={1}
+              step={10}
+              value={customTargetHp}
+              onChange={(event) => onCustomHpChange(event.target.value)}
+            />
+          </label>
+        ) : null}
+
+        {selectedTarget && selectedVersion ? (
+          <div className="target-selector__summary">
+            <span className="target-selector__summary-title">Active target</span>
+            <span className="target-selector__summary-value">
+              {selectedTarget.bossName}
+            </span>
+            <span className="target-selector__summary-meta">{selectedVersion.title}</span>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
 
 type HeaderBarProps = {
   readonly onOpenModal: () => void;
@@ -73,144 +362,47 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
     hasPreviousSequenceStage,
   ]);
 
+  const arenaName = selectedTarget?.location ?? null;
+
   return (
     <div className="encounter-header">
-      <header className="app-navbar">
-        <div className="app-navbar__brand">
-          <h1 className="app-navbar__title">Hollow Knight Damage Tracker</h1>
-          <p className="app-navbar__subtitle">
-            Plan your build, log every strike, and monitor fight-ending stats in real
-            time.
-          </p>
-        </div>
-        <div className="app-navbar__actions">
-          <button type="button" className="header-button" onClick={onOpenModal}>
-            Player Loadout
-          </button>
-        </div>
-      </header>
+      <div className="encounter-hud">
+        <EncounterBrand onOpenModal={onOpenModal} />
+        <StageTimeline
+          bossSequences={bossSequences}
+          sequenceSelectValue={sequenceSelectValue}
+          onSequenceChange={handleSequenceChange}
+          isSequenceActive={isSequenceActive}
+          sequenceEntries={sequenceEntries}
+          cappedSequenceIndex={cappedSequenceIndex}
+          onStageSelect={handleSequenceStageChange}
+          onAdvance={handleAdvanceSequence}
+          onRewind={handleRewindSequence}
+          hasNext={hasNextSequenceStage}
+          hasPrevious={hasPreviousSequenceStage}
+        />
+        <TargetScoreboard
+          targetHp={derived.targetHp}
+          totalDamage={derived.totalDamage}
+          remainingHp={derived.remainingHp}
+          currentStageName={currentSequenceEntry?.target.bossName ?? null}
+          arenaName={arenaName}
+        />
+      </div>
 
-      <section
-        className="encounter-toolbar"
-        role="group"
-        aria-label="Encounter selection"
-      >
-        <div className="toolbar-stack">
-          <label className="toolbar-field">
-            <span className="toolbar-field__label">Boss sequence</span>
-            <select
-              value={sequenceSelectValue}
-              onChange={(event) => handleSequenceChange(event.target.value)}
-            >
-              <option value="">Single target practice</option>
-              {bossSequences.map((sequence) => (
-                <option key={sequence.id} value={sequence.id}>
-                  {sequence.name}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          {isSequenceActive ? (
-            <div
-              className="sequence-toolbar"
-              role="group"
-              aria-label="Sequence navigation"
-            >
-              <button
-                type="button"
-                className="sequence-toolbar__button"
-                onClick={handleRewindSequence}
-                disabled={!hasPreviousSequenceStage}
-                aria-keyshortcuts="["
-              >
-                Prev
-              </button>
-              <label className="toolbar-field toolbar-field--compact">
-                <span className="toolbar-field__label">Stage</span>
-                <select
-                  value={String(cappedSequenceIndex)}
-                  onChange={(event) =>
-                    handleSequenceStageChange(Number(event.target.value))
-                  }
-                >
-                  {sequenceEntries.map((entry, index) => (
-                    <option key={entry.id} value={index}>
-                      {`${String(index + 1).padStart(2, '0')} • ${entry.target.bossName}`}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <button
-                type="button"
-                className="sequence-toolbar__button"
-                onClick={handleAdvanceSequence}
-                disabled={!hasNextSequenceStage}
-                aria-keyshortcuts="]"
-              >
-                Next
-              </button>
-            </div>
-          ) : null}
-        </div>
-
-        <div className="toolbar-stack">
-          <label className="toolbar-field">
-            <span className="toolbar-field__label">Boss target</span>
-            <select
-              id="boss-target"
-              value={bossSelectValue}
-              onChange={(event) => handleBossChange(event.target.value)}
-              disabled={isSequenceActive}
-            >
-              {bosses.map((boss) => (
-                <option key={boss.id} value={boss.id}>
-                  {boss.name}
-                </option>
-              ))}
-              <option value={CUSTOM_BOSS_ID}>Custom target</option>
-            </select>
-          </label>
-
-          {!isSequenceActive && selectedBoss && selectedBossId !== CUSTOM_BOSS_ID ? (
-            <label className="toolbar-field">
-              <span className="toolbar-field__label">Boss version</span>
-              <select
-                value={selectedBossId}
-                onChange={(event) => handleBossVersionChange(event.target.value)}
-              >
-                {selectedBoss.versions.map((version) => (
-                  <option key={version.targetId} value={version.targetId}>
-                    {`${version.title} • ${version.hp.toLocaleString()} HP`}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : null}
-
-          {!isSequenceActive && selectedBossId === CUSTOM_BOSS_ID ? (
-            <label className="toolbar-field" htmlFor="custom-target-hp">
-              <span className="toolbar-field__label">Custom target HP</span>
-              <input
-                id="custom-target-hp"
-                type="number"
-                min={1}
-                step={10}
-                value={customTargetHp}
-                onChange={(event) => handleCustomHpChange(event.target.value)}
-              />
-            </label>
-          ) : null}
-
-          {selectedTarget && selectedVersion ? (
-            <div className="toolbar-summary" aria-live="polite">
-              <span className="toolbar-summary__title">Active target</span>
-              <span className="toolbar-summary__value">{selectedTarget.bossName}</span>
-              <span className="toolbar-summary__meta">{selectedVersion.title}</span>
-            </div>
-          ) : null}
-        </div>
-      </section>
+      <TargetSelector
+        bosses={bosses}
+        bossSelectValue={bossSelectValue}
+        onBossChange={handleBossChange}
+        isSequenceActive={isSequenceActive}
+        selectedBoss={selectedBoss}
+        selectedBossId={selectedBossId}
+        onBossVersionChange={handleBossVersionChange}
+        selectedTarget={selectedTarget}
+        selectedVersion={selectedVersion}
+        customTargetHp={customTargetHp}
+        onCustomHpChange={handleCustomHpChange}
+      />
 
       {activeSequence && activeSequence.conditions.length > 0 ? (
         <section className="sequence-conditions-panel">
@@ -247,38 +439,6 @@ const HeaderBar: FC<HeaderBarProps> = ({ onOpenModal }) => {
           </div>
         </section>
       ) : null}
-
-      <section className="encounter-summary" aria-live="polite">
-        <div className="summary-chip">
-          <span className="summary-chip__label">Target HP</span>
-          <span className="summary-chip__value">{derived.targetHp.toLocaleString()}</span>
-        </div>
-        <div className="summary-chip">
-          <span className="summary-chip__label">Damage Logged</span>
-          <span className="summary-chip__value">
-            {derived.totalDamage.toLocaleString()}
-          </span>
-        </div>
-        <div className="summary-chip">
-          <span className="summary-chip__label">Remaining</span>
-          <span className="summary-chip__value">
-            {derived.remainingHp.toLocaleString()}
-          </span>
-        </div>
-        {currentSequenceEntry ? (
-          <div className="summary-chip">
-            <span className="summary-chip__label">Current Stage</span>
-            <span className="summary-chip__value">
-              {currentSequenceEntry.target.bossName}
-            </span>
-          </div>
-        ) : selectedTarget ? (
-          <div className="summary-chip">
-            <span className="summary-chip__label">Arena</span>
-            <span className="summary-chip__value">{selectedTarget.location}</span>
-          </div>
-        ) : null}
-      </section>
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,43 +55,54 @@ body {
 
 .encounter-header {
   display: grid;
-  gap: clamp(0.55rem, 1.4vw, 0.95rem);
+  gap: clamp(0.7rem, 1.6vw, 1.2rem);
 }
 
-.app-navbar {
+.encounter-hud {
+  position: sticky;
+  top: clamp(0.75rem, 2.6vw, 1.4rem);
+  z-index: 5;
+  display: grid;
+  gap: clamp(0.7rem, 1.6vw, 1.2rem);
+  padding: clamp(0.75rem, 2.1vw, 1.4rem);
+  border-radius: 1.35rem;
+  background: linear-gradient(155deg, rgb(18 26 52 / 88%), rgb(12 17 36 / 92%));
+  border: 1px solid rgb(130 207 255 / 32%);
+  box-shadow: 0 18px 42px rgb(5 8 24 / 30%);
+  backdrop-filter: blur(18px);
+}
+
+.hud-brand {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: clamp(0.6rem, 1.4vw, 1rem);
-  padding: 0.55rem clamp(0.75rem, 2vw, 1.4rem);
-  border-radius: 999px;
-  background: linear-gradient(145deg, rgb(18 26 52 / 88%), rgb(12 17 36 / 92%));
-  border: 1px solid rgb(130 207 255 / 32%);
-  box-shadow: 0 16px 36px rgb(5 8 24 / 28%);
+  gap: clamp(0.6rem, 1.4vw, 1.1rem);
 }
 
-.app-navbar__brand {
+.hud-brand__copy {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.2rem;
+  flex: 1 1 220px;
   min-width: min(100%, 220px);
 }
 
-.app-navbar__title {
+.hud-brand__title {
   margin: 0;
-  font-size: clamp(1.05rem, 1.8vw, 1.4rem);
+  font-size: clamp(1.08rem, 1.9vw, 1.5rem);
   font-weight: 700;
   letter-spacing: 0.01em;
 }
 
-.app-navbar__subtitle {
+.hud-brand__subtitle {
   margin: 0;
   color: rgb(240 243 255 / 60%);
-  font-size: clamp(0.68rem, 1vw, 0.78rem);
-  max-width: 46ch;
+  font-size: clamp(0.68rem, 1vw, 0.8rem);
+  max-width: 48ch;
 }
 
-.app-navbar__actions {
+.hud-brand__actions {
   display: flex;
   align-items: center;
   flex-shrink: 0;
@@ -122,39 +133,18 @@ body {
   border-color: rgb(130 207 255 / 60%);
 }
 
-.encounter-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: clamp(0.55rem, 1.1vw, 0.85rem);
-  padding: 0.6rem clamp(0.7rem, 2vw, 1.3rem);
-  border-radius: 1.1rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(9 12 24 / 72%);
-  backdrop-filter: blur(12px);
+.stage-timeline {
+  display: grid;
+  gap: clamp(0.4rem, 1vw, 0.7rem);
 }
 
-.toolbar-stack {
-  display: flex;
-  flex: 1 1 260px;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: clamp(0.5rem, 1vw, 0.75rem);
-}
-
-.toolbar-field {
+.stage-timeline__select {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  flex: 1 1 190px;
 }
 
-.toolbar-field--compact {
-  min-width: 8.5rem;
-  flex: 0 1 8.5rem;
-}
-
-.toolbar-field__label {
+.stage-timeline__label {
   font-size: 0.74rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -162,57 +152,28 @@ body {
   color: var(--color-muted);
 }
 
-.toolbar-field select,
-.toolbar-field input[type='number'] {
+.stage-timeline__select select {
   appearance: none;
-  border-radius: 0.6rem;
+  border-radius: 0.65rem;
   border: 1px solid var(--color-border-subtle);
   background: rgb(10 12 26 / 76%);
   color: inherit;
   padding: 0.45rem 0.7rem;
-  font-size: 0.88rem;
-  width: 100%;
+  font-size: 0.9rem;
 }
 
-.toolbar-summary {
-  border-radius: 0.75rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(12 16 32 / 74%);
-  padding: 0.5rem 0.75rem;
-  display: grid;
-  gap: 0.1rem;
-  min-width: 190px;
-}
-
-.toolbar-summary__title {
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.toolbar-summary__value {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.toolbar-summary__meta {
-  font-size: 0.78rem;
-  color: var(--color-muted);
-}
-
-.sequence-toolbar {
+.stage-timeline__rail {
   display: flex;
   align-items: center;
-  gap: 0.38rem;
+  gap: clamp(0.35rem, 0.8vw, 0.6rem);
 }
 
-.sequence-toolbar__button {
-  border-radius: 0.6rem;
+.stage-timeline__nav {
+  border-radius: 0.7rem;
   border: 1px solid var(--color-border-subtle);
   background: rgb(130 207 255 / 18%);
   color: inherit;
-  padding: 0.4rem 0.65rem;
+  padding: 0.42rem 0.7rem;
   font-size: 0.76rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -223,18 +184,274 @@ body {
     border-color 120ms ease;
 }
 
-.sequence-toolbar__button:hover,
-.sequence-toolbar__button:focus-visible {
+.stage-timeline__nav:hover,
+.stage-timeline__nav:focus-visible {
   outline: none;
   transform: translateY(-1px);
   background: rgb(130 207 255 / 28%);
   border-color: rgb(130 207 255 / 60%);
 }
 
-.sequence-toolbar__button:disabled {
+.stage-timeline__nav:disabled {
   opacity: 0.4;
   cursor: not-allowed;
   transform: none;
+}
+
+.stage-timeline__stages {
+  display: flex;
+  gap: clamp(0.3rem, 0.8vw, 0.6rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.stage-timeline__stage-button {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgb(255 255 255 / 16%);
+  background: rgb(8 11 22 / 78%);
+  color: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.stage-timeline__stage-button[aria-current='step'] {
+  background: rgb(130 207 255 / 24%);
+  border-color: rgb(130 207 255 / 48%);
+  transform: translateY(-1px);
+}
+
+.stage-timeline__stage-button:hover,
+.stage-timeline__stage-button:focus-visible {
+  outline: none;
+  border-color: rgb(130 207 255 / 60%);
+  background: rgb(130 207 255 / 28%);
+  transform: translateY(-1px);
+}
+
+.stage-timeline__stage-index {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.stage-timeline__stage-name {
+  font-weight: 600;
+}
+
+.stage-timeline__empty {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.target-scoreboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: clamp(0.4rem, 1vw, 0.7rem);
+}
+
+.scoreboard-metric {
+  border-radius: 0.85rem;
+  border: 1px solid rgb(255 255 255 / 14%);
+  background: rgb(8 11 22 / 76%);
+  padding: 0.5rem 0.75rem;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.scoreboard-metric__label {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.scoreboard-metric__value {
+  font-size: 1.04rem;
+  font-weight: 700;
+}
+
+.target-selector {
+  border-radius: 1.2rem;
+  border: 1px solid rgb(255 255 255 / 12%);
+  background: rgb(9 12 24 / 74%);
+  backdrop-filter: blur(12px);
+  padding: clamp(0.75rem, 2.1vw, 1.3rem);
+  display: grid;
+  gap: clamp(0.6rem, 1.1vw, 0.9rem);
+}
+
+.target-selector__primary {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.target-selector__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.target-selector__label {
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.target-selector__options-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 16%);
+  background: rgb(8 11 22 / 78%);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 1rem;
+  transition:
+    transform 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.target-selector__options-toggle:hover,
+.target-selector__options-toggle:focus-visible,
+.target-selector__options-toggle[aria-expanded='true'] {
+  outline: none;
+  transform: translateY(-1px);
+  background: rgb(130 207 255 / 26%);
+  border-color: rgb(130 207 255 / 52%);
+}
+
+.segmented-control {
+  display: flex;
+  gap: 0.35rem;
+  overflow-x: auto;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  background: rgb(7 9 20 / 78%);
+  scrollbar-width: thin;
+}
+
+.segmented-control__option {
+  border: none;
+  border-radius: 999px;
+  padding: 0.38rem 0.85rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+  white-space: nowrap;
+}
+
+.segmented-control__option[data-selected='true'] {
+  background: rgb(130 207 255 / 26%);
+  color: var(--color-text);
+  transform: translateY(-1px);
+}
+
+.segmented-control__option:hover,
+.segmented-control__option:focus-visible {
+  outline: none;
+  background: rgb(130 207 255 / 22%);
+  transform: translateY(-1px);
+}
+
+.segmented-control__option:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.target-selector__tray {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.target-selector__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.target-selector__field-label {
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.target-selector__field select,
+.target-selector__field input[type='number'] {
+  appearance: none;
+  border-radius: 0.65rem;
+  border: 1px solid var(--color-border-subtle);
+  background: rgb(10 12 26 / 76%);
+  color: inherit;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.target-selector__summary {
+  border-radius: 0.85rem;
+  border: 1px solid rgb(255 255 255 / 14%);
+  background: rgb(8 11 22 / 76%);
+  padding: 0.55rem 0.75rem;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.target-selector__summary-title {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.target-selector__summary-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.target-selector__summary-meta {
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip-path: inset(50%);
 }
 
 .sequence-conditions-panel {
@@ -254,50 +471,17 @@ body {
   color: var(--color-muted);
 }
 
-.encounter-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: clamp(0.45rem, 0.9vw, 0.75rem);
-}
-
-.summary-chip {
-  border-radius: 0.75rem;
-  padding: 0.45rem 0.75rem;
-  background: rgb(9 12 24 / 62%);
-  border: 1px solid rgb(255 255 255 / 10%);
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  min-width: 120px;
-}
-
-.summary-chip__label {
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.summary-chip__value {
-  font-size: 1.02rem;
-  font-weight: 700;
-}
-
 .app-main {
   gap: clamp(0.9rem, 1.9vw, 1.35rem);
 }
 
 @media (width >= 768px) {
-  .app-navbar {
-    padding-inline: clamp(1rem, 2.2vw, 1.65rem);
+  .encounter-hud {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .toolbar-stack {
-    flex-wrap: nowrap;
-  }
-
-  .toolbar-summary {
-    min-width: 210px;
+  .target-scoreboard {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor the encounter header into dedicated brand, timeline, and scoreboard subcomponents with a segmented target selector and advanced options tray
- restyle the HUD for a sticky scoreboard and responsive encounter controls
- update unit tests to exercise the new target selector interactions and scoreboard metrics

## Testing
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d79d36ec88832fa21261e588b9422c