### PR TITLE
feat: add global help modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
 - **Your Knight's build:** Combine nail upgrades, spell levels, and charms—including retaliatory vines, minions, and spell conversions—to instantly see tuned damage presets.
 - **Boss presets & custom targets:** Swap between Hallownest's fiercest foes, Godhome variants (Attuned, Ascended, Radiant), or set a custom HP pool for practice sessions.
 - **Attack grid mastery:** Log nail strikes, spells, and charm effects with undo/redo support. Each button shows how many more hits of that move would finish the fight.
+- **Built-in guidance:** Open the header Help modal for a walkthrough of encounter setup, logging controls, shortcuts, and persistence tips.
 
 ### For the Analyst 📊
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import {
   FightStateProvider,
   useFightDerivedStats,
 } from '../features/fight-state/FightStateContext';
+import { HelpModal } from '../features/help/HelpModal';
 
 const formatNumber = (value: number) => value.toLocaleString();
 
@@ -218,6 +219,7 @@ type HeaderBarProps = {
   readonly arenaLabel: string | null;
   readonly onToggleSetup: () => void;
   readonly onOpenLoadout: () => void;
+  readonly onOpenHelp: () => void;
   readonly isSetupOpen: boolean;
   readonly stageLabel: string | null;
   readonly stageProgress: { current: number; total: number } | null;
@@ -234,6 +236,7 @@ const HeaderBar: FC<HeaderBarProps> = ({
   arenaLabel,
   onToggleSetup,
   onOpenLoadout,
+  onOpenHelp,
   isSetupOpen,
   stageLabel,
   stageProgress,
@@ -263,6 +266,10 @@ const HeaderBar: FC<HeaderBarProps> = ({
         <button type="button" className="hud-actions__button" onClick={onOpenLoadout}>
           <span aria-hidden="true">👤</span>
           <span className="hud-actions__label">Player loadout</span>
+        </button>
+        <button type="button" className="hud-actions__button" onClick={onOpenHelp}>
+          <span aria-hidden="true">❓</span>
+          <span className="hud-actions__label">Help</span>
         </button>
       </div>
     </div>
@@ -601,6 +608,7 @@ const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
 const AppContent: FC = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isSetupOpen, setSetupOpen] = useState(false);
+  const [isHelpOpen, setHelpOpen] = useState(false);
 
   const {
     bosses,
@@ -721,6 +729,7 @@ const AppContent: FC = () => {
         arenaLabel={arenaLabel}
         onToggleSetup={() => setSetupOpen((open) => !open)}
         onOpenLoadout={() => setModalOpen(true)}
+        onOpenHelp={() => setHelpOpen(true)}
         isSetupOpen={isSetupOpen}
         stageLabel={stageLabel}
         stageProgress={stageProgress}
@@ -760,10 +769,6 @@ const AppContent: FC = () => {
         >
           <div className="app-panel__header">
             <h2 id="attack-log-heading">Attack Log</h2>
-            <p className="app-panel__description">
-              Record each strike to reduce the boss health target. Buttons support
-              keyboard shortcuts for fast practice reps.
-            </p>
           </div>
           <div className="app-panel__body">
             <AttackLogPanel />
@@ -775,9 +780,6 @@ const AppContent: FC = () => {
         >
           <div className="app-panel__header">
             <h2 id="combat-stats-heading">Combat Overview</h2>
-            <p className="app-panel__description">
-              Track your progress and efficiency throughout the encounter.
-            </p>
           </div>
           <div className="app-panel__body">
             <CombatStatsPanel />
@@ -786,6 +788,7 @@ const AppContent: FC = () => {
       </main>
 
       <PlayerConfigModal isOpen={isModalOpen} onClose={() => setModalOpen(false)} />
+      <HelpModal isOpen={isHelpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 };

--- a/src/features/help/HelpModal.tsx
+++ b/src/features/help/HelpModal.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef, type FC } from 'react';
+
+type HelpModalProps = {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+};
+
+const HelpModalContent: FC<Pick<HelpModalProps, 'onClose'>> = ({ onClose }) => {
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    queueMicrotask(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="app-help-title"
+    >
+      <button
+        type="button"
+        className="modal__backdrop"
+        aria-label="Close dialog"
+        onClick={onClose}
+      />
+      <div className="modal__content">
+        <header className="modal__header">
+          <div>
+            <h2 id="app-help-title" className="modal__title">
+              App help
+            </h2>
+            <p className="modal__subtitle">
+              Learn how to practice encounters, log attacks, and interpret performance
+              metrics.
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="modal__close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </header>
+        <div className="modal__body">
+          <section
+            className="modal-section"
+            aria-labelledby="help-getting-started-heading"
+          >
+            <div className="modal-section__header">
+              <h3 id="help-getting-started-heading">Getting started</h3>
+            </div>
+            <p className="modal-section__description">
+              Use <strong>Change encounter</strong> to pick a boss, version, and arena.
+              For custom practice scenarios, choose the Custom option and provide an HP
+              target. The selected encounter drives the numbers shown throughout the
+              tracker.
+            </p>
+          </section>
+
+          <section className="modal-section" aria-labelledby="help-attack-log-heading">
+            <div className="modal-section__header">
+              <h3 id="help-attack-log-heading">Logging attacks</h3>
+            </div>
+            <p className="modal-section__description">
+              The <strong>Attack Log</strong> lists every strike you record. Click the
+              attack buttons or press their keyboard shortcuts to subtract damage and keep
+              the log in sync with your practice run. Hover each button to see its
+              shortcut and damage value.
+            </p>
+            <p>
+              Made a mistake? Remove the most recent entry from the log to restore the
+              boss HP and associated metrics.
+            </p>
+          </section>
+
+          <section
+            className="modal-section"
+            aria-labelledby="help-combat-overview-heading"
+          >
+            <div className="modal-section__header">
+              <h3 id="help-combat-overview-heading">Understanding the Combat Overview</h3>
+            </div>
+            <p className="modal-section__description">
+              The <strong>Combat Overview</strong> summarizes progress, including total
+              damage, average DPS, fight duration, stagger tracking, and charm effects.
+              Watch these indicators to evaluate the consistency of your attempts.
+            </p>
+          </section>
+
+          <section className="modal-section" aria-labelledby="help-loadout-heading">
+            <div className="modal-section__header">
+              <h3 id="help-loadout-heading">Player loadout and advanced setup</h3>
+            </div>
+            <p className="modal-section__description">
+              Open <strong>Player loadout</strong> to configure nail upgrades, spells, and
+              charms. Presets offer quick starting points, and you can toggle individual
+              charms to match your build. The tracker automatically adjusts damage values
+              and charm effects based on your selection.
+            </p>
+            <p>
+              Need stage-specific practice? Expand the encounter setup drawer to select
+              sequences, control stage progression, and enable conditional modifiers.
+            </p>
+          </section>
+
+          <section className="modal-section" aria-labelledby="help-shortcuts-heading">
+            <div className="modal-section__header">
+              <h3 id="help-shortcuts-heading">Keyboard shortcuts</h3>
+            </div>
+            <p className="modal-section__description">
+              Attack buttons support dedicated shortcuts for rapid practice reps. Use the
+              bracket keys <kbd>[</kbd> and <kbd>]</kbd> to move between sequence stages
+              when available. The Escape key closes any open modal.
+            </p>
+          </section>
+
+          <section className="modal-section" aria-labelledby="help-progress-heading">
+            <div className="modal-section__header">
+              <h3 id="help-progress-heading">Saving progress</h3>
+            </div>
+            <p className="modal-section__description">
+              Your encounter, loadout, and attack history persist automatically in the
+              browser. Reload the page or return later to continue from where you left
+              off.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const HelpModal: FC<HelpModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return <HelpModalContent onClose={onClose} />;
+};

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -200,9 +200,22 @@ test.describe('Landing page', () => {
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Change Encounter' })).toBeVisible();
     await expect(page.getByRole('button', { name: /Player loadout/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Help' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Attack Log' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Combat Overview' })).toBeVisible();
     await expect(page.getByRole('progressbar', { name: 'Boss HP' })).toBeVisible();
+  });
+
+  test('displays application help modal', async ({ page }) => {
+    await page.getByRole('button', { name: 'Help' }).click();
+
+    const helpDialog = page.getByRole('dialog', { name: 'App help' });
+    await expect(helpDialog).toBeVisible();
+    await expect(
+      helpDialog.getByRole('heading', { name: 'Player loadout and advanced setup' }),
+    ).toBeVisible();
+    await helpDialog.getByRole('button', { name: 'Close', exact: true }).click();
+    await expect(helpDialog).not.toBeVisible();
   });
 
   test('restores build configuration and logs after a reload', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a help button to the header and surface a detailed in-app help modal
- remove redundant introductory copy from the attack log and combat overview panels
- document the new help overlay and extend the landing Playwright coverage

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:e2e` *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d890f09128832fb4f614201b78c097