### PR TITLE
feat: rebuild attack particle effects

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -144,28 +144,164 @@ textarea {
 }
 
 button {
-  --press-x: 50%;
-  --press-y: 50%;
-
   position: relative;
 }
 
 button[data-particle-effect] {
-  overflow: visible;
+  overflow: hidden;
 }
 
+button[data-particle-effect]::before,
 button[data-particle-effect]::after {
   content: '';
   position: absolute;
-  top: var(--press-y, 50%);
-  left: var(--press-x, 50%);
   pointer-events: none;
-  transform: translate(-50%, -50%) scale(0.2);
   opacity: 0;
-  border-radius: 50%;
+  transform: scale(0.6);
+  transform-origin: center;
   will-change: transform, opacity;
   mix-blend-mode: screen;
-  z-index: 2;
+  transition: none;
+}
+
+button[data-particle-effect='nail']::after {
+  top: 50%;
+  left: 50%;
+  width: 72%;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgb(255 255 255 / 0%) 0%,
+    rgb(255 255 255 / 85%) 35%,
+    rgb(208 226 255 / 65%) 65%,
+    rgb(255 255 255 / 0%) 100%
+  );
+  box-shadow:
+    0 -10px 0 0 rgb(255 255 255 / 60%),
+    0 10px 0 0 rgb(208 226 255 / 45%);
+  transform: translate(-50%, -50%) scaleX(0.45);
+}
+
+button.is-particle-active[data-particle-effect='nail']::after {
+  animation: particle-nail 200ms ease-out forwards;
+}
+
+button[data-particle-effect='spell-spirit']::before {
+  top: 50%;
+  left: 50%;
+  width: 132%;
+  height: 132%;
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle at 50% 50%,
+      rgb(255 255 255 / 65%) 0%,
+      rgb(210 230 255 / 18%) 55%,
+      transparent 75%
+    ),
+    radial-gradient(circle at 50% 50%, rgb(180 210 255 / 45%) 0%, transparent 70%);
+  transform: translate(-50%, -50%) scale(0.55);
+}
+
+button[data-particle-effect='spell-spirit']::after {
+  top: 50%;
+  left: 50%;
+  width: 86%;
+  height: 86%;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle at 50% 48%,
+    rgb(240 248 255 / 75%) 0%,
+    rgb(190 220 255 / 28%) 42%,
+    transparent 70%
+  );
+  transform: translate(-50%, -50%) scale(0.7);
+}
+
+button.is-particle-active[data-particle-effect='spell-spirit']::before {
+  animation: particle-spell-spirit-soft 220ms ease-out forwards;
+}
+
+button.is-particle-active[data-particle-effect='spell-spirit']::after {
+  animation: particle-spell-spirit-core 220ms ease-out forwards;
+}
+
+button[data-particle-effect='spell-dive']::after {
+  left: 50%;
+  bottom: -6%;
+  width: 140%;
+  height: 88%;
+  border-radius: 65% 65% 0 0;
+  background: radial-gradient(
+    circle at 50% 100%,
+    rgb(230 244 255 / 75%) 0%,
+    rgb(170 210 255 / 35%) 55%,
+    transparent 80%
+  );
+  transform-origin: 50% 100%;
+  transform: translate(-50%, 10%) scale(1, 0.75);
+}
+
+button.is-particle-active[data-particle-effect='spell-dive']::after {
+  animation: particle-spell-dive 230ms ease-out forwards;
+}
+
+button[data-particle-effect='spell-wraith']::after {
+  left: 50%;
+  top: -6%;
+  width: 140%;
+  height: 88%;
+  border-radius: 0 0 65% 65%;
+  background: radial-gradient(
+    circle at 50% 0%,
+    rgb(230 244 255 / 75%) 0%,
+    rgb(170 214 255 / 35%) 55%,
+    transparent 80%
+  );
+  transform-origin: 50% 0%;
+  transform: translate(-50%, -10%) scale(1, 0.75);
+}
+
+button.is-particle-active[data-particle-effect='spell-wraith']::after {
+  animation: particle-spell-wraith 230ms ease-out forwards;
+}
+
+button[data-particle-effect='control']::after {
+  top: 50%;
+  left: 50%;
+  width: 36%;
+  height: 36%;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgb(225 234 250 / 65%) 0%,
+    rgb(200 210 230 / 28%) 60%,
+    transparent 80%
+  );
+  transform: translate(-50%, -50%) scale(0.6);
+}
+
+button[data-particle-effect='control']::before {
+  top: 50%;
+  left: 50%;
+  width: 18%;
+  height: 18%;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgb(255 255 255 / 70%) 0%,
+    rgb(210 220 240 / 0%) 100%
+  );
+  transform: translate(-50%, -50%) scale(0.4);
+}
+
+button.is-particle-active[data-particle-effect='control']::after {
+  animation: particle-control-glow 150ms ease-out forwards;
+}
+
+button.is-particle-active[data-particle-effect='control']::before {
+  animation: particle-control-spark 150ms ease-out forwards;
 }
 
 :where(button, select):focus-visible {
@@ -179,77 +315,6 @@ button[data-particle-effect]::after {
     0 0 0 1px rgb(225 238 255 / 55%),
     0 0 14px 4px rgb(135 182 255 / 28%);
   border-color: rgb(218 232 255 / 65%);
-}
-
-button.is-particle-active[data-particle-effect='nail']::after {
-  width: 6px;
-  height: 6px;
-  background: transparent;
-  box-shadow:
-    0 -26px 0 1.2px rgb(255 255 255 / 85%),
-    18px -12px 0 1px rgb(255 255 255 / 60%),
-    -18px -12px 0 1px rgb(255 255 255 / 60%),
-    0 26px 0 1px rgb(146 188 255 / 45%);
-  animation: particle-nail 220ms ease-out forwards;
-}
-
-button.is-particle-active[data-particle-effect='spell-spirit']::after {
-  width: 84px;
-  height: 84px;
-  background-image:
-    radial-gradient(circle at 50% 52%, rgb(228 238 255 / 45%) 0%, transparent 56%),
-    conic-gradient(
-      from 150deg at 50% 50%,
-      rgb(200 220 255 / 70%) 0deg,
-      rgb(160 200 255 / 35%) 120deg,
-      transparent 200deg,
-      rgb(210 234 255 / 55%) 300deg,
-      transparent 360deg
-    );
-  animation: particle-spirit 360ms ease-out forwards;
-  filter: drop-shadow(0 0 28px rgb(170 208 255 / 28%));
-}
-
-button.is-particle-active[data-particle-effect='spell-dive']::after {
-  width: 120px;
-  height: 120px;
-  background-image: radial-gradient(
-    ellipse at 50% 88%,
-    rgb(226 244 255 / 65%) 0%,
-    rgb(154 202 255 / 35%) 40%,
-    transparent 70%
-  );
-  transform-origin: 50% 100%;
-  animation: particle-dive 320ms ease-out forwards;
-  filter: drop-shadow(0 18px 30px rgb(110 168 255 / 35%));
-}
-
-button.is-particle-active[data-particle-effect='spell-wraith']::after {
-  width: 120px;
-  height: 120px;
-  background-image: radial-gradient(
-    ellipse at 50% 12%,
-    rgb(226 244 255 / 65%) 0%,
-    rgb(170 214 255 / 35%) 40%,
-    transparent 68%
-  );
-  transform-origin: 50% 0%;
-  animation: particle-wraith 340ms ease-out forwards;
-  filter: drop-shadow(0 -12px 26px rgb(140 192 255 / 35%));
-}
-
-button.is-particle-active[data-particle-effect='control']::after {
-  width: 10px;
-  height: 10px;
-  background: transparent;
-  box-shadow:
-    0 -12px 0 0 rgb(180 190 210 / 40%),
-    10px -4px 0 0 rgb(180 190 210 / 28%),
-    -10px -4px 0 0 rgb(180 190 210 / 30%),
-    6px 8px 0 0 rgb(180 190 210 / 26%),
-    -6px 8px 0 0 rgb(180 190 210 / 26%);
-  animation: particle-dust 280ms ease-out forwards;
-  filter: blur(0.2px);
 }
 
 h1,
@@ -2291,77 +2356,110 @@ h6 {
 
 @keyframes particle-nail {
   0% {
-    opacity: 0.85;
-    transform: translate(-50%, -50%) scale(0.2) rotate(0deg);
+    opacity: 0.9;
+    transform: translate(-50%, -50%) scaleX(0.45);
   }
 
-  60% {
+  55% {
     opacity: 0.6;
+    transform: translate(-50%, -50%) scaleX(1.05);
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(1.05) rotate(8deg);
+    transform: translate(-50%, -50%) scaleX(1.35);
   }
 }
 
-@keyframes particle-spirit {
+@keyframes particle-spell-spirit-soft {
   0% {
-    opacity: 0.8;
-    transform: translate(-50%, -50%) scale(0.35) rotate(-25deg);
+    opacity: 0.55;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+
+  60% {
+    opacity: 0.4;
+    transform: translate(-50%, -50%) scale(0.95);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.15);
+  }
+}
+
+@keyframes particle-spell-spirit-core {
+  0% {
+    opacity: 0.85;
+    transform: translate(-50%, -50%) scale(0.7);
   }
 
   70% {
     opacity: 0.45;
+    transform: translate(-50%, -50%) scale(1.05);
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(1.05) rotate(40deg);
+    transform: translate(-50%, -50%) scale(1.25);
   }
 }
 
-@keyframes particle-dive {
+@keyframes particle-spell-dive {
   0% {
     opacity: 0.85;
-    transform: translate(-50%, -50%) scale(0.4, 0.18);
+    transform: translate(-50%, 6%) scale(1, 0.75);
   }
 
   65% {
     opacity: 0.5;
+    transform: translate(-50%, 18%) scale(0.95, 0.55);
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(1.1, 0.65);
+    transform: translate(-50%, 32%) scale(0.85, 0.4);
   }
 }
 
-@keyframes particle-wraith {
+@keyframes particle-spell-wraith {
   0% {
     opacity: 0.85;
-    transform: translate(-50%, -50%) scale(0.4, 0.25);
+    transform: translate(-50%, -6%) scale(1, 0.75);
   }
 
   65% {
     opacity: 0.5;
+    transform: translate(-50%, -18%) scale(0.95, 0.55);
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(1.05, 0.7);
+    transform: translate(-50%, -32%) scale(0.85, 0.4);
   }
 }
 
-@keyframes particle-dust {
+@keyframes particle-control-glow {
   0% {
-    opacity: 0.75;
+    opacity: 0.55;
     transform: translate(-50%, -50%) scale(0.6);
   }
 
   100% {
     opacity: 0;
-    transform: translate(-50%, -70%) scale(1.1);
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes particle-control-spark {
+  0% {
+    opacity: 0.8;
+    transform: translate(-50%, -50%) scale(0.4);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify the attack log particle trigger logic to use lightweight class toggles that also fire for keyboard shortcuts
- restyle the particle effects with pseudo-elements and transform/opacity-only animations tailored to each attack category
- refresh control button feedback with a subtle glow to match the new performance-focused particle system

## Testing
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d86c9738fc832f85fb55f9df4b8638