### PR TITLE
feat: replace particle effects with soul ripple feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,16 @@ When extending the UI, lean on these tokens before introducing bespoke colors so
 ### Atmosphere & Interactivity
 
 - **Dimmed cavern glow:** The global background now layers deep blue-grey gradients, a gentle vignette, and a faint hex lattice so the interface feels like a relic lit within a Godhome chamber.
-- **Tactile controls:** Buttons and selects compress with a brief soul-white flash, while nail, spell, and control buttons trigger themed CSS particle bursts to make every click feel like a strike.
+- **Tactile controls:** Buttons and selects compress with a brief soul-white flash so every click still feels like a strike.
 - **State-aware cues:** Combat panels pulse when a fight begins or ends, and the Remaining HP readout glows softly under 25% to telegraph danger and victory without stealing focus.
 
 Contributors can inspect the implementations inside `src/styles/global.css`—mirroring these primitives will keep future components steeped in the same ancient elegance.
+
+### Tactile, Performant Feedback
+
+- **Soul Ripple activations:** Interactive buttons shrink via `transform: scale(0.98)` and emit a pale outline drawn with their `::after` pseudo-element. The ripple races outward (`ripple-out`) and fades within 300 ms so inputs feel immediate rather than floaty.
+- **Keyboard and pointer parity:** The same classes fire from pointer presses, key presses, and global shortcuts, guaranteeing identical feedback for mouse and keyboard hunters.
+- **GPU-friendly motion:** All animations stick to `transform` and `opacity`, avoiding layout-bound properties. The effect renders entirely in CSS, keeping the interface pinned at 60 FPS even during frantic combat logging.
 
 ## Tech Stack
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,7 @@
   --color-border-soft: rgb(208 215 240 / 32%);
   --color-border-faint: rgb(208 215 240 / 18%);
   --color-accent: #b5e3ff;
+  --color-accent-glow: rgb(181 227 255 / 45%);
   --color-accent-ember: #f2b87f;
   --color-text: #f4f6ff;
   --color-muted: rgb(244 246 255 / 72%);
@@ -147,161 +148,62 @@ button {
   position: relative;
 }
 
