### PR TITLE
fix: restore strict eslint enforcement

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,13 +85,14 @@ export default [
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-confusing-void-expression': 'off',
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
-      '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+          allowNumber: true,
+        },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "20",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^8.44.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,19 @@
+import { env } from 'node:process';
+
 import { defineConfig, devices } from '@playwright/test';
+
+const isCI = env.CI === 'true' || env.CI === '1';
+const usePreview =
+  env.PLAYWRIGHT_USE_PREVIEW === 'true' || env.PLAYWRIGHT_USE_PREVIEW === '1';
 
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 60_000,
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 2 : undefined,
+  reporter: isCI
     ? [['github'], ['html', { open: 'never' }]]
     : [['html', { open: 'never' }]],
   use: {
@@ -17,11 +23,11 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: process.env.PLAYWRIGHT_USE_PREVIEW
+    command: usePreview
       ? 'pnpm preview --host 127.0.0.1 --port 4173 --strictPort'
       : 'pnpm dev --host 127.0.0.1 --port 4173 --strictPort',
     url: 'http://127.0.0.1:4173',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     stdout: 'pipe',
   },
   projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: '20'
+        version: 20.19.17
       '@types/react':
         specifier: ^19.1.13
         version: 19.1.13
@@ -44,10 +47,10 @@ importers:
         version: 8.44.1(eslint@9.36.0)(typescript@5.9.2)
       '@vitejs/plugin-react-swc':
         specifier: ^4.1.0
-        version: 4.1.0(vite@7.1.7)
+        version: 4.1.0(vite@7.1.7(@types/node@20.19.17))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(jsdom@27.0.0(postcss@8.5.6)))
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
         specifier: ^9.36.0
         version: 9.36.0
@@ -92,10 +95,10 @@ importers:
         version: 5.9.2
       vite:
         specifier: ^7.1.7
-        version: 7.1.7
+        version: 7.1.7(@types/node@20.19.17)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(jsdom@27.0.0(postcss@8.5.6))
+        version: 3.2.4(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6))
 
 packages:
 
@@ -697,6 +700,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.17':
+    resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
 
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
@@ -2394,6 +2400,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3015,6 +3024,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@20.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/react-dom@19.1.9(@types/react@19.1.13)':
     dependencies:
       '@types/react': 19.1.13
@@ -3116,15 +3129,15 @@ snapshots:
       '@typescript-eslint/types': 8.44.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-swc@4.1.0(vite@7.1.7)':
+  '@vitejs/plugin-react-swc@4.1.0(vite@7.1.7(@types/node@20.19.17))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.35
       '@swc/core': 1.13.5
-      vite: 7.1.7
+      vite: 7.1.7(@types/node@20.19.17)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(jsdom@27.0.0(postcss@8.5.6)))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3139,7 +3152,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(jsdom@27.0.0(postcss@8.5.6))
+      vitest: 3.2.4(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -3151,13 +3164,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.7)':
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@20.19.17))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.7
+      vite: 7.1.7(@types/node@20.19.17)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5050,6 +5063,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@6.21.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -5061,13 +5076,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(@types/node@20.19.17):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.7
+      vite: 7.1.7(@types/node@20.19.17)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5082,7 +5097,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.7:
+  vite@7.1.7(@types/node@20.19.17):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5091,13 +5106,14 @@ snapshots:
       rollup: 4.52.2
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 20.19.17
       fsevents: 2.3.3
 
