### PR TITLE
style: refresh HUD visual language

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,36 +58,44 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 
-## Visual Language System
+## 🎨 Design Philosophy
 
-The global stylesheet (`src/styles/global.css`) now provides a reusable visual language for depth, translucency, and typography across the tracker.
+The tracker’s interface now mirrors the relics, reliquaries, and parchment that define Hallownest’s menus. Rather than glass panels, every surface feels etched from ancient stone or hammered metal, with soft enamel highlights that echo the Hunter’s Journal and the nailmaster tablets.
 
-### Layered depth tokens
+### Materiality & Texture
 
-- **Translucent panels:** `--surface-glass-low`, `--surface-glass-mid`, `--surface-glass-strong`, and `--surface-panel-muted` mix subtle gradients for layered glass panels.
-- **Elevation shadows:** `--elevation-layer-1`, `--elevation-layer-2`, `--elevation-layer-3`, and `--elevation-inner-soft` combine drop shadows with soft inset rims to suggest stacked HUD layers.
-- **Accent glows:** `--glow-accent-soft`, `--glow-accent-strong`, and the existing overcharm glow tokens keep interactive elements illuminated without hard borders.
+- **Stone-dark foundations:** `--color-bg`, `--color-bg-deep`, and `--color-surface` establish the cavernous midnight blues seen throughout Godhome. Layer radial gradients with `var(--texture-vein)` and `var(--texture-noise)` to keep new panels mottled and weathered instead of flat.
+- **Carved silhouettes:** `--shape-tablet` and etched shadow tokens (`--frame-outline`, `--frame-etch`, `--frame-highlight`) deliver sharp, chamfered edges reminiscent of charm plaques and Royal Waterways signage.
 
-Use these variables instead of hard-coded borders when styling new controls so components inherit the shared depth cues.
+### Ornate framing & reusable pieces
 
-### Typography scale
+- `.app-navbar`, `.app-panel`, `.summary-chip`, and `.modal__content` all clip to `var(--shape-tablet)` and apply the shared etching stack so new layouts inherit the same chiseled border treatment.
+- `.summary-chip--toolbar`, `.hud-actions__button`, and the segmented controls trade pill buttons for faceted lozenges that glow with SOUL-blue light on hover.
+- The player loadout now features a **charm notch bracelet**: `.notch-panel__bracelet` draws the metal strap and `.notch-dot` renders the circular sockets, filling with pale soullight when equipped and pulsing magenta when overcharmed.
 
-- `--font-size-display`
-- `--font-size-headline`
-- `--font-size-title`
-- `--font-size-subhead`
-- `--font-size-body`
-- `--font-size-caption`
+### Typographic voice
 