-button[data-particle-effect] {
-  overflow: hidden;
+button.is-active-effect {
+  transform: scale(0.98);
 }
 
-button[data-particle-effect]::before,
-button[data-particle-effect]::after {
+.quick-actions__button,
+.button-grid__button {
+  isolation: isolate;
+  overflow: visible;
+}
+
+.quick-actions__button::after,
+.button-grid__button::after {
   content: '';
   position: absolute;
-  pointer-events: none;
+  inset: -1px;
+  border: 1.5px solid var(--color-accent);
+  border-radius: inherit;
   opacity: 0;
-  transform: scale(0.6);
+  transform: scale(1);
   transform-origin: center;
-  will-change: transform, opacity;
+  pointer-events: none;
   mix-blend-mode: screen;
-  transition: none;
+  will-change: transform, opacity;
+  z-index: -1;
 }
 
-button[data-particle-effect='nail']::after {
-  top: 50%;
-  left: 50%;
-  width: 72%;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    rgb(255 255 255 / 0%) 0%,
-    rgb(255 255 255 / 85%) 35%,
-    rgb(208 226 255 / 65%) 65%,
-    rgb(255 255 255 / 0%) 100%
+.quick-actions__button::after {
+  clip-path: polygon(
+    12px 0,
+    calc(100% - 12px) 0,
+    100% 50%,
+    calc(100% - 12px) 100%,
+    12px 100%,
+    0 50%
   );
-  box-shadow:
-    0 -10px 0 0 rgb(255 255 255 / 60%),
-    0 10px 0 0 rgb(208 226 255 / 45%);
-  transform: translate(-50%, -50%) scaleX(0.45);
 }
 
-button.is-particle-active[data-particle-effect='nail']::after {
-  animation: particle-nail 200ms ease-out forwards;
+.button-grid__button::after {
+  clip-path: var(--shape-tablet);
 }
 
-button[data-particle-effect='spell-spirit']::before {
-  top: 50%;
-  left: 50%;
-  width: 132%;
-  height: 132%;
-  border-radius: 999px;
-  background:
-    radial-gradient(
-      circle at 50% 50%,
-      rgb(255 255 255 / 65%) 0%,
-      rgb(210 230 255 / 18%) 55%,
-      transparent 75%
-    ),
-    radial-gradient(circle at 50% 50%, rgb(180 210 255 / 45%) 0%, transparent 70%);
-  transform: translate(-50%, -50%) scale(0.55);
+.quick-actions__button.is-active-effect::after,
+.button-grid__button.is-active-effect::after {
+  animation: ripple-out 300ms ease-out forwards;
 }
 
-button[data-particle-effect='spell-spirit']::after {
-  top: 50%;
-  left: 50%;
-  width: 86%;
-  height: 86%;
-  border-radius: 999px;
-  background: radial-gradient(
-    circle at 50% 48%,
-    rgb(240 248 255 / 75%) 0%,
-    rgb(190 220 255 / 28%) 42%,
-    transparent 70%
-  );
-  transform: translate(-50%, -50%) scale(0.7);
-}
+@keyframes ripple-out {
+  0% {
+    opacity: 0.8;
+    transform: scale(1);
+  }
 
-button.is-particle-active[data-particle-effect='spell-spirit']::before {
-  animation: particle-spell-spirit-soft 220ms ease-out forwards;
-}
-
-button.is-particle-active[data-particle-effect='spell-spirit']::after {
-  animation: particle-spell-spirit-core 220ms ease-out forwards;
-}
-
-button[data-particle-effect='spell-dive']::after {
-  left: 50%;
-  bottom: -6%;
-  width: 140%;
-  height: 88%;
-  border-radius: 65% 65% 0 0;
-  background: radial-gradient(
-    circle at 50% 100%,
-    rgb(230 244 255 / 75%) 0%,
-    rgb(170 210 255 / 35%) 55%,
-    transparent 80%
-  );
-  transform-origin: 50% 100%;
-  transform: translate(-50%, 10%) scale(1, 0.75);
-}
-
-button.is-particle-active[data-particle-effect='spell-dive']::after {
-  animation: particle-spell-dive 230ms ease-out forwards;
-}
-
-button[data-particle-effect='spell-wraith']::after {
-  left: 50%;
-  top: -6%;
-  width: 140%;
-  height: 88%;
-  border-radius: 0 0 65% 65%;
-  background: radial-gradient(
-    circle at 50% 0%,
-    rgb(230 244 255 / 75%) 0%,
-    rgb(170 214 255 / 35%) 55%,
-    transparent 80%
-  );
-  transform-origin: 50% 0%;
-  transform: translate(-50%, -10%) scale(1, 0.75);
-}
-
-button.is-particle-active[data-particle-effect='spell-wraith']::after {
-  animation: particle-spell-wraith 230ms ease-out forwards;
-}
-
-button[data-particle-effect='control']::after {
-  top: 50%;
-  left: 50%;
-  width: 36%;
-  height: 36%;
-  border-radius: 999px;
-  background: radial-gradient(
-    circle at 50% 50%,
-    rgb(225 234 250 / 65%) 0%,
-    rgb(200 210 230 / 28%) 60%,
-    transparent 80%
-  );
-  transform: translate(-50%, -50%) scale(0.6);
-}
-
-button[data-particle-effect='control']::before {
-  top: 50%;
-  left: 50%;
-  width: 18%;
-  height: 18%;
-  border-radius: 999px;
-  background: radial-gradient(
-    circle at 50% 50%,
-    rgb(255 255 255 / 70%) 0%,
-    rgb(210 220 240 / 0%) 100%
-  );
-  transform: translate(-50%, -50%) scale(0.4);
-}
-
-button.is-particle-active[data-particle-effect='control']::after {
-  animation: particle-control-glow 150ms ease-out forwards;
-}
-
-button.is-particle-active[data-particle-effect='control']::before {
-  animation: particle-control-spark 150ms ease-out forwards;
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
 }
 
 :where(button, select):focus-visible {
@@ -311,10 +213,7 @@ button.is-particle-active[data-particle-effect='control']::before {
 
 :where(button, select):active:not(:disabled) {
   transform: scale(0.97);
-  box-shadow:
-    0 0 0 1px rgb(225 238 255 / 55%),
-    0 0 14px 4px rgb(135 182 255 / 28%);
-  border-color: rgb(218 232 255 / 65%);
+  border-color: var(--color-accent);
 }
 
 h1,
@@ -630,6 +529,7 @@ h6 {
     color 160ms ease,
     text-shadow 160ms ease,
     box-shadow 160ms ease,
+    border-color 160ms ease,
     transform 160ms ease;
 }
 
@@ -1358,6 +1258,7 @@ h6 {
     color 160ms ease,
     text-shadow 160ms ease,
     box-shadow 160ms ease,
+    border-color 160ms ease,
     transform 160ms ease;
 }
 
@@ -1366,10 +1267,10 @@ h6 {
   outline: none;
   color: var(--color-accent);
   text-shadow: 0 0 12px rgb(215 245 255 / 55%);
-  transform: translateY(-1px);
+  border-color: var(--color-accent);
   box-shadow:
     0 18px 32px rgb(0 0 0 / 60%),
-    0 0 18px rgb(215 245 255 / 35%),
+    0 0 10px var(--color-accent-glow),
     inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
@@ -1437,10 +1338,10 @@ h6 {
   outline: none;
   color: var(--color-accent);
   text-shadow: 0 0 12px rgb(215 245 255 / 55%);
-  transform: translateY(-1px);
+  border-color: var(--color-accent);
   box-shadow:
     0 20px 36px rgb(0 0 0 / 60%),
-    0 0 20px rgb(215 245 255 / 35%),
+    0 0 12px var(--color-accent-glow),
     inset 0 0 0 1px rgb(255 255 255 / 16%);
 }
 
@@ -2351,115 +2252,6 @@ h6 {
 
   .charm-grid__row--offset {
     margin-left: calc((var(--charm-size) + var(--charm-gap)) / 1.6);
-  }
-}
-
-@keyframes particle-nail {
-  0% {
-    opacity: 0.9;
-    transform: translate(-50%, -50%) scaleX(0.45);
-  }
-
-  55% {
-    opacity: 0.6;
-    transform: translate(-50%, -50%) scaleX(1.05);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scaleX(1.35);
-  }
-}
-
-@keyframes particle-spell-spirit-soft {
-  0% {
-    opacity: 0.55;
-    transform: translate(-50%, -50%) scale(0.55);
-  }
-
-  60% {
-    opacity: 0.4;
-    transform: translate(-50%, -50%) scale(0.95);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(1.15);
-  }
-}
-
-@keyframes particle-spell-spirit-core {
-  0% {
-    opacity: 0.85;
-    transform: translate(-50%, -50%) scale(0.7);
-  }
-
-  70% {
-    opacity: 0.45;
-    transform: translate(-50%, -50%) scale(1.05);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(1.25);
-  }
-}
-
-@keyframes particle-spell-dive {
-  0% {
-    opacity: 0.85;
-    transform: translate(-50%, 6%) scale(1, 0.75);
-  }
-
-  65% {
-    opacity: 0.5;
-    transform: translate(-50%, 18%) scale(0.95, 0.55);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, 32%) scale(0.85, 0.4);
-  }
-}
-
-@keyframes particle-spell-wraith {
-  0% {
-    opacity: 0.85;
-    transform: translate(-50%, -6%) scale(1, 0.75);
-  }
-
-  65% {
-    opacity: 0.5;
-    transform: translate(-50%, -18%) scale(0.95, 0.55);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -32%) scale(0.85, 0.4);
-  }
-}
-
-@keyframes particle-control-glow {
-  0% {
-    opacity: 0.55;
-    transform: translate(-50%, -50%) scale(0.6);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(1);
-  }
-}
-
-@keyframes particle-control-spark {
-  0% {
-    opacity: 0.8;
-    transform: translate(-50%, -50%) scale(0.4);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the particle effect system from the attack log panel and replace it with a class-driven soul ripple trigger that works for pointer and keyboard inputs
- refresh the shared button styles to add the ripple animation, hover glow, and accent glow token while avoiding layout-heavy animations
- document the new tactile, performant feedback philosophy in the design section of the README

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d872387b84832f88b81a9098dd3a45