### PR TITLE
fix: refine glow and button animations

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -630,24 +630,9 @@ const AppContent: FC = () => {
   } = useBuildConfiguration();
 
   const derived = useFightDerivedStats();
-  const [panelGlow, setPanelGlow] = useState<'idle' | 'start' | 'victory'>('idle');
+  const [panelGlow, setPanelGlow] = useState<'idle' | 'victory'>('idle');
   const glowTimeoutRef = useRef<number | null>(null);
-  const previousFightStartRef = useRef<number | null>(null);
   const previousRemainingRef = useRef<number>(derived.remainingHp);
-
-  useEffect(() => {
-    if (derived.fightStartTimestamp == null) {
-      previousFightStartRef.current = null;
-      return;
-    }
-    if (
-      previousFightStartRef.current == null ||
-      previousFightStartRef.current !== derived.fightStartTimestamp
-    ) {
-      setPanelGlow('start');
-    }
-    previousFightStartRef.current = derived.fightStartTimestamp;
-  }, [derived.fightStartTimestamp]);
 
   useEffect(() => {
     if (
@@ -667,7 +652,7 @@ const AppContent: FC = () => {
     if (glowTimeoutRef.current) {
       window.clearTimeout(glowTimeoutRef.current);
     }
-    const duration = panelGlow === 'victory' ? 760 : 520;
+    const duration = 820;
     const timeoutId = window.setTimeout(() => {
       setPanelGlow('idle');
       glowTimeoutRef.current = null;
@@ -685,12 +670,7 @@ const AppContent: FC = () => {
     [],
   );
 
-  const panelGlowClass =
-    panelGlow === 'idle'
-      ? ''
-      : panelGlow === 'victory'
-        ? 'app-panel--glow-victory'
-        : 'app-panel--glow-start';
+  const panelGlowClass = panelGlow === 'victory' ? 'app-panel--glow-victory' : '';
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -166,7 +166,7 @@ button.is-active-effect {
   border: 1.5px solid rgb(170 225 255 / 90%);
   border-radius: inherit;
   opacity: 0;
-  transform: scale(0.9);
+  transform: scale(0.97);
   transform-origin: center;
   pointer-events: none;
   mix-blend-mode: screen;
@@ -191,7 +191,7 @@ button.is-active-effect {
 
 .quick-actions__button.is-active-effect::after,
 .button-grid__button.is-active-effect::after {
-  animation: button-flare 220ms cubic-bezier(0.28, 0.65, 0.35, 1) forwards;
+  animation: button-flare 700ms cubic-bezier(0.28, 0.65, 0.35, 1) forwards;
 }
 
 @keyframes button-strike {
@@ -200,11 +200,11 @@ button.is-active-effect {
   }
 
   45% {
-    transform: translateY(1px) scale(0.94);
+    transform: translateY(0.5px) scale(0.985);
   }
 
   70% {
-    transform: translateY(-1px) scale(1.06);
+    transform: translateY(-0.5px) scale(1.015);
   }
 
   100% {
@@ -215,20 +215,26 @@ button.is-active-effect {
 @keyframes button-flare {
   0% {
     opacity: 0;
-    transform: scale(0.9);
-    box-shadow: 0 0 0 0 rgb(170 225 255 / 65%);
+    transform: scale(0.97);
+    box-shadow: 0 0 0 0 rgb(170 225 255 / 55%);
   }
 
-  55% {
+  35% {
     opacity: 1;
-    transform: scale(1.05);
-    box-shadow: 0 0 18px 8px rgb(170 225 255 / 45%);
+    transform: scale(1.015);
+    box-shadow: 0 0 14px 6px rgb(170 225 255 / 40%);
+  }
+
+  65% {
+    opacity: 0.85;
+    transform: scale(1.02);
+    box-shadow: 0 0 18px 8px rgb(170 225 255 / 26%);
   }
 
   100% {
     opacity: 0;
-    transform: scale(1.18);
-    box-shadow: 0 0 36px 14px rgb(170 225 255 / 0%);
+    transform: scale(1.025);
+    box-shadow: 0 0 20px 10px rgb(170 225 255 / 0%);
   }
 }
 
@@ -1192,17 +1198,6 @@ h6 {
   z-index: 2;
 }
 
-.app-panel--glow-start::after {
-  background: linear-gradient(
-    118deg,
-    rgb(185 215 255 / 0%) 14%,
-    rgb(210 240 255 / 78%) 44%,
-    rgb(140 200 255 / 30%) 62%,
-    rgb(185 215 255 / 0%) 78%
-  );
-  animation: panel-shimmer-start 460ms cubic-bezier(0.28, 0.65, 0.32, 1) forwards;
-}
-
 .app-panel--glow-victory::after {
   background: linear-gradient(
     118deg,
@@ -1211,7 +1206,7 @@ h6 {
     rgb(255 220 160 / 45%) 55%,
     rgb(210 235 255 / 0%) 78%
   );
-  animation: panel-shimmer-victory 680ms cubic-bezier(0.25, 0.7, 0.3, 1) forwards;
+  animation: panel-shimmer-victory 820ms cubic-bezier(0.25, 0.7, 0.3, 1) forwards;
 }
 
 .app-panel > * {
@@ -2291,25 +2286,6 @@ h6 {
   }
 }
 
-@keyframes panel-shimmer-start {
-  0% {
-    opacity: 0;
-    transform: translateX(-125%) skewX(-12deg);
-    box-shadow: 0 0 0 0 rgb(210 240 255 / 45%);
-  }
-
-  35% {
-    opacity: 1;
-    box-shadow: 0 0 24px 10px rgb(210 240 255 / 50%);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translateX(125%) skewX(-12deg);
-    box-shadow: 0 0 40px 18px rgb(210 240 255 / 0%);
-  }
-}
-
 @keyframes panel-shimmer-victory {
   0% {
     opacity: 0;
@@ -2317,12 +2293,12 @@ h6 {
     box-shadow: 0 0 0 0 rgb(230 250 255 / 55%);
   }
 
-  25% {
+  30% {
     opacity: 1;
     box-shadow: 0 0 32px 14px rgb(230 250 255 / 60%);
   }
 
-  60% {
+  65% {
     opacity: 0.85;
     box-shadow: 0 0 44px 20px rgb(255 215 160 / 45%);
   }


### PR DESCRIPTION
## Summary
- remove the panel shimmer that played at the start of fights and lengthen the victory sweep
- tone down button strike scaling while extending the accompanying flare fade-out

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d87e8f01bc832f9acd75287a07c640