-  vitest@3.2.4(jsdom@27.0.0(postcss@8.5.6)):
+  vitest@3.2.4(@types/node@20.19.17)(jsdom@27.0.0(postcss@8.5.6)):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.7)
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@20.19.17))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5115,10 +5131,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.7
-      vite-node: 3.2.4
+      vite: 7.1.7(@types/node@20.19.17)
+      vite-node: 3.2.4(@types/node@20.19.17)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 20.19.17
       jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -379,11 +379,11 @@ const TargetSelector: FC<TargetSelectorProps> = ({
         className="target-selector__tray"
         hidden={!isOptionsOpen}
       >
-        {selectedBoss && selectedBossId !== CUSTOM_BOSS_ID ? (
+        {selectedBoss && selectedBossId !== CUSTOM_BOSS_ID && selectedTarget ? (
           <label className="target-selector__field">
             <span className="target-selector__field-label">Boss version</span>
             <select
-              value={selectedTarget?.id ?? selectedBoss.versions[0]?.targetId ?? ''}
+              value={selectedTarget.id}
               onChange={(event) => onBossVersionChange(event.target.value)}
             >
               {selectedBoss.versions.map((version) => (
@@ -578,7 +578,7 @@ const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
         <h4 className="sequence-conditions__title">Sequence conditions</h4>
         <div className="sequence-conditions__grid">
           {activeSequence.conditions.map((condition) => {
-            const isEnabled = sequenceConditionValues[condition.id] ?? false;
+            const isEnabled = sequenceConditionValues[condition.id];
             return (
               <label key={condition.id} className="sequence-conditions__option">
                 <input
@@ -718,7 +718,7 @@ const AppContent: FC = () => {
         total: sequenceEntries.length,
       }
     : null;
-  const stageLabel = currentSequenceEntry?.target.bossName ?? null;
+  const stageLabel = currentSequenceEntry ? currentSequenceEntry.target.bossName : null;
 
   return (
     <div className="app-shell">

--- a/src/features/attack-log/useAttackDefinitions.test.ts
+++ b/src/features/attack-log/useAttackDefinitions.test.ts
@@ -97,10 +97,11 @@ describe('useAttackDefinitions helpers', () => {
   });
 
   it('omits spells that are not yet acquired', () => {
-    const [firstSpell] = spells;
-    if (!firstSpell) {
+    if (spells.length === 0) {
       throw new Error('Expected at least one spell fixture');
     }
+
+    const [firstSpell] = spells;
 
     const state = createFightState({
       build: {

--- a/src/features/attack-log/useAttackDefinitions.ts
+++ b/src/features/attack-log/useAttackDefinitions.ts
@@ -115,15 +115,22 @@ const getVariantDamage = (variant: (typeof spells)[number]['base']) => {
 };
 
 export const buildAttackGroups = (build: FightState['build']): AttackGroup[] => {
+  if (nailUpgrades.length === 0) {
+    throw new Error('Nail upgrade data is unavailable.');
+  }
+
+  const fallbackNailUpgrade = nailUpgrades[0];
+
   const nailUpgrade =
-    nailUpgrades.find((upgrade) => upgrade.id === build.nailUpgradeId) ?? nailUpgrades[0];
+    nailUpgrades.find((upgrade) => upgrade.id === build.nailUpgradeId) ??
+    fallbackNailUpgrade;
   const hasStrength = hasStrengthCharm(build.activeCharmIds);
   const hasFury = build.activeCharmIds.includes('fury-of-the-fallen');
   const hasShamanStone = build.activeCharmIds.includes('shaman-stone');
   const hasSpellTwister = build.activeCharmIds.includes('spell-twister');
   const hasFlukenest = build.activeCharmIds.includes('flukenest');
 
-  const baseNailDamage = nailUpgrade?.damage ?? 0;
+  const baseNailDamage = nailUpgrade.damage;
   const strengthMultiplier = hasStrength ? 1.5 : 1;
   const nailDamageExact = baseNailDamage * strengthMultiplier;
   const nailDamage = Math.round(nailDamageExact);
@@ -171,7 +178,7 @@ export const buildAttackGroups = (build: FightState['build']): AttackGroup[] => 
   const spellAttacks: AttackDefinition[] = [];
 
   for (const spell of spells) {
-    const level = build.spellLevels[spell.id] ?? 'base';
+    const level = build.spellLevels[spell.id];
     if (level === 'none') {
       continue;
     }

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -146,7 +146,8 @@ export const useBuildConfiguration = () => {
     ? Math.min(Math.max(sequenceIndex, 0), sequenceEntries.length - 1)
     : 0;
 
-  const currentSequenceEntry = sequenceEntries[cappedSequenceIndex];
+  const currentSequenceEntry =
+    sequenceEntries.length > 0 ? sequenceEntries[cappedSequenceIndex] : undefined;
   const isSequenceActive = Boolean(activeSequence);
   const hasPreviousSequenceStage = isSequenceActive && cappedSequenceIndex > 0;
   const hasNextSequenceStage =

--- a/src/features/combat-stats/CombatStatsPanel.test.tsx
+++ b/src/features/combat-stats/CombatStatsPanel.test.tsx
@@ -29,7 +29,7 @@ vi.mock('./Sparkline', () => ({
     const record: SparklineRecord = {
       length: data.length,
       first: data[0],
-      last: data.at(-1),
+      last: data.length > 0 ? data[data.length - 1] : undefined,
       valueDomain,
     };
 

--- a/src/features/combat-stats/CombatStatsPanel.tsx
+++ b/src/features/combat-stats/CombatStatsPanel.tsx
@@ -98,9 +98,10 @@ const buildDpsBucketSeries = (timeline: TimelinePoint[]): SparklinePoint[] => {
 
     while (currentBucketIndex < pointBucketIndex) {
       const bucketDurationSeconds = 1;
+      const bucketAverage = bucketDamage / bucketDurationSeconds;
       series.push({
         time: (currentBucketIndex + 1) * 1000,
-        value: bucketDurationSeconds > 0 ? bucketDamage / bucketDurationSeconds : 0,
+        value: bucketAverage,
       });
       currentBucketIndex += 1;
       bucketStart = currentBucketIndex * 1000;
@@ -119,7 +120,7 @@ const buildDpsBucketSeries = (timeline: TimelinePoint[]): SparklinePoint[] => {
     const bucketDurationSeconds = Math.min(elapsedInBucket, 1000) / 1000;
     series.push({
       time: point.time,
-      value: bucketDurationSeconds > 0 ? bucketDamage / bucketDurationSeconds : 0,
+      value: bucketDamage / bucketDurationSeconds,
     });
   }
 
@@ -166,12 +167,16 @@ export const CombatStatsPanel: FC = () => {
     const elapsedSeconds = elapsed / 1000;
     const cumulativeDamage = lastPoint.cumulativeDamage;
 
+    if (elapsedSeconds <= 0) {
+      return null;
+    }
+
     return {
       time: elapsed,
       cumulativeDamage,
       remainingHp: Math.max(0, targetHp - cumulativeDamage),
       frameDamage: 0,
-      dps: elapsedSeconds > 0 ? cumulativeDamage / elapsedSeconds : 0,
+      dps: cumulativeDamage / elapsedSeconds,
     } satisfies TimelinePoint;
   }, [timeline, fightEndTimestamp, fightStartTimestamp, frameTimestamp, targetHp]);
 
@@ -180,7 +185,7 @@ export const CombatStatsPanel: FC = () => {
       return timeline;
     }
 
-    const lastPoint = timeline[timeline.length - 1];
+    const lastPoint = timeline.length > 0 ? timeline[timeline.length - 1] : undefined;
 
     if (
       lastPoint &&

--- a/src/features/fight-state/fightReducer.test.ts
+++ b/src/features/fight-state/fightReducer.test.ts
@@ -136,12 +136,11 @@ describe('fightReducer sequence management', () => {
     throw new Error('Expected pantheon-of-the-master sequence to be defined for tests');
   }
 
-  const firstStage = masterSequence.entries[0];
-  const secondStage = masterSequence.entries[1];
-
-  if (!firstStage || !secondStage) {
+  if (masterSequence.entries.length < 2) {
     throw new Error('Expected pantheon-of-the-master sequence to have multiple stages');
   }
+
+  const [firstStage, secondStage] = masterSequence.entries;
 
   it('clears progress across all stages when resetting the sequence', () => {
     let state = createInitialState();

--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -375,7 +375,7 @@ export const restorePersistedState = (fallback: FightState): FightState => {
       return fallback;
     }
 
-    const parsed = JSON.parse(serialized);
+    const parsed: unknown = JSON.parse(serialized);
     if (!isRecord(parsed)) {
       return fallback;
     }


### PR DESCRIPTION
## Summary
- re-enable strict @typescript-eslint rules while allowing numeric template interpolation
- harden fight-state state management and persistence logic to operate without unsafe assumptions and update tests accordingly
- tighten environment, data, and component code paths to avoid unsafe access and add Node.js type definitions for tooling

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d895d450e0832fb446449b6cec8457