### PR TITLE
chore: extend react linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import prettierPlugin from 'eslint-plugin-prettier';
+import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import prettierConfig from 'eslint-config-prettier';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -51,6 +52,7 @@ const basePlugins = {
   react: reactPlugin,
   'react-hooks': reactHooksPlugin,
   'jsx-a11y': jsxA11yPlugin,
+  'react-refresh': reactRefreshPlugin,
   prettier: prettierPlugin,
 };
 
@@ -82,6 +84,23 @@ export default [
       ...prettierRecommendedRules,
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
+      'react/jsx-boolean-value': ['error', 'never'],
+      'react/self-closing-comp': ['error'],
+      'react-refresh/only-export-components': [
+        'warn',
+        {
+          allowConstantExport: true,
+          allowExportNames: [
+            'CUSTOM_BOSS_ID',
+            'DerivedStats',
+            'useFightActions',
+            'useFightStateSelector',
+            'useFightState',
+            'useFightDerivedStats',
+            'hasStrengthCharm',
+          ],
+        },
+      ],
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-confusing-void-expression': 'off',
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.22",
     "jsdom": "^27.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.36.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.22
+        version: 0.4.22(eslint@9.36.0)
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
@@ -1215,6 +1218,11 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.22:
+    resolution: {integrity: sha512-atkAG6QaJMGoTLc4MDAP+rqZcfwQuTIh2IqHWFLy2TEjxr0MOK+5BSG4RzL2564AAPpZkDRsZXAUz68kjnU6Ug==}
+    peerDependencies:
+      eslint: '>=8.40'
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -3706,6 +3714,10 @@ snapshots:
       eslint-config-prettier: 10.1.8(eslint@9.36.0)
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.36.0):
+    dependencies:
+      eslint: 9.36.0
+
+  eslint-plugin-react-refresh@0.4.22(eslint@9.36.0):
     dependencies:
       eslint: 9.36.0
 

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -38,7 +38,7 @@ export type {
 export { CUSTOM_BOSS_ID } from './fightReducer';
 import { persistStateToStorage, restorePersistedState } from './persistence';
 
-export interface DerivedStats {
+export type DerivedStats = {
   targetHp: number;
   totalDamage: number;
   remainingHp: number;
@@ -53,7 +53,7 @@ export interface DerivedStats {
   isFightInProgress: boolean;
   isFightComplete: boolean;
   frameTimestamp: number;
-}
+};
 
 type FightActions = {
   selectBoss: (bossId: string) => void;


### PR DESCRIPTION
## Summary
- add React lint rules for boolean prop shorthand and self-closing components
- integrate eslint-plugin-react-refresh with Vite-specific fast refresh safeguards
- adjust DerivedStats type export to avoid false positives from the new lint rule

## Testing
- pnpm lint:js
- pnpm lint:css
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d89f18d2d0832fb01c1f82d19b3812