### PR TITLE
feat: refresh combat metrics and charts

### DIFF
--- a/src/features/combat-stats/Sparkline.tsx
+++ b/src/features/combat-stats/Sparkline.tsx
@@ -12,6 +12,7 @@ interface SparklineProps {
   width?: number;
   height?: number;
   padding?: number;
+  valueDomain?: readonly [number, number];
 }
 
 const buildPolylinePoints = (
@@ -19,6 +20,7 @@ const buildPolylinePoints = (
   width: number,
   height: number,
   padding: number,
+  valueDomain?: readonly [number, number],
 ) => {
   const size = data.length;
 
@@ -46,7 +48,9 @@ const buildPolylinePoints = (
     }
   }
 
-  const valueRange = maxValue - minValue;
+  const resolvedMinValue = valueDomain ? valueDomain[0] : minValue;
+  const resolvedMaxValue = valueDomain ? valueDomain[1] : maxValue;
+  const valueRange = resolvedMaxValue - resolvedMinValue;
   const timeRange = maxTime - minTime;
 
   const innerWidth = width - padding * 2;
@@ -57,7 +61,8 @@ const buildPolylinePoints = (
   }
 
   const points = data.map(({ time, value }) => {
-    const normalizedValue = valueRange === 0 ? 0.5 : (value - minValue) / valueRange;
+    const normalizedValue =
+      valueRange === 0 ? 0.5 : (value - resolvedMinValue) / valueRange;
     const normalizedTime = timeRange === 0 ? 0 : (time - minTime) / timeRange;
     const x = padding + normalizedTime * innerWidth;
     const y = padding + (1 - normalizedValue) * innerHeight;
@@ -89,12 +94,13 @@ export const Sparkline: FC<SparklineProps> = ({
   width = 88,
   height = 28,
   padding = 2,
+  valueDomain,
 }) => {
   if (data.length < 2) {
     return null;
   }
 
-  const polyline = buildPolylinePoints(data, width, height, padding);
+  const polyline = buildPolylinePoints(data, width, height, padding, valueDomain);
 
   if (!polyline) {
     return null;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -468,6 +468,13 @@ h6 {
   flex-wrap: wrap;
 }
 
+.hud-scoreboard__status {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(0.45rem, 1.2vw, 0.9rem);
+  flex-wrap: wrap;
+}
+
 .hud-health {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- move stage navigation next to the health bar and replace HUD metrics with stopwatch-style elapsed, remaining, and DPS values
- update combat overview charts to plot per-hit averages, bucket DPS by second, and lock remaining HP sparklines to the target health range
- add focused unit tests for the revised combat statistics panel transformations and sparkline value domains

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d85a4d42c8832fa744eaa2c5f03756