### PR TITLE
feat: allow starting fights via enter key

### DIFF
--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -161,12 +161,12 @@ describe('AttackLogPanel', () => {
     const undoButton = screen.getByRole('button', { name: /undo/i });
     const redoButton = screen.getByRole('button', { name: /redo/i });
     const resetButton = screen.getByRole('button', { name: /quick reset/i });
-    const endFightButton = screen.getByRole('button', { name: /end fight/i });
+    const endFightButton = screen.getByRole('button', { name: /fight \(enter\)/i });
 
     expect(undoButton).toBeDisabled();
     expect(redoButton).toBeDisabled();
     expect(resetButton).toBeDisabled();
-    expect(endFightButton).toBeDisabled();
+    expect(endFightButton).not.toBeDisabled();
 
     const nailStrikeButton = screen.getByRole('button', { name: /nail strike/i });
     await user.click(nailStrikeButton);
@@ -198,7 +198,38 @@ describe('AttackLogPanel', () => {
     expect(undoButton).toBeDisabled();
     expect(redoButton).toBeDisabled();
     expect(resetButton).toBeDisabled();
-    expect(endFightButton).toBeDisabled();
+    expect(endFightButton).not.toBeDisabled();
+  });
+
+  it('starts fights via the Enter key without logging damage', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <>
+        <AttackLogPanel />
+        <CombatStatsPanel />
+      </>,
+    );
+
+    const startButton = screen.getByRole('button', { name: /start fight \(enter\)/i });
+    expect(startButton).not.toBeDisabled();
+
+    await user.keyboard('{Enter}');
+
+    const damageRow = screen.getByText('Damage Logged').closest('.data-list__item');
+    expect(within(damageRow as HTMLElement).getByText('0')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /end fight \(enter\)/i }),
+      ).not.toBeDisabled();
+    });
+
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /fight \(enter\)/i })).toBeDisabled();
+    });
   });
 
   it('supports keyboard shortcuts for logging attacks and resetting', async () => {
@@ -220,7 +251,7 @@ describe('AttackLogPanel', () => {
 
     await user.keyboard('{Enter}');
 
-    const endFightButton = screen.getByRole('button', { name: /end fight/i });
+    const endFightButton = screen.getByRole('button', { name: /fight \(enter\)/i });
     expect(endFightButton).toBeDisabled();
 
     await user.keyboard('{Escape}');
@@ -301,10 +332,10 @@ describe('AttackLogPanel', () => {
     );
 
     const nailStrikeButton = screen.getByRole('button', { name: /nail strike/i });
-    const endFightButton = screen.getByRole('button', { name: /end fight/i });
+    const endFightButton = screen.getByRole('button', { name: /fight \(enter\)/i });
     const resetButton = screen.getByRole('button', { name: /quick reset/i });
 
-    expect(endFightButton).toBeDisabled();
+    expect(endFightButton).not.toBeDisabled();
 
     await user.click(nailStrikeButton);
     expect(endFightButton).not.toBeDisabled();
@@ -318,7 +349,7 @@ describe('AttackLogPanel', () => {
     ).toBeInTheDocument();
 
     await user.click(resetButton);
-    expect(endFightButton).toBeDisabled();
+    expect(endFightButton).not.toBeDisabled();
 
     await user.click(nailStrikeButton);
     await user.keyboard('{Enter}');

--- a/src/features/attack-log/useAttackDefinitions.test.ts
+++ b/src/features/attack-log/useAttackDefinitions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { nailUpgrades, spells } from '../../data';
 import type { FightState } from '../fight-state/FightStateContext';
+import { createInitialState } from '../fight-state/fightReducer';
 import {
   FURY_MULTIPLIER,
   KEY_SEQUENCE,
@@ -16,22 +17,7 @@ const DEFAULT_SPELL_LEVELS = Object.fromEntries(
 ) as FightState['build']['spellLevels'];
 
 const createFightState = (overrides: Partial<FightState> = {}): FightState => {
-  const baseState: FightState = {
-    selectedBossId: 'false-knight__standard',
-    customTargetHp: 0,
-    build: {
-      nailUpgradeId: 'old-nail',
-      activeCharmIds: [],
-      spellLevels: { ...DEFAULT_SPELL_LEVELS },
-    },
-    damageLog: [],
-    redoStack: [],
-    activeSequenceId: null,
-    sequenceIndex: 0,
-    sequenceLogs: {},
-    sequenceRedoStacks: {},
-    sequenceConditions: {},
-  };
+  const baseState = createInitialState();
 
   return {
     ...baseState,

--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -25,7 +25,7 @@ describe('FightStateProvider persistence', () => {
 
   it('hydrates state from localStorage when data is available', () => {
     const persistedState = {
-      version: 3,
+      version: 4,
       state: {
         selectedBossId: CUSTOM_BOSS_ID,
         customTargetHp: 3333.7,
@@ -114,7 +114,7 @@ describe('FightStateProvider persistence', () => {
         version: number;
         state: { selectedBossId: string; customTargetHp: number };
       };
-      expect(parsed.version).toBe(3);
+      expect(parsed.version).toBe(4);
       expect(parsed.state.selectedBossId).toBe(CUSTOM_BOSS_ID);
       expect(parsed.state.customTargetHp).toBe(4321);
     });

--- a/src/features/fight-state/fightReducer.test.ts
+++ b/src/features/fight-state/fightReducer.test.ts
@@ -111,6 +111,22 @@ describe('fightReducer fight completion tracking', () => {
     expect(resumed.fightEndTimestamp).toBeNull();
     expect(resumed.fightManuallyEnded).toBe(false);
   });
+
+  it('supports manually starting fights without logging attacks', () => {
+    const state = createInitialState();
+
+    const started = fightReducer(state, { type: 'startFight', timestamp: 1_000 });
+
+    expect(started.fightStartTimestamp).toBe(1_000);
+    expect(started.fightManuallyStarted).toBe(true);
+    expect(started.fightEndTimestamp).toBeNull();
+    expect(started.fightManuallyEnded).toBe(false);
+
+    const ended = fightReducer(started, { type: 'endFight', timestamp: 2_000 });
+
+    expect(ended.fightEndTimestamp).toBe(2_000);
+    expect(ended.fightManuallyEnded).toBe(true);
+  });
 });
 
 describe('fightReducer sequence management', () => {
@@ -165,6 +181,8 @@ describe('fightReducer sequence management', () => {
     expect(reset.sequenceIndex).toBe(0);
     expect(reset.damageLog).toHaveLength(0);
     expect(reset.redoStack).toHaveLength(0);
+    expect(reset.fightStartTimestamp).toBeNull();
+    expect(reset.fightManuallyStarted).toBe(false);
     expect(reset.fightEndTimestamp).toBeNull();
     expect(reset.fightManuallyEnded).toBe(false);
     expect(reset.selectedBossId).toBe(firstStage.target.id);
@@ -184,6 +202,16 @@ describe('fightReducer sequence management', () => {
     ).toBe(false);
     expect(
       Object.keys(reset.sequenceManualEndFlags).some((key) =>
+        key.startsWith(sequencePrefix),
+      ),
+    ).toBe(false);
+    expect(
+      Object.keys(reset.sequenceFightStartTimestamps).some((key) =>
+        key.startsWith(sequencePrefix),
+      ),
+    ).toBe(false);
+    expect(
+      Object.keys(reset.sequenceManualStartFlags).some((key) =>
         key.startsWith(sequencePrefix),
       ),
     ).toBe(false);

--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -180,7 +180,7 @@ describe('fight-state persistence', () => {
     const fallback = ensureSequenceState(ensureSpellLevels(createInitialState()));
 
     const persisted = {
-      version: 3,
+      version: 4,
       state: {
         selectedBossId: CUSTOM_BOSS_ID,
         customTargetHp: 4242,
@@ -241,7 +241,7 @@ describe('fight-state persistence', () => {
     }
 
     const parsed = JSON.parse(stored) as { version: number; state: unknown };
-    expect(parsed.version).toBe(3);
+    expect(parsed.version).toBe(4);
     expect(parsed.state).toBeTruthy();
   });
 

--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -14,7 +14,7 @@ import type { NailArtId } from '../attack-log/attackData';
 const isNailArtId = (id: string): id is NailArtId => NAIL_ART_IDS.has(id as NailArtId);
 
 export const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
-export const STORAGE_VERSION = 3;
+export const STORAGE_VERSION = 4;
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -302,6 +302,14 @@ export const mergePersistedState = (
     persisted.sequenceConditions,
     fallback.sequenceConditions,
   );
+  const fightStartTimestamp = sanitizeOptionalTimestamp(
+    persisted.fightStartTimestamp,
+    fallback.fightStartTimestamp,
+  );
+  const fightManuallyStarted =
+    typeof persisted.fightManuallyStarted === 'boolean'
+      ? persisted.fightManuallyStarted
+      : fallback.fightManuallyStarted;
   const fightEndTimestamp = sanitizeOptionalTimestamp(
     persisted.fightEndTimestamp,
     fallback.fightEndTimestamp,
@@ -310,6 +318,14 @@ export const mergePersistedState = (
     typeof persisted.fightManuallyEnded === 'boolean'
       ? persisted.fightManuallyEnded
       : fallback.fightManuallyEnded;
+  const sequenceFightStartTimestamps = sanitizeSequenceTimestampMap(
+    persisted.sequenceFightStartTimestamps,
+    fallback.sequenceFightStartTimestamps,
+  );
+  const sequenceManualStartFlags = sanitizeBooleanRecord(
+    persisted.sequenceManualStartFlags,
+    fallback.sequenceManualStartFlags,
+  );
   const sequenceFightEndTimestamps = sanitizeSequenceTimestampMap(
     persisted.sequenceFightEndTimestamps,
     fallback.sequenceFightEndTimestamps,
@@ -336,8 +352,12 @@ export const mergePersistedState = (
       sequenceLogs,
       sequenceRedoStacks,
       sequenceConditions,
+      fightStartTimestamp,
+      fightManuallyStarted,
       fightEndTimestamp,
       fightManuallyEnded,
+      sequenceFightStartTimestamps,
+      sequenceManualStartFlags,
       sequenceFightEndTimestamps,
       sequenceManualEndFlags,
     }),

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
-const STORAGE_VERSION = 3;
+const STORAGE_VERSION = 4;
 type SpellLevel = 'none' | 'base' | 'upgrade';
 
 const numberFormatter = new Intl.NumberFormat('en-US');


### PR DESCRIPTION
## Summary
- allow the attack log's Enter shortcut and button to start a fight before any attacks are logged
- extend fight state to track manual fight starts across sequences and persistence
- add unit coverage for the new start behaviour

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d87ea356c4832faa7db00937548d1e