### PR TITLE
ci: reuse build artifact across checks and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,16 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
       - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm lint
 
-  unit-tests:
+  build:
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -29,15 +31,52 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
       - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Cache Vite build output
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vite
+            ~/.vite
+          key: ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml', 'vite.config.ts') }}
+      - name: Build project
+        run: pnpm build
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
       - run: pnpm test
 
   e2e-tests:
-    needs: lint
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,14 +91,22 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
       - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
       - run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           CI: true
+          PLAYWRIGHT_USE_PREVIEW: '1'
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,19 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
 
 concurrency:
   group: deploy-pages
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - uses: actions/upload-pages-artifact@v4
-        with:
-          path: dist
-
   deploy:
-    needs: build
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -38,5 +22,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
       - uses: actions/deploy-pages@v4
         id: deploy

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,9 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: 'pnpm dev --host 127.0.0.1 --port 4173 --strictPort',
+    command: process.env.PLAYWRIGHT_USE_PREVIEW
+      ? 'pnpm preview --host 127.0.0.1 --port 4173 --strictPort'
+      : 'pnpm dev --host 127.0.0.1 --port 4173 --strictPort',
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
## Summary
- run lint before the rest of the CI graph and split out a dedicated build job that uploads the dist artifact
- reuse the build artifact for unit tests, Playwright, and the deployment workflow while caching Vite outputs
- deploy from the CI-generated artifact via workflow_run and use the built preview server during Playwright runs

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d84cd83b38832f9e3f3e5fa91a7f40