-Apply the scale to headings, buttons, and helper text to keep casing and rhythm consistent. Microcopy that previously relied on `text-transform: uppercase` has been converted to sentence case, so string literals should also use sentence case moving forward.
+- Headings, HUD badges, and ceremonial labels use [Cinzel](https://fonts.google.com/specimen/Cinzel) (`var(--font-display)`) for a carved, gothic cadence similar to the game’s official UI.
+- Body copy, tooltips, and stat labels rely on [Source Sans 3](https://fonts.google.com/specimen/Source+Sans+3) for clarity during frantic fights.
+- The existing type scale variables (`--font-size-display` through `--font-size-caption`) still govern hierarchy; prefer sentence case microcopy to match the in-game Hunter’s Journal tone.
 
-### Reusable components
+### Hallownest palette
 
-- `.app-navbar` wraps sticky headers such as the encounter HUD with layered gradients and accent glow shadows.
-- `.app-panel` standardizes raised content blocks used by the attack log and combat stats.
-- `.summary-chip` (with modifiers like `--toolbar` and `--accent`) replaces outlined pills for timeline indicators, HP badges, and selection summaries.
+- `--color-bg` `#04060d` – cavern walls and Godhome’s night sky.
+- `--color-surface` / `--color-surface-raised` – oxidized steel tablets for primary panels and chips.
+- `--color-border` / `--color-border-soft` – bone-white engraving highlights that define carved edges.
+- `--color-accent` – the pale cyan soul glimmer used for hover glows, progress meters, and timeline glyphs.
+- `--color-accent-ember` – a warm ember reserved for lore callouts or warning states alongside the long-lived overcharm pink.
 
-When introducing new UI, prefer these primitives before adding bespoke gradients or borders.
+When extending the UI, lean on these tokens before introducing bespoke colors so every addition stays anchored to Hallownest’s palette.
+
+### Interactive highlights
+
+- Hover states replace modern drop shadows with rune-like glows (`rgb(215 245 255 / 35%)`) that mirror the SOUL meter charge.
+- Buttons and toggles use polygonal `clip-path` treatments to emulate charm slots and tablet corners instead of rounded pills.
+- Modals and panels layer subtle noise above the gradients, preventing modern flatness while keeping readability high.
+
+Contributors can inspect the implementations inside `src/styles/global.css`—mirroring these primitives will keep future components steeped in the same ancient elegance.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ Vitest (unit tests) and Playwright (e2e tests) validate that core sections rende
 
 Automated workflows in `.github/workflows/` run linting, unit tests, end-to-end tests, and GitHub Pages deployments on every push.
 
+## Visual Language System
+
+The global stylesheet (`src/styles/global.css`) now provides a reusable visual language for depth, translucency, and typography across the tracker.
+
+### Layered depth tokens
+
+- **Translucent panels:** `--surface-glass-low`, `--surface-glass-mid`, `--surface-glass-strong`, and `--surface-panel-muted` mix subtle gradients for layered glass panels.
+- **Elevation shadows:** `--elevation-layer-1`, `--elevation-layer-2`, `--elevation-layer-3`, and `--elevation-inner-soft` combine drop shadows with soft inset rims to suggest stacked HUD layers.
+- **Accent glows:** `--glow-accent-soft`, `--glow-accent-strong`, and the existing overcharm glow tokens keep interactive elements illuminated without hard borders.
+
+Use these variables instead of hard-coded borders when styling new controls so components inherit the shared depth cues.
+
+### Typography scale
+
+- `--font-size-display`
+- `--font-size-headline`
+- `--font-size-title`
+- `--font-size-subhead`
+- `--font-size-body`
+- `--font-size-caption`
+
+Apply the scale to headings, buttons, and helper text to keep casing and rhythm consistent. Microcopy that previously relied on `text-transform: uppercase` has been converted to sentence case, so string literals should also use sentence case moving forward.
+
+### Reusable components
+
+- `.app-navbar` wraps sticky headers such as the encounter HUD with layered gradients and accent glow shadows.
+- `.app-panel` standardizes raised content blocks used by the attack log and combat stats.
+- `.summary-chip` (with modifiers like `--toolbar` and `--accent`) replaces outlined pills for timeline indicators, HP badges, and selection summaries.
+
+When introducing new UI, prefer these primitives before adding bespoke gradients or borders.
+
 ## Tech Stack
 
 - [Vite](https://vitejs.dev/) for lightning-fast builds and previews.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,7 +47,11 @@ const StageTimeline: FC<StageTimelineProps> = ({
   const stagePosition = `${stageProgress.current}/${stageProgress.total}`;
 
   return (
-    <div className="hud-timeline" role="group" aria-label="Stage navigation">
+    <div
+      className="hud-timeline summary-chip summary-chip--toolbar"
+      role="group"
+      aria-label="Stage navigation"
+    >
       <button
         type="button"
         className="hud-timeline__control"
@@ -130,7 +134,11 @@ const TargetScoreboard: FC<TargetScoreboardProps> = ({ derived }) => {
 
   return (
     <section className="hud-scoreboard" aria-label="Encounter scoreboard">
-      <div className="hud-health" role="group" aria-label="Boss HP">
+      <div
+        className="hud-health summary-chip summary-chip--accent"
+        role="group"
+        aria-label="Boss HP"
+      >
         <span className="hud-health__label">HP</span>
         <div
           className="hud-health__track"
@@ -193,7 +201,7 @@ const HeaderBar: FC<HeaderBarProps> = ({
   hasNextStage,
   hasPreviousStage,
 }) => (
-  <header className="encounter-hud" role="banner">
+  <header className="encounter-hud app-navbar" role="banner">
     <div className="encounter-hud__primary">
       <EncounterBrand
         encounterName={encounterName}
@@ -217,11 +225,11 @@ const HeaderBar: FC<HeaderBarProps> = ({
           aria-controls="encounter-setup"
         >
           <span aria-hidden="true">⚙️</span>
-          <span className="hud-actions__label">Change Encounter</span>
+          <span className="hud-actions__label">Change encounter</span>
         </button>
         <button type="button" className="hud-actions__button" onClick={onOpenLoadout}>
           <span aria-hidden="true">👤</span>
-          <span className="hud-actions__label">Player Loadout</span>
+          <span className="hud-actions__label">Player loadout</span>
         </button>
       </div>
     </div>
@@ -278,7 +286,7 @@ const TargetSelector: FC<TargetSelectorProps> = ({
   return (
     <section className="target-selector" aria-labelledby="target-selector-heading">
       <div className="target-selector__header">
-        <h3 id="target-selector-heading">Boss Target</h3>
+        <h3 id="target-selector-heading">Boss target</h3>
         <button
           type="button"
           className="target-selector__options-toggle"
@@ -359,7 +367,7 @@ const TargetSelector: FC<TargetSelectorProps> = ({
         ) : null}
 
         {selectedTarget && selectedVersion ? (
-          <div className="target-selector__summary">
+          <div className="target-selector__summary summary-chip">
             <span className="target-selector__summary-title">Active target</span>
             <span className="target-selector__summary-value">
               {selectedTarget.bossName}
@@ -391,7 +399,7 @@ const SequenceSelector: FC<SequenceSelectorProps> = ({
 }) => (
   <section className="sequence-selector" aria-labelledby="sequence-selector-heading">
     <div className="sequence-selector__header">
-      <h3 id="sequence-selector-heading">Encounter Stage</h3>
+      <h3 id="sequence-selector-heading">Encounter stage</h3>
     </div>
     <label className="sequence-selector__field">
       <span className="sequence-selector__field-label">Mode</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,55 +1,66 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600;700&display=swap');
+
 :root {
   color-scheme: dark;
   font-family:
-    Inter,
+    'Source Sans 3',
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
     'Segoe UI',
     sans-serif;
-
-  --font-display: 'Perpetua', 'Palatino Linotype', 'Times New Roman', serif;
-
   line-height: 1.5;
   font-weight: 400;
 
-  --color-bg: #050711;
-  --color-text: #f6f7fb;
-  --color-muted: rgb(240 243 255 / 68%);
-  --color-accent: #82cfff;
-  --color-overcharm: #ff6edb;
-  --color-overcharm-glow: rgb(255 110 219 / 45%);
-
-  /* Surfaces */
-  --surface-glass-low: linear-gradient(155deg, rgb(17 23 44 / 80%), rgb(7 10 23 / 94%));
-  --surface-glass-mid: linear-gradient(160deg, rgb(22 28 52 / 86%), rgb(9 12 26 / 96%));
-  --surface-glass-strong: linear-gradient(
-    170deg,
-    rgb(28 36 62 / 88%),
-    rgb(10 14 30 / 96%)
+  --font-display: 'Cinzel', 'Times New Roman', serif;
+  --color-bg: #04060d;
+  --color-bg-deep: #020309;
+  --color-surface: #101523;
+  --color-surface-raised: #161d2f;
+  --color-surface-muted: #0c111d;
+  --color-border: #d6d9e7;
+  --color-border-soft: rgb(214 217 231 / 38%);
+  --color-border-faint: rgb(214 217 231 / 22%);
+  --color-accent: #d7f5ff;
+  --color-accent-ember: #f2b87f;
+  --color-text: #f1f2f6;
+  --color-muted: rgb(241 242 246 / 72%);
+  --color-subtle: rgb(241 242 246 / 46%);
+  --color-overcharm: #f5a0d0;
+  --color-overcharm-glow: rgb(245 160 208 / 35%);
+  --color-glyph-shadow: rgb(5 8 16 / 90%);
+  --texture-noise: radial-gradient(
+    circle at 1px 1px,
+    rgb(255 255 255 / 6%) 0.5px,
+    transparent 0.6px
   );
-  --surface-panel-muted: linear-gradient(165deg, rgb(14 18 38 / 78%), rgb(6 9 20 / 92%));
-
-  /* Elevation */
-  --elevation-layer-1: 0 12px 28px rgb(3 6 18 / 48%);
-  --elevation-layer-2: 0 18px 46px rgb(4 8 28 / 56%);
-  --elevation-layer-3: 0 28px 72px rgb(6 10 34 / 64%);
-  --elevation-inner-soft:
-    inset 0 1px 0 rgb(255 255 255 / 8%), inset 0 -1px 0 rgb(6 8 20 / 60%);
-
-  /* Accent glows */
-  --glow-accent-soft: 0 0 0 1px rgb(130 207 255 / 28%), 0 0 24px rgb(130 207 255 / 28%);
-  --glow-accent-strong: 0 0 0 1px rgb(130 207 255 / 36%), 0 0 32px rgb(130 207 255 / 36%);
-  --panel-radius: 22px;
+  --texture-vein:
+    linear-gradient(120deg, rgb(255 255 255 / 4%), transparent),
+    linear-gradient(300deg, rgb(0 0 0 / 45%), rgb(0 0 0 / 65%));
+  --frame-shadow-raised: 0 18px 38px rgb(0 0 0 / 62%);
+  --frame-shadow-floating: 0 28px 64px rgb(0 0 0 / 68%);
+  --frame-etch: inset 0 0 0 1px rgb(0 0 0 / 78%);
+  --frame-highlight: inset 0 1px 0 rgb(255 255 255 / 16%);
+  --frame-outline: 0 0 0 1px var(--color-border-soft);
+  --frame-outline-strong: 0 0 0 1.5px rgb(214 217 231 / 55%);
+  --shape-tablet: polygon(
+    14px 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% calc(100% - 14px),
+    calc(100% - 14px) 100%,
+    14px 100%,
+    0 calc(100% - 14px),
+    0 14px
+  );
+  --panel-radius: 18px;
   --header-gap: clamp(0.55rem, 1.1vw, 0.9rem);
-
-  /* Typography scale */
-  --font-size-display: clamp(1.75rem, 3vw, 2.35rem);
-  --font-size-headline: clamp(1.32rem, 2.4vw, 1.8rem);
-  --font-size-title: clamp(1.05rem, 2vw, 1.45rem);
-  --font-size-subhead: clamp(0.95rem, 1.8vw, 1.2rem);
-  --font-size-body: clamp(0.9rem, 1.5vw, 1.05rem);
-  --font-size-caption: clamp(0.72rem, 1.2vw, 0.82rem);
+  --font-size-display: clamp(1.9rem, 3.4vw, 2.6rem);
+  --font-size-headline: clamp(1.38rem, 2.6vw, 1.95rem);
+  --font-size-title: clamp(1.08rem, 2.1vw, 1.52rem);
+  --font-size-subhead: clamp(0.96rem, 1.9vw, 1.22rem);
+  --font-size-body: clamp(0.92rem, 1.55vw, 1.08rem);
+  --font-size-caption: clamp(0.74rem, 1.25vw, 0.84rem);
 
   background-color: var(--color-bg);
   color: var(--color-text);
@@ -62,13 +73,44 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgb(20 34 84 / 35%), var(--color-bg));
+  background-color: var(--color-bg);
+  background-image:
+    radial-gradient(circle at 18% 12%, rgb(40 62 104 / 38%), transparent 60%),
+    radial-gradient(circle at 80% 85%, rgb(28 44 86 / 28%), transparent 64%),
+    radial-gradient(circle at 50% 50%, rgb(8 12 24 / 78%), rgb(4 6 13 / 94%)),
+    var(--texture-noise);
+  background-size:
+    cover,
+    cover,
+    cover,
+    4px 4px;
+  background-attachment: fixed, fixed, fixed, fixed;
 }
 
 #root {
   min-height: 100vh;
   display: flex;
   justify-content: center;
+}
+
+body,
+input,
+select,
+button,
+textarea {
+  font-family: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+  letter-spacing: 0.045em;
+  font-weight: 500;
+  text-transform: none;
 }
 
 .app-shell {
@@ -85,17 +127,57 @@ body {
   top: clamp(0.55rem, 2vw, 1.05rem);
   z-index: 10;
   display: grid;
-  gap: clamp(0.4rem, 1vw, 0.7rem);
-  padding: clamp(0.55rem, 1.4vw, 0.9rem) clamp(0.85rem, 2vw, 1.35rem);
-  border-radius: var(--panel-radius);
+  gap: clamp(0.4rem, 0.8vw, 0.65rem);
 }
 
 .app-navbar {
-  background: var(--surface-glass-strong);
+  position: relative;
+  padding: clamp(0.75rem, 1.6vw, 1.15rem) clamp(1.1rem, 2.4vw, 1.85rem);
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface-raised);
+  background-image:
+    radial-gradient(circle at 50% -30%, rgb(214 217 231 / 55%), transparent 65%),
+    radial-gradient(circle at 10% 40%, rgb(255 255 255 / 12%), transparent 70%),
+    radial-gradient(circle at 90% 70%, rgb(35 55 90 / 42%), transparent 70%),
+    var(--texture-vein);
   box-shadow:
-    var(--elevation-layer-3), var(--glow-accent-soft), var(--elevation-inner-soft);
-  backdrop-filter: blur(18px);
-  border: none;
+    var(--frame-shadow-raised), var(--frame-outline-strong), var(--frame-highlight),
+    var(--frame-etch);
+  overflow: hidden;
+}
+
+.app-navbar::before,
+.app-navbar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  pointer-events: none;
+}
+
+.app-navbar::before {
+  border: 1px solid var(--color-border-soft);
+  mix-blend-mode: screen;
+  opacity: 0.5;
+}
+
+.app-navbar::after {
+  background-image:
+    linear-gradient(90deg, transparent, rgb(214 217 231 / 16%), transparent),
+    radial-gradient(ellipse at 50% -40%, rgb(214 217 231 / 45%), transparent 70%);
+  background-size:
+    100% 100%,
+    140px 120px;
+  background-position:
+    center,
+    50% 0;
+  background-repeat: no-repeat;
+  opacity: 0.6;
+}
+
+.app-navbar > * {
+  position: relative;
+  z-index: 1;
 }
 
 .encounter-hud__primary {
@@ -120,6 +202,7 @@ body {
   letter-spacing: 0.02em;
   text-transform: none;
   line-height: 1.1;
+  text-shadow: 0 3px 6px rgb(0 0 0 / 70%);
 }
 
 .hud-brand__context {
@@ -157,22 +240,65 @@ body {
 }
 
 .summary-chip {
-  border-radius: 0.9rem;
-  background: var(--surface-glass-mid);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(14px);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 20% 20%, rgb(214 217 231 / 18%), transparent 65%),
+    radial-gradient(circle at 80% 80%, rgb(22 46 88 / 36%), transparent 70%),
+    var(--texture-vein);
+  color: inherit;
+  box-shadow:
+    var(--frame-shadow-raised), var(--frame-outline), var(--frame-highlight),
+    var(--frame-etch);
+  overflow: hidden;
+}
+
+.summary-chip::before,
+.summary-chip::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  pointer-events: none;
+}
+
+.summary-chip::before {
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  mix-blend-mode: soft-light;
+  opacity: 0.25;
+}
+
+.summary-chip::after {
+  border: 1px solid var(--color-border-faint);
+  box-shadow: inset 0 0 12px rgb(0 0 0 / 55%);
 }
 
 .summary-chip--toolbar {
-  border-radius: 999px;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  background-color: var(--color-surface-muted);
+  background-image:
+    radial-gradient(circle at 15% 30%, rgb(214 217 231 / 16%), transparent 60%),
+    radial-gradient(circle at 85% 70%, rgb(36 54 84 / 38%), transparent 75%),
+    var(--texture-vein);
+  box-shadow:
+    0 12px 24px rgb(0 0 0 / 55%),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
 }
 
 .summary-chip--accent {
-  background: var(--surface-glass-mid);
+  background-color: #1c2538;
+  background-image:
+    radial-gradient(circle at 30% 25%, rgb(215 245 255 / 28%), transparent 65%),
+    radial-gradient(circle at 80% 70%, rgb(34 62 94 / 45%), transparent 75%),
+    var(--texture-vein);
   box-shadow:
-    var(--elevation-layer-2), var(--glow-accent-strong), var(--elevation-inner-soft);
+    0 16px 32px rgb(0 0 0 / 58%),
+    0 0 0 1px rgb(215 245 255 / 32%),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    var(--frame-etch);
 }
 
 .hud-timeline {
@@ -205,24 +331,41 @@ body {
 }
 
 .hud-timeline__control {
-  border: none;
-  background: transparent;
-  color: inherit;
-  font-size: 1rem;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.1rem;
-  min-width: 1.2rem;
-  border-radius: 0.35rem;
-  transition: background 120ms ease;
+  width: 1.9rem;
+  height: 1.9rem;
+  font-size: 1rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  color: var(--color-text);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(145deg, rgb(255 255 255 / 14%), transparent),
+    radial-gradient(circle at 50% 120%, rgb(16 24 44 / 78%), transparent 72%);
+  border: 1px solid var(--color-border-soft);
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+  box-shadow:
+    0 8px 16px rgb(0 0 0 / 55%),
+    inset 0 0 0 1px rgb(255 255 255 / 12%),
+    inset 0 0 12px rgb(0 0 0 / 65%);
+  cursor: pointer;
+  transition:
+    box-shadow 160ms ease,
+    transform 160ms ease,
+    color 160ms ease;
 }
 
 .hud-timeline__control:hover,
 .hud-timeline__control:focus-visible {
   outline: none;
-  background: rgb(130 207 255 / 18%);
+  box-shadow:
+    0 10px 20px rgb(0 0 0 / 60%),
+    0 0 16px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 16%);
+  color: var(--color-accent);
+  transform: translateY(-1px);
 }
 
 .hud-timeline__control:disabled {
@@ -240,31 +383,68 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
-  padding: 0.3rem 0.7rem;
-  border-radius: 999px;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  color: inherit;
+  padding: 0.4rem 0.95rem;
+  clip-path: polygon(
+    12px 0,
+    calc(100% - 12px) 0,
+    100% 50%,
+    calc(100% - 12px) 100%,
+    12px 100%,
+    0 50%
+  );
+  border: 1px solid var(--color-border-soft);
+  background-color: var(--color-surface);
+  background-image:
+    linear-gradient(135deg, rgb(255 255 255 / 12%), transparent),
+    radial-gradient(circle at 80% 30%, rgb(32 52 84 / 45%), transparent 65%),
+    var(--texture-vein);
+  color: var(--color-text);
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   text-transform: none;
   cursor: pointer;
+  position: relative;
+  box-shadow:
+    0 14px 26px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.hud-actions__button::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  clip-path: polygon(
+    10px 0,
+    calc(100% - 10px) 0,
+    100% 50%,
+    calc(100% - 10px) 100%,
+    10px 100%,
+    0 50%
+  );
+  border: 1px solid rgb(255 255 255 / 8%);
+  pointer-events: none;
+  mix-blend-mode: screen;
 }
 
 .hud-actions__button:hover,
 .hud-actions__button:focus-visible,
 .hud-actions__button[aria-expanded='true'] {
   outline: none;
+  color: var(--color-accent);
+  text-shadow: 0 0 12px rgb(215 245 255 / 55%);
   transform: translateY(-1px);
-  background: var(--surface-glass-mid);
   box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
+    0 18px 32px rgb(0 0 0 / 60%),
+    0 0 18px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
 .hud-actions__label {
@@ -299,18 +479,20 @@ body {
   width: clamp(140px, 24vw, 280px);
   height: 0.55rem;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgb(36 44 84 / 65%), rgb(18 24 50 / 65%));
+  background-color: #0d1424;
+  background-image: linear-gradient(90deg, rgb(30 48 78 / 80%), rgb(12 18 30 / 92%));
   overflow: hidden;
+  border: 1px solid rgb(214 217 231 / 45%);
   box-shadow:
-    inset 0 0 0 1px rgb(130 207 255 / 22%),
-    inset 0 6px 18px rgb(6 12 32 / 55%);
+    inset 0 1px 0 rgb(255 255 255 / 18%),
+    inset 0 -3px 6px rgb(0 0 0 / 65%);
 }
 
 .hud-health__fill {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgb(129 234 255 / 85%), rgb(116 169 255 / 92%));
+  background: linear-gradient(90deg, rgb(215 245 255 / 85%), rgb(90 136 188 / 78%));
   transition: width 160ms ease;
 }
 
@@ -351,13 +533,22 @@ body {
 }
 
 .encounter-setup {
-  border-radius: 1rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(7 10 22 / 78%);
-  backdrop-filter: blur(14px);
-  padding: clamp(0.9rem, 2.2vw, 1.4rem);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface-muted);
+  background-image:
+    radial-gradient(circle at 25% 20%, rgb(214 217 231 / 18%), transparent 62%),
+    radial-gradient(circle at 80% 75%, rgb(34 52 84 / 42%), transparent 70%),
+    var(--texture-vein);
+  padding: clamp(0.95rem, 2.4vw, 1.45rem);
   display: grid;
   gap: clamp(0.8rem, 1.6vw, 1.2rem);
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
 }
 
 .encounter-setup[hidden] {
@@ -370,13 +561,22 @@ body {
 }
 
 .target-selector {
-  border-radius: 0.95rem;
-  background: var(--surface-panel-muted);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(12px);
-  padding: clamp(0.65rem, 1.9vw, 1.1rem);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 15% 15%, rgb(214 217 231 / 20%), transparent 60%),
+    radial-gradient(circle at 85% 70%, rgb(34 54 90 / 42%), transparent 70%),
+    var(--texture-vein);
+  padding: clamp(0.75rem, 1.9vw, 1.15rem);
   display: grid;
-  gap: clamp(0.55rem, 1.1vw, 0.85rem);
+  gap: clamp(0.6rem, 1.2vw, 0.95rem);
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
 }
 
 .target-selector__header {
@@ -397,79 +597,118 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-soft);
+  background-color: var(--color-surface-muted);
+  background-image:
+    radial-gradient(circle at 40% 35%, rgb(214 217 231 / 18%), transparent 60%),
+    radial-gradient(circle at 60% 70%, rgb(24 40 70 / 45%), transparent 70%),
+    var(--texture-vein);
   color: var(--color-text);
   cursor: pointer;
   font-size: 1rem;
+  position: relative;
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
+  box-shadow:
+    0 12px 22px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 12%),
+    inset 0 -2px 4px rgb(0 0 0 / 65%);
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.target-selector__options-toggle::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  border: 1px solid rgb(255 255 255 / 12%);
+  pointer-events: none;
 }
 
 .target-selector__options-toggle:hover,
 .target-selector__options-toggle:focus-visible,
 .target-selector__options-toggle[aria-expanded='true'] {
   outline: none;
+  color: var(--color-accent);
+  text-shadow: 0 0 8px rgb(215 245 255 / 45%);
   transform: translateY(-1px);
-  background: var(--surface-glass-mid);
   box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
+    0 16px 28px rgb(0 0 0 / 60%),
+    0 0 16px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
 .segmented-control {
   display: flex;
   gap: 0.35rem;
   overflow-x: auto;
-  padding: 0.35rem;
-  border-radius: 999px;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  padding: 0.45rem;
+  border-radius: 32px;
+  background-color: var(--color-surface-muted);
+  background-image:
+    radial-gradient(circle at 12% 30%, rgb(214 217 231 / 18%), transparent 65%),
+    radial-gradient(circle at 85% 70%, rgb(26 44 78 / 42%), transparent 70%),
+    var(--texture-vein);
+  box-shadow:
+    0 14px 26px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    inset 0 -1px 0 rgb(0 0 0 / 60%);
   scrollbar-width: thin;
 }
 
 .segmented-control__option {
-  border: none;
-  border-radius: 999px;
-  padding: 0.38rem 0.85rem;
-  background: transparent;
-  color: inherit;
+  border: 1px solid transparent;
+  border-radius: 26px;
+  padding: 0.4rem 0.95rem;
+  background: linear-gradient(140deg, rgb(255 255 255 / 10%), transparent);
+  color: var(--color-subtle);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
   cursor: pointer;
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    color 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease;
   white-space: nowrap;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 80%);
 }
 
 .segmented-control__option[data-selected='true'] {
-  background: var(--surface-glass-mid);
   color: var(--color-text);
-  box-shadow: var(--glow-accent-soft);
-  transform: translateY(-1px);
+  background:
+    linear-gradient(140deg, rgb(215 245 255 / 24%), transparent),
+    radial-gradient(circle at 40% 50%, rgb(30 52 90 / 46%), transparent 70%);
+  border-color: rgb(215 245 255 / 35%);
+  box-shadow:
+    0 10px 20px rgb(0 0 0 / 55%),
+    0 0 16px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 18%);
 }
 
 .segmented-control__option:hover,
 .segmented-control__option:focus-visible {
   outline: none;
-  background: var(--surface-glass-mid);
-  box-shadow: var(--glow-accent-soft);
-  transform: translateY(-1px);
+  color: var(--color-accent);
+  background:
+    linear-gradient(140deg, rgb(215 245 255 / 22%), transparent),
+    radial-gradient(circle at 40% 50%, rgb(30 52 90 / 46%), transparent 70%);
+  box-shadow:
+    0 12px 24px rgb(0 0 0 / 58%),
+    0 0 14px rgb(215 245 255 / 32%),
+    inset 0 0 0 1px rgb(255 255 255 / 14%);
 }
 
 .segmented-control__option:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  transform: none;
 }
 
 .target-selector__tray {
@@ -492,15 +731,31 @@ body {
 }
 
 .target-selector__field select,
-.target-selector__field input[type='text'] {
+.target-selector__field input[type='text'],
+.sequence-selector__field select,
+.form-grid__field select,
+.form-grid__field input {
   appearance: none;
-  border-radius: 0.65rem;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
-  color: inherit;
-  padding: 0.45rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-faint);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 10%), transparent), var(--texture-vein);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 6%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
+  color: var(--color-text);
+  padding: 0.45rem 0.75rem;
   font-size: var(--font-size-body);
+}
+
+.target-selector__field select:focus-visible,
+.target-selector__field input[type='text']:focus-visible,
+.sequence-selector__field select:focus-visible,
+.form-grid__field select:focus-visible,
+.form-grid__field input:focus-visible {
+  outline: 2px solid rgb(215 245 255 / 55%);
+  outline-offset: 3px;
 }
 
 .target-selector__summary {
@@ -539,13 +794,22 @@ body {
 }
 
 .sequence-selector {
-  border-radius: 0.95rem;
-  background: var(--surface-panel-muted);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(12px);
-  padding: clamp(0.65rem, 1.9vw, 1.1rem);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 15% 18%, rgb(214 217 231 / 20%), transparent 62%),
+    radial-gradient(circle at 85% 75%, rgb(34 54 90 / 44%), transparent 70%),
+    var(--texture-vein);
+  padding: clamp(0.75rem, 1.9vw, 1.15rem);
   display: grid;
-  gap: clamp(0.55rem, 1.1vw, 0.85rem);
+  gap: clamp(0.6rem, 1.2vw, 0.95rem);
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
 }
 
 .sequence-selector__header {
@@ -575,17 +839,6 @@ body {
   color: var(--color-muted);
 }
 
-.sequence-selector__field select {
-  appearance: none;
-  border-radius: 0.65rem;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
-  color: inherit;
-  padding: 0.45rem 0.7rem;
-  font-size: var(--font-size-body);
-}
-
 .sequence-selector__stages {
   display: grid;
   gap: 0.35rem;
@@ -599,35 +852,56 @@ body {
   display: flex;
   align-items: center;
   gap: 0.45rem;
-  border-radius: 0.75rem;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  padding: 0.45rem 0.65rem;
-  color: inherit;
+  border: 1px solid var(--color-border-faint);
+  clip-path: polygon(
+    12px 0,
+    calc(100% - 12px) 0,
+    100% 50%,
+    calc(100% - 12px) 100%,
+    12px 100%,
+    0 50%
+  );
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 12%), transparent),
+    radial-gradient(circle at 80% 35%, rgb(30 52 90 / 44%), transparent 70%),
+    var(--texture-vein);
+  padding: 0.5rem 0.75rem;
+  color: var(--color-text);
   font-size: var(--font-size-body);
   font-weight: 600;
   cursor: pointer;
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
+  position: relative;
+  box-shadow:
+    0 12px 24px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
 .sequence-selector__stage[aria-current='true'] {
-  background: var(--surface-glass-mid);
+  color: var(--color-accent);
   box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
-  transform: translateY(-1px);
+    0 16px 30px rgb(0 0 0 / 60%),
+    0 0 18px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 18%);
 }
 
 .sequence-selector__stage:hover,
 .sequence-selector__stage:focus-visible {
   outline: none;
-  background: var(--surface-glass-mid);
-  box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
+  color: var(--color-accent);
+  text-shadow: 0 0 12px rgb(215 245 255 / 55%);
   transform: translateY(-1px);
+  box-shadow:
+    0 16px 30px rgb(0 0 0 / 60%),
+    0 0 18px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 18%);
 }
 
 .sequence-selector__stage-index {
@@ -648,13 +922,22 @@ body {
 }
 
 .sequence-conditions {
-  border-radius: 0.95rem;
-  background: var(--surface-panel-muted);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(12px);
-  padding: clamp(0.65rem, 1.9vw, 1.1rem);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 20% 18%, rgb(214 217 231 / 18%), transparent 60%),
+    radial-gradient(circle at 85% 72%, rgb(34 54 90 / 44%), transparent 70%),
+    var(--texture-vein);
+  padding: clamp(0.75rem, 1.9vw, 1.15rem);
   display: grid;
   gap: 0.6rem;
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
 }
 
 .sequence-conditions__title {
@@ -716,11 +999,36 @@ body {
 .app-panel {
   display: flex;
   flex-direction: column;
-  border-radius: var(--panel-radius);
-  background: var(--surface-glass-mid);
-  box-shadow: var(--elevation-layer-2), var(--elevation-inner-soft);
-  backdrop-filter: blur(18px);
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 18% 18%, rgb(214 217 231 / 20%), transparent 65%),
+    radial-gradient(circle at 88% 78%, rgb(32 54 90 / 46%), transparent 72%),
+    var(--texture-vein);
+  box-shadow:
+    var(--frame-shadow-floating),
+    var(--frame-outline-strong),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    var(--frame-etch);
   overflow: hidden;
+}
+
+.app-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  mix-blend-mode: soft-light;
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.app-panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 .app-panel__header {
@@ -765,29 +1073,52 @@ body {
 }
 
 .quick-actions__button {
-  border: none;
-  border-radius: 999px;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  color: inherit;
-  padding: 0.38rem 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--color-border-soft);
+  padding: 0.45rem 1rem;
+  clip-path: polygon(
+    12px 0,
+    calc(100% - 12px) 0,
+    100% 50%,
+    calc(100% - 12px) 100%,
+    12px 100%,
+    0 50%
+  );
+  background-color: var(--color-surface);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 12%), transparent),
+    radial-gradient(circle at 70% 40%, rgb(32 52 84 / 42%), transparent 70%),
+    var(--texture-vein);
+  color: var(--color-text);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.04em;
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
   cursor: pointer;
+  position: relative;
+  box-shadow:
+    0 14px 26px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .quick-actions__button:hover,
 .quick-actions__button:focus-visible {
   outline: none;
+  color: var(--color-accent);
+  text-shadow: 0 0 12px rgb(215 245 255 / 55%);
   transform: translateY(-1px);
-  background: var(--surface-glass-mid);
   box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
+    0 18px 32px rgb(0 0 0 / 60%),
+    0 0 18px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
 .quick-actions__button:disabled {
@@ -825,27 +1156,40 @@ body {
   display: inline-flex;
   flex-direction: column;
   gap: 0.4rem;
-  border-radius: 0.9rem;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  padding: 0.75rem;
+  border: 1px solid var(--color-border-faint);
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(145deg, rgb(255 255 255 / 12%), transparent),
+    radial-gradient(circle at 78% 32%, rgb(32 52 84 / 45%), transparent 70%),
+    var(--texture-vein);
+  padding: 0.85rem;
   text-align: left;
-  color: inherit;
+  color: var(--color-text);
   font-weight: 600;
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    box-shadow 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
+  position: relative;
+  box-shadow:
+    0 16px 28px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
 .button-grid__button:hover,
 .button-grid__button:focus-visible {
   outline: none;
+  color: var(--color-accent);
+  text-shadow: 0 0 12px rgb(215 245 255 / 55%);
   transform: translateY(-1px);
-  background: var(--surface-glass-mid);
   box-shadow:
-    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
+    0 20px 36px rgb(0 0 0 / 60%),
+    0 0 20px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
 .button-grid__header {
@@ -863,12 +1207,16 @@ body {
   font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
   text-transform: none;
-  padding: 0.15rem 0.4rem;
-  border-radius: 0.45rem;
-  border: none;
+  padding: 0.2rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-faint);
   color: var(--color-muted);
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 10%), transparent), var(--texture-vein);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 6%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
 .button-grid__meta {
@@ -893,10 +1241,15 @@ body {
   font-size: var(--font-size-caption);
   letter-spacing: 0.05em;
   text-transform: none;
-  padding: 0.15rem 0.5rem;
+  padding: 0.2rem 0.65rem;
   border-radius: 999px;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
+  border: 1px solid var(--color-border-faint);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 12%), transparent), var(--texture-vein);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
 .button-grid__description {
@@ -996,14 +1349,38 @@ body {
   width: min(100%, 980px);
   max-height: min(90vh, 900px);
   overflow-y: auto;
-  border-radius: 26px;
-  background: linear-gradient(160deg, rgb(16 22 38 / 95%), rgb(8 12 28 / 98%));
-  border: 1px solid rgb(130 207 255 / 30%);
-  box-shadow: 0 40px 120px rgb(2 4 15 / 70%);
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 22% 15%, rgb(214 217 231 / 20%), transparent 60%),
+    radial-gradient(circle at 78% 80%, rgb(30 50 88 / 48%), transparent 72%),
+    var(--texture-vein);
+  border: 1px solid var(--color-border-soft);
+  box-shadow:
+    0 42px 120px rgb(0 0 0 / 70%),
+    0 0 0 1px rgb(255 255 255 / 10%),
+    var(--frame-etch);
   padding: clamp(1.5rem, 3vw, 2.5rem);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.modal__content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  opacity: 0.18;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+.modal__content > * {
+  position: relative;
+  z-index: 1;
 }
 
 .modal__header {
@@ -1026,26 +1403,51 @@ body {
 }
 
 .modal__close {
-  border-radius: 999px;
-  border: 1px solid rgb(255 255 255 / 20%);
-  background: rgb(130 207 255 / 18%);
-  color: inherit;
-  padding: 0.4rem 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--color-border-soft);
+  padding: 0.45rem 1.2rem;
+  clip-path: polygon(
+    14px 0,
+    calc(100% - 14px) 0,
+    100% 50%,
+    calc(100% - 14px) 100%,
+    14px 100%,
+    0 50%
+  );
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 14%), transparent),
+    radial-gradient(circle at 75% 30%, rgb(34 56 94 / 42%), transparent 70%),
+    var(--texture-vein);
+  color: var(--color-text);
   font-weight: 600;
   letter-spacing: 0.04em;
+  text-shadow: 0 1px 2px var(--color-glyph-shadow);
   cursor: pointer;
+  position: relative;
+  box-shadow:
+    0 16px 30px rgb(0 0 0 / 58%),
+    inset 0 0 0 1px rgb(255 255 255 / 12%),
+    inset 0 -2px 0 rgb(0 0 0 / 60%);
   transition:
-    transform 120ms ease,
-    background 120ms ease,
-    border-color 120ms ease;
+    color 160ms ease,
+    text-shadow 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .modal__close:hover,
 .modal__close:focus-visible {
   outline: none;
+  color: var(--color-accent);
+  text-shadow: 0 0 12px rgb(215 245 255 / 55%);
   transform: translateY(-1px);
-  background: rgb(130 207 255 / 26%);
-  border-color: rgb(130 207 255 / 55%);
+  box-shadow:
+    0 20px 36px rgb(0 0 0 / 60%),
+    0 0 18px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 18%);
 }
 
 .modal__body {
@@ -1153,15 +1555,44 @@ body {
 .equipped-panel,
 .notch-panel,
 .preset-panel {
-  background: var(--surface-panel-muted);
-  border-radius: 18px;
-  border: none;
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(14px);
-  padding: 1rem;
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 18% 15%, rgb(214 217 231 / 18%), transparent 62%),
+    radial-gradient(circle at 82% 78%, rgb(32 52 84 / 44%), transparent 70%),
+    var(--texture-vein);
+  padding: 1.05rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
+}
+
+.equipped-panel::before,
+.notch-panel::before,
+.preset-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  opacity: 0.2;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+.equipped-panel > *,
+.notch-panel > *,
+.preset-panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 .equipped-panel__title,
@@ -1183,11 +1614,15 @@ body {
 .equipped-panel__item {
   display: grid;
   place-items: center;
-  padding: 0.35rem;
+  padding: 0.45rem;
   border-radius: 12px;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
+  border: 1px solid var(--color-border-faint);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(145deg, rgb(255 255 255 / 12%), transparent), var(--texture-vein);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
 .equipped-panel__icon {
@@ -1220,34 +1655,124 @@ body {
 }
 
 .notch-panel__bracelet {
+  --notch-size: clamp(1.2rem, 3vw, 1.6rem);
+
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
+  flex-wrap: nowrap;
+  gap: clamp(0.45rem, 0.9vw, 0.6rem);
   align-items: center;
+  padding: clamp(0.6rem, 1.4vw, 0.85rem) clamp(0.85rem, 2.2vw, 1.2rem);
+  border-radius: 999px;
+  border: 1px solid var(--color-border-soft);
+  background-color: #12192b;
+  background-image:
+    linear-gradient(120deg, rgb(255 255 255 / 14%), transparent),
+    radial-gradient(circle at 10% 50%, rgb(214 217 231 / 12%), transparent 65%),
+    radial-gradient(circle at 90% 50%, rgb(24 38 66 / 75%), transparent 75%);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 12%),
+    inset 0 -3px 4px rgb(0 0 0 / 70%),
+    0 16px 28px rgb(0 0 0 / 58%);
+  position: relative;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.notch-panel__bracelet::-webkit-scrollbar {
+  height: 0.35rem;
+}
+
+.notch-panel__bracelet::-webkit-scrollbar-thumb {
+  background: rgb(215 245 255 / 28%);
+  border-radius: 999px;
+}
+
+.notch-panel__bracelet::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: clamp(0.75rem, 2vw, 1.35rem);
+  right: clamp(0.75rem, 2vw, 1.35rem);
+  height: clamp(0.55rem, 1.2vw, 0.75rem);
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgb(215 245 255 / 18%),
+    rgb(11 18 32 / 92%),
+    rgb(215 245 255 / 18%)
+  );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 25%),
+    inset 0 -2px 2px rgb(0 0 0 / 80%);
+  pointer-events: none;
 }
 
 .notch-dot {
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 999px;
-  background: rgb(120 140 200 / 28%);
-  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 12%);
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  width: var(--notch-size);
+  height: var(--notch-size);
+  border-radius: 50%;
+  border: 2px solid rgb(214 217 231 / 55%);
+  background: radial-gradient(circle at 50% 60%, rgb(18 28 48 / 90%), rgb(5 8 16 / 92%));
+  box-shadow:
+    inset 0 0 8px rgb(0 0 0 / 75%),
+    0 4px 8px rgb(0 0 0 / 55%);
   transition:
     transform 160ms ease,
-    background 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    border-color 160ms ease;
+}
+
+.notch-dot::before {
+  content: '';
+  position: absolute;
+  inset: 24%;
+  border-radius: 50%;
+  border: 1px solid rgb(255 255 255 / 18%);
+  background: radial-gradient(
+    circle at 50% 65%,
+    rgb(36 52 82 / 70%),
+    rgb(10 16 30 / 92%)
+  );
+  box-shadow: inset 0 0 6px rgb(0 0 0 / 75%);
+  pointer-events: none;
 }
 
 .notch-dot--available {
-  background: rgb(130 207 255 / 32%);
+  border-color: rgb(214 217 231 / 65%);
+}
+
+.notch-dot--available::before {
+  background: radial-gradient(
+    circle at 50% 45%,
+    rgb(105 142 198 / 45%),
+    rgb(12 20 34 / 88%)
+  );
 }
 
 .notch-dot--filled {
-  transform: scale(1.15);
-  background: linear-gradient(145deg, rgb(255 215 160 / 85%), rgb(255 171 94 / 75%));
+  transform: scale(1.1);
+  border-color: rgb(215 245 255 / 75%);
   box-shadow:
-    0 0 16px rgb(255 199 126 / 35%),
-    inset 0 0 6px rgb(0 0 0 / 28%);
+    0 8px 16px rgb(0 0 0 / 60%),
+    0 0 24px rgb(215 245 255 / 35%),
+    inset 0 0 12px rgb(215 245 255 / 25%);
+}
+
+.notch-dot--filled::before {
+  background: radial-gradient(
+    circle at 50% 45%,
+    rgb(215 245 255 / 85%),
+    rgb(110 154 208 / 55%),
+    transparent 78%
+  );
+  border-color: rgb(215 245 255 / 55%);
+  box-shadow:
+    inset 0 0 10px rgb(215 245 255 / 45%),
+    0 0 18px rgb(215 245 255 / 35%);
 }
 
 .notch-dot--locked {
@@ -1255,8 +1780,11 @@ body {
 }
 
 .notch-dot--overfill {
-  background: linear-gradient(145deg, var(--color-overcharm), #ffd7ff);
-  box-shadow: 0 0 18px var(--color-overcharm-glow);
+  border-color: var(--color-overcharm);
+  box-shadow:
+    0 10px 20px rgb(0 0 0 / 60%),
+    0 0 26px var(--color-overcharm-glow),
+    inset 0 0 10px rgb(255 220 240 / 45%);
 }
 
 .notch-panel__slider {
@@ -1286,18 +1814,40 @@ body {
 }
 
 .overcharm-banner {
-  border-radius: 14px;
-  border: none;
-  background: linear-gradient(120deg, rgb(255 110 219 / 28%), rgb(255 110 219 / 10%));
-  padding: 0.85rem 1rem;
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: rgb(38 8 28 / 92%);
+  background-image:
+    radial-gradient(circle at 20% 20%, rgb(255 173 228 / 45%), transparent 70%),
+    radial-gradient(circle at 80% 80%, rgb(120 34 92 / 65%), transparent 75%);
+  padding: 0.95rem 1.1rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 0.75rem;
   align-items: baseline;
   color: var(--color-overcharm);
   box-shadow:
-    0 16px 36px rgb(255 110 219 / 18%),
-    inset 0 0 0 1px rgb(255 110 219 / 38%);
+    0 20px 36px rgb(0 0 0 / 55%),
+    0 0 26px var(--color-overcharm-glow),
+    inset 0 0 0 1px rgb(255 173 228 / 42%),
+    inset 0 -1px 0 rgb(90 14 58 / 80%);
+}
+
+.overcharm-banner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  opacity: 0.2;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.overcharm-banner > * {
+  position: relative;
+  z-index: 1;
 }
 
 .overcharm-banner__label {
@@ -1450,15 +2000,40 @@ body {
 }
 
 .spell-card {
-  border-radius: 1rem;
-  border: none;
-  background: var(--surface-panel-muted);
-  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
-  backdrop-filter: blur(12px);
-  padding: 0.9rem;
+  position: relative;
+  clip-path: var(--shape-tablet);
+  background-color: var(--color-surface);
+  background-image:
+    radial-gradient(circle at 18% 20%, rgb(214 217 231 / 18%), transparent 62%),
+    radial-gradient(circle at 82% 78%, rgb(32 52 84 / 44%), transparent 70%),
+    var(--texture-vein);
+  padding: 0.95rem;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+  box-shadow:
+    var(--frame-shadow-raised),
+    var(--frame-outline),
+    inset 0 0 0 1px rgb(255 255 255 / 8%),
+    var(--frame-etch);
+  overflow: hidden;
+}
+
+.spell-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: var(--shape-tablet);
+  background-image: var(--texture-noise);
+  background-size: 4px 4px;
+  opacity: 0.18;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+.spell-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .spell-card legend {
@@ -1496,16 +2071,6 @@ body {
   letter-spacing: 0.04em;
   text-transform: none;
   color: var(--color-muted);
-}
-
-.form-grid__field select,
-.form-grid__field input {
-  border-radius: 0.75rem;
-  border: none;
-  background: var(--surface-glass-low);
-  box-shadow: var(--elevation-inner-soft);
-  color: inherit;
-  padding: 0.55rem 0.75rem;
 }
 
 .form-grid__summary {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,18 +14,42 @@
   font-weight: 400;
 
   --color-bg: #050711;
-  --color-surface: rgb(19 25 44 / 88%);
-  --color-surface-strong: rgb(28 36 62 / 92%);
-  --color-border: rgb(110 138 255 / 24%);
-  --color-border-subtle: rgb(255 255 255 / 12%);
   --color-text: #f6f7fb;
   --color-muted: rgb(240 243 255 / 68%);
   --color-accent: #82cfff;
   --color-overcharm: #ff6edb;
   --color-overcharm-glow: rgb(255 110 219 / 45%);
-  --color-card-bg: rgb(14 18 38 / 78%);
-  --header-gap: clamp(0.55rem, 1.1vw, 0.9rem);
+
+  /* Surfaces */
+  --surface-glass-low: linear-gradient(155deg, rgb(17 23 44 / 80%), rgb(7 10 23 / 94%));
+  --surface-glass-mid: linear-gradient(160deg, rgb(22 28 52 / 86%), rgb(9 12 26 / 96%));
+  --surface-glass-strong: linear-gradient(
+    170deg,
+    rgb(28 36 62 / 88%),
+    rgb(10 14 30 / 96%)
+  );
+  --surface-panel-muted: linear-gradient(165deg, rgb(14 18 38 / 78%), rgb(6 9 20 / 92%));
+
+  /* Elevation */
+  --elevation-layer-1: 0 12px 28px rgb(3 6 18 / 48%);
+  --elevation-layer-2: 0 18px 46px rgb(4 8 28 / 56%);
+  --elevation-layer-3: 0 28px 72px rgb(6 10 34 / 64%);
+  --elevation-inner-soft:
+    inset 0 1px 0 rgb(255 255 255 / 8%), inset 0 -1px 0 rgb(6 8 20 / 60%);
+
+  /* Accent glows */
+  --glow-accent-soft: 0 0 0 1px rgb(130 207 255 / 28%), 0 0 24px rgb(130 207 255 / 28%);
+  --glow-accent-strong: 0 0 0 1px rgb(130 207 255 / 36%), 0 0 32px rgb(130 207 255 / 36%);
   --panel-radius: 22px;
+  --header-gap: clamp(0.55rem, 1.1vw, 0.9rem);
+
+  /* Typography scale */
+  --font-size-display: clamp(1.75rem, 3vw, 2.35rem);
+  --font-size-headline: clamp(1.32rem, 2.4vw, 1.8rem);
+  --font-size-title: clamp(1.05rem, 2vw, 1.45rem);
+  --font-size-subhead: clamp(0.95rem, 1.8vw, 1.2rem);
+  --font-size-body: clamp(0.9rem, 1.5vw, 1.05rem);
+  --font-size-caption: clamp(0.72rem, 1.2vw, 0.82rem);
 
   background-color: var(--color-bg);
   color: var(--color-text);
@@ -63,11 +87,15 @@ body {
   display: grid;
   gap: clamp(0.4rem, 1vw, 0.7rem);
   padding: clamp(0.55rem, 1.4vw, 0.9rem) clamp(0.85rem, 2vw, 1.35rem);
-  border-radius: 1rem;
-  background: linear-gradient(140deg, rgb(16 21 40 / 92%), rgb(7 10 22 / 94%));
-  border: 1px solid rgb(130 207 255 / 36%);
-  box-shadow: 0 14px 36px rgb(3 6 18 / 55%);
-  backdrop-filter: blur(16px);
+  border-radius: var(--panel-radius);
+}
+
+.app-navbar {
+  background: var(--surface-glass-strong);
+  box-shadow:
+    var(--elevation-layer-3), var(--glow-accent-soft), var(--elevation-inner-soft);
+  backdrop-filter: blur(18px);
+  border: none;
 }
 
 .encounter-hud__primary {
@@ -88,9 +116,10 @@ body {
 .hud-brand__title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(1rem, 1.8vw, 1.25rem);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  font-size: var(--font-size-display);
+  letter-spacing: 0.02em;
+  text-transform: none;
+  line-height: 1.1;
 }
 
 .hud-brand__context {
@@ -98,7 +127,8 @@ body {
   align-items: center;
   gap: clamp(0.3rem, 0.8vw, 0.55rem);
   color: rgb(240 243 255 / 82%);
-  font-size: clamp(0.75rem, 1vw, 0.88rem);
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.01em;
 }
 
 .hud-brand__encounter {
@@ -126,17 +156,33 @@ body {
   opacity: 0.7;
 }
 
+.summary-chip {
+  border-radius: 0.9rem;
+  background: var(--surface-glass-mid);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(14px);
+}
+
+.summary-chip--toolbar {
+  border-radius: 999px;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+}
+
+.summary-chip--accent {
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-2), var(--glow-accent-strong), var(--elevation-inner-soft);
+}
+
 .hud-timeline {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.55rem;
-  border-radius: 999px;
-  border: 1px solid rgb(130 207 255 / 28%);
-  background: rgb(10 14 30 / 70%);
-  font-size: clamp(0.68rem, 0.95vw, 0.78rem);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.08em;
+  text-transform: none;
 }
 
 .hud-timeline__label {
@@ -196,18 +242,19 @@ body {
   gap: 0.3rem;
   padding: 0.3rem 0.7rem;
   border-radius: 999px;
-  border: 1px solid rgb(130 207 255 / 36%);
-  background: rgb(130 207 255 / 14%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   color: inherit;
-  font-size: 0.75rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  text-transform: none;
   cursor: pointer;
   transition:
     transform 120ms ease,
     background 120ms ease,
-    border-color 120ms ease;
+    box-shadow 120ms ease;
 }
 
 .hud-actions__button:hover,
@@ -215,8 +262,9 @@ body {
 .hud-actions__button[aria-expanded='true'] {
   outline: none;
   transform: translateY(-1px);
-  background: rgb(130 207 255 / 24%);
-  border-color: rgb(130 207 255 / 60%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
 }
 
 .hud-actions__label {
@@ -237,14 +285,12 @@ body {
   gap: 0.6rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgb(130 207 255 / 24%);
-  background: rgb(12 16 30 / 75%);
 }
 
 .hud-health__label {
-  font-size: 0.68rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.12em;
+  text-transform: none;
   color: rgb(240 243 255 / 64%);
 }
 
@@ -255,7 +301,9 @@ body {
   border-radius: 999px;
   background: linear-gradient(90deg, rgb(36 44 84 / 65%), rgb(18 24 50 / 65%));
   overflow: hidden;
-  border: 1px solid rgb(130 207 255 / 28%);
+  box-shadow:
+    inset 0 0 0 1px rgb(130 207 255 / 22%),
+    inset 0 6px 18px rgb(6 12 32 / 55%);
 }
 
 .hud-health__fill {
@@ -268,8 +316,8 @@ body {
 
 .hud-health__value {
   font-family: var(--font-display);
-  font-size: clamp(0.85rem, 1.35vw, 0.98rem);
-  letter-spacing: 0.06em;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.05em;
 }
 
 .hud-metrics {
@@ -290,16 +338,16 @@ body {
 }
 
 .hud-metrics__label {
-  font-size: 0.62rem;
+  font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
-  text-transform: uppercase;
+  text-transform: none;
   color: rgb(240 243 255 / 58%);
 }
 
 .hud-metrics__value {
   font-family: var(--font-display);
-  font-size: clamp(0.92rem, 1.5vw, 1.1rem);
-  letter-spacing: 0.04em;
+  font-size: var(--font-size-title);
+  letter-spacing: 0.03em;
 }
 
 .encounter-setup {
@@ -323,8 +371,9 @@ body {
 
 .target-selector {
   border-radius: 0.95rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(9 12 24 / 74%);
+  background: var(--surface-panel-muted);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(12px);
   padding: clamp(0.65rem, 1.9vw, 1.1rem);
   display: grid;
   gap: clamp(0.55rem, 1.1vw, 0.85rem);
@@ -339,9 +388,9 @@ body {
 
 .target-selector h3 {
   margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  font-size: var(--font-size-title);
+  letter-spacing: 0.02em;
+  text-transform: none;
 }
 
 .target-selector__options-toggle {
@@ -351,15 +400,16 @@ body {
   width: 2rem;
   height: 2rem;
   border-radius: 999px;
-  border: 1px solid rgb(255 255 255 / 16%);
-  background: rgb(8 11 22 / 78%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   color: var(--color-text);
   cursor: pointer;
   font-size: 1rem;
   transition:
     transform 120ms ease,
     background 120ms ease,
-    border-color 120ms ease;
+    box-shadow 120ms ease;
 }
 
 .target-selector__options-toggle:hover,
@@ -367,18 +417,19 @@ body {
 .target-selector__options-toggle[aria-expanded='true'] {
   outline: none;
   transform: translateY(-1px);
-  background: rgb(130 207 255 / 26%);
-  border-color: rgb(130 207 255 / 52%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
 }
 
 .segmented-control {
   display: flex;
   gap: 0.35rem;
   overflow-x: auto;
-  padding: 0.25rem;
+  padding: 0.35rem;
   border-radius: 999px;
-  border: 1px solid rgb(255 255 255 / 14%);
-  background: rgb(7 9 20 / 78%);
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   scrollbar-width: thin;
 }
 
@@ -388,27 +439,30 @@ body {
   padding: 0.38rem 0.85rem;
   background: transparent;
   color: inherit;
-  font-size: 0.8rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.03em;
   cursor: pointer;
   transition:
     transform 120ms ease,
     background 120ms ease,
-    color 120ms ease;
+    color 120ms ease,
+    box-shadow 120ms ease;
   white-space: nowrap;
 }
 
 .segmented-control__option[data-selected='true'] {
-  background: rgb(130 207 255 / 26%);
+  background: var(--surface-glass-mid);
   color: var(--color-text);
+  box-shadow: var(--glow-accent-soft);
   transform: translateY(-1px);
 }
 
 .segmented-control__option:hover,
 .segmented-control__option:focus-visible {
   outline: none;
-  background: rgb(130 207 255 / 22%);
+  background: var(--surface-glass-mid);
+  box-shadow: var(--glow-accent-soft);
   transform: translateY(-1px);
 }
 
@@ -430,10 +484,10 @@ body {
 }
 
 .target-selector__field-label {
-  font-size: 0.74rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
@@ -441,36 +495,34 @@ body {
 .target-selector__field input[type='text'] {
   appearance: none;
   border-radius: 0.65rem;
-  border: 1px solid var(--color-border-subtle);
-  background: rgb(10 12 26 / 76%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
   color: inherit;
   padding: 0.45rem 0.7rem;
-  font-size: 0.9rem;
+  font-size: var(--font-size-body);
 }
 
 .target-selector__summary {
-  border-radius: 0.85rem;
-  border: 1px solid rgb(255 255 255 / 14%);
-  background: rgb(8 11 22 / 76%);
   padding: 0.55rem 0.75rem;
   display: grid;
   gap: 0.12rem;
 }
 
 .target-selector__summary-title {
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.05em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
 .target-selector__summary-value {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: var(--font-size-subhead);
 }
 
 .target-selector__summary-meta {
-  font-size: 0.78rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
@@ -488,8 +540,9 @@ body {
 
 .sequence-selector {
   border-radius: 0.95rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(9 12 24 / 74%);
+  background: var(--surface-panel-muted);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(12px);
   padding: clamp(0.65rem, 1.9vw, 1.1rem);
   display: grid;
   gap: clamp(0.55rem, 1.1vw, 0.85rem);
@@ -503,9 +556,9 @@ body {
 
 .sequence-selector h3 {
   margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  font-size: var(--font-size-title);
+  letter-spacing: 0.02em;
+  text-transform: none;
 }
 
 .sequence-selector__field {
@@ -515,21 +568,22 @@ body {
 }
 
 .sequence-selector__field-label {
-  font-size: 0.74rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
 .sequence-selector__field select {
   appearance: none;
   border-radius: 0.65rem;
-  border: 1px solid var(--color-border-subtle);
-  background: rgb(10 12 26 / 76%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
   color: inherit;
   padding: 0.45rem 0.7rem;
-  font-size: 0.9rem;
+  font-size: var(--font-size-body);
 }
 
 .sequence-selector__stages {
@@ -546,37 +600,40 @@ body {
   align-items: center;
   gap: 0.45rem;
   border-radius: 0.75rem;
-  border: 1px solid rgb(255 255 255 / 14%);
-  background: rgb(8 11 22 / 74%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   padding: 0.45rem 0.65rem;
   color: inherit;
-  font-size: 0.86rem;
+  font-size: var(--font-size-body);
   font-weight: 600;
   cursor: pointer;
   transition:
     transform 120ms ease,
     background 120ms ease,
-    border-color 120ms ease;
+    box-shadow 120ms ease;
 }
 
 .sequence-selector__stage[aria-current='true'] {
-  background: rgb(130 207 255 / 24%);
-  border-color: rgb(130 207 255 / 48%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
   transform: translateY(-1px);
 }
 
 .sequence-selector__stage:hover,
 .sequence-selector__stage:focus-visible {
   outline: none;
-  background: rgb(130 207 255 / 22%);
-  border-color: rgb(130 207 255 / 60%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
   transform: translateY(-1px);
 }
 
 .sequence-selector__stage-index {
-  font-size: 0.72rem;
+  font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
-  text-transform: uppercase;
+  text-transform: none;
   color: var(--color-muted);
 }
 
@@ -586,14 +643,15 @@ body {
 
 .sequence-selector__empty {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
 .sequence-conditions {
   border-radius: 0.95rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(9 12 24 / 70%);
+  background: var(--surface-panel-muted);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(12px);
   padding: clamp(0.65rem, 1.9vw, 1.1rem);
   display: grid;
   gap: 0.6rem;
@@ -601,9 +659,9 @@ body {
 
 .sequence-conditions__title {
   margin: 0;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
@@ -617,7 +675,7 @@ body {
   grid-template-columns: auto 1fr;
   gap: 0.55rem;
   align-items: start;
-  font-size: 0.85rem;
+  font-size: var(--font-size-body);
 }
 
 .sequence-conditions__option input[type='checkbox'] {
@@ -633,7 +691,7 @@ body {
 .sequence-conditions__description {
   display: block;
   color: var(--color-muted);
-  font-size: 0.78rem;
+  font-size: var(--font-size-caption);
   margin-top: 0.15rem;
 }
 
@@ -659,9 +717,9 @@ body {
   display: flex;
   flex-direction: column;
   border-radius: var(--panel-radius);
-  background: linear-gradient(165deg, rgb(12 16 32 / 88%), rgb(7 9 20 / 95%));
-  border: 1px solid rgb(255 255 255 / 10%);
-  box-shadow: 0 24px 60px rgb(4 6 18 / 42%);
+  background: var(--surface-glass-mid);
+  box-shadow: var(--elevation-layer-2), var(--elevation-inner-soft);
+  backdrop-filter: blur(18px);
   overflow: hidden;
 }
 
@@ -674,14 +732,14 @@ body {
 
 .app-panel__header h2 {
   margin: 0;
-  font-size: 1.35rem;
-  letter-spacing: 0.03em;
+  font-size: var(--font-size-headline);
+  letter-spacing: 0.02em;
 }
 
 .app-panel__description {
   margin: 0;
   color: var(--color-muted);
-  font-size: 0.95rem;
+  font-size: var(--font-size-body);
 }
 
 .app-panel__body {
@@ -707,27 +765,29 @@ body {
 }
 
 .quick-actions__button {
-  border: 1px solid rgb(255 255 255 / 20%);
+  border: none;
   border-radius: 999px;
-  background: rgb(130 207 255 / 14%);
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   color: inherit;
   padding: 0.38rem 0.95rem;
-  font-size: 0.8rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.04em;
   cursor: pointer;
   transition:
     transform 120ms ease,
     background 120ms ease,
-    border-color 120ms ease;
+    box-shadow 120ms ease;
 }
 
 .quick-actions__button:hover,
 .quick-actions__button:focus-visible {
   outline: none;
   transform: translateY(-1px);
-  background: rgb(130 207 255 / 22%);
-  border-color: rgb(130 207 255 / 60%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
 }
 
 .quick-actions__button:disabled {
@@ -749,9 +809,9 @@ body {
 }
 
 .attack-group__title {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  font-size: var(--font-size-caption);
+  text-transform: none;
+  letter-spacing: 0.08em;
   color: var(--color-muted);
 }
 
@@ -766,8 +826,9 @@ body {
   flex-direction: column;
   gap: 0.4rem;
   border-radius: 0.9rem;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: rgb(255 255 255 / 6%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
   padding: 0.75rem;
   text-align: left;
   color: inherit;
@@ -775,15 +836,16 @@ body {
   transition:
     transform 120ms ease,
     background 120ms ease,
-    border-color 120ms ease;
+    box-shadow 120ms ease;
 }
 
 .button-grid__button:hover,
 .button-grid__button:focus-visible {
   outline: none;
   transform: translateY(-1px);
-  background: rgb(130 207 255 / 20%);
-  border-color: rgb(130 207 255 / 45%);
+  background: var(--surface-glass-mid);
+  box-shadow:
+    var(--elevation-layer-1), var(--glow-accent-soft), var(--elevation-inner-soft);
 }
 
 .button-grid__header {
@@ -794,18 +856,19 @@ body {
 }
 
 .button-grid__label {
-  font-size: 0.95rem;
+  font-size: var(--font-size-subhead);
 }
 
 .button-grid__hotkey {
-  font-size: 0.65rem;
+  font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
-  text-transform: uppercase;
+  text-transform: none;
   padding: 0.15rem 0.4rem;
   border-radius: 0.45rem;
-  border: 1px solid rgb(255 255 255 / 16%);
+  border: none;
   color: var(--color-muted);
-  background: rgb(0 0 0 / 25%);
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
 }
 
 .button-grid__meta {
@@ -815,7 +878,7 @@ body {
   justify-content: space-between;
   gap: 0.35rem;
   width: 100%;
-  font-size: 0.85rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
@@ -827,16 +890,17 @@ body {
 
 .button-grid__soul,
 .button-grid__hits {
-  font-size: 0.7rem;
+  font-size: var(--font-size-caption);
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  text-transform: none;
   padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  background: rgb(255 255 255 / 14%);
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
 }
 
 .button-grid__description {
-  font-size: 0.78rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
@@ -865,9 +929,9 @@ body {
 }
 
 .data-list__label {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: var(--font-size-caption);
+  text-transform: none;
+  letter-spacing: 0.06em;
   color: var(--color-muted);
 }
 
@@ -1089,10 +1153,11 @@ body {
 .equipped-panel,
 .notch-panel,
 .preset-panel {
-  background: var(--color-card-bg);
+  background: var(--surface-panel-muted);
   border-radius: 18px;
-  border: 1px solid var(--color-border-subtle);
-  box-shadow: 0 16px 40px rgb(4 6 18 / 28%);
+  border: none;
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(14px);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -1103,9 +1168,9 @@ body {
 .notch-panel__title,
 .preset-panel__title {
   margin: 0;
-  font-size: 0.9rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
@@ -1120,9 +1185,9 @@ body {
   place-items: center;
   padding: 0.35rem;
   border-radius: 12px;
-  border: 1px solid rgb(130 207 255 / 25%);
-  background: rgb(130 207 255 / 8%);
-  box-shadow: inset 0 0 12px rgb(130 207 255 / 12%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
 }
 
 .equipped-panel__icon {
@@ -1133,7 +1198,7 @@ body {
 
 .equipped-panel__empty {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
@@ -1201,10 +1266,10 @@ body {
 }
 
 .notch-panel__slider-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  text-transform: none;
   color: var(--color-muted);
 }
 
@@ -1216,28 +1281,30 @@ body {
 .notch-panel__description,
 .preset-panel__description {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
 .overcharm-banner {
   border-radius: 14px;
-  border: 1px solid rgb(255 110 219 / 55%);
-  background: linear-gradient(120deg, rgb(255 110 219 / 35%), rgb(255 110 219 / 15%));
+  border: none;
+  background: linear-gradient(120deg, rgb(255 110 219 / 28%), rgb(255 110 219 / 10%));
   padding: 0.85rem 1rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 0.75rem;
   align-items: baseline;
   color: var(--color-overcharm);
-  box-shadow: 0 16px 36px rgb(255 110 219 / 18%);
+  box-shadow:
+    0 16px 36px rgb(255 110 219 / 18%),
+    inset 0 0 0 1px rgb(255 110 219 / 38%);
 }
 
 .overcharm-banner__label {
-  font-size: 0.9rem;
+  font-size: var(--font-size-subhead);
   font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-transform: none;
 }
 
 .overcharm-banner__message {
@@ -1246,8 +1313,10 @@ body {
 }
 
 .notch-panel--overcharmed {
-  border-color: rgb(255 110 219 / 55%);
-  box-shadow: 0 18px 48px rgb(255 110 219 / 25%);
+  box-shadow:
+    var(--elevation-layer-1),
+    0 18px 48px rgb(255 110 219 / 25%),
+    inset 0 0 0 1px rgb(255 110 219 / 38%);
 }
 
 .notch-panel--overcharmed::after {
@@ -1368,9 +1437,9 @@ body {
   inset: 0.45rem 0.45rem auto auto;
   border-radius: 999px;
   padding: 0.15rem 0.45rem;
-  font-size: 0.7rem;
+  font-size: var(--font-size-caption);
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  text-transform: none;
   background: rgb(0 0 0 / 55%);
 }
 
@@ -1382,8 +1451,10 @@ body {
 
 .spell-card {
   border-radius: 1rem;
-  border: 1px solid rgb(255 255 255 / 10%);
-  background: rgb(10 14 28 / 85%);
+  border: none;
+  background: var(--surface-panel-muted);
+  box-shadow: var(--elevation-layer-1), var(--elevation-inner-soft);
+  backdrop-filter: blur(12px);
   padding: 0.9rem;
   display: flex;
   flex-direction: column;
@@ -1392,7 +1463,7 @@ body {
 
 .spell-card legend {
   font-weight: 600;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.02em;
   margin-bottom: 0.2rem;
 }
 
@@ -1420,18 +1491,19 @@ body {
 }
 
 .form-grid__field span {
-  font-size: 0.85rem;
+  font-size: var(--font-size-caption);
   font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
 .form-grid__field select,
 .form-grid__field input {
   border-radius: 0.75rem;
-  border: 1px solid rgb(255 255 255 / 16%);
-  background: rgb(6 9 20 / 75%);
+  border: none;
+  background: var(--surface-glass-low);
+  box-shadow: var(--elevation-inner-soft);
   color: inherit;
   padding: 0.55rem 0.75rem;
 }


### PR DESCRIPTION
## Summary
- add layered elevation, surface, glow, and typography tokens to `global.css` and restyle the app navbar and panels with depth cues
- convert HUD controls, target selector summaries, and timeline chips to the new summary-chip patterns with sentence case microcopy
- document the visual language system and typography scale in the README for future contributors

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7abb14f74832f9dda92aaa4fd0aa8