### PR TITLE
chore: streamline lint and ts configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ on:
       - 'src/**'
       - 'tests/**'
       - '.github/workflows/ci.yml'
+      - 'eslint.config.mjs'
+      - 'playwright.config.ts'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'tsconfig*.json'
 
 jobs:
   lint:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,8 +32,6 @@ const disableTypeCheckedRules =
 const prettierRecommendedRules = {
   ...prettierConfig.rules,
   'prettier/prettier': 'error',
-  'arrow-body-style': 'off',
-  'prefer-arrow-callback': 'off',
 };
 
 const baseLanguageOptions = {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
-import { env } from 'node:process';
+import process from 'node:process';
 
 import { defineConfig, devices } from '@playwright/test';
 
-const isCI = env.CI === 'true' || env.CI === '1';
-const usePreview =
-  env.PLAYWRIGHT_USE_PREVIEW === 'true' || env.PLAYWRIGHT_USE_PREVIEW === '1';
+const { CI, PLAYWRIGHT_USE_PREVIEW } = process.env;
+
+const isCI = CI === 'true' || CI === '1';
+const usePreview = PLAYWRIGHT_USE_PREVIEW === 'true' || PLAYWRIGHT_USE_PREVIEW === '1';
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,10 @@
-import process from 'node:process';
-
 import { defineConfig, devices } from '@playwright/test';
 
-const { CI, PLAYWRIGHT_USE_PREVIEW } = process.env;
+const env = process.env as NodeJS.ProcessEnv;
 
-const isCI = CI === 'true' || CI === '1';
-const usePreview = PLAYWRIGHT_USE_PREVIEW === 'true' || PLAYWRIGHT_USE_PREVIEW === '1';
+const isCI = env.CI === 'true' || env.CI === '1';
+const usePreview =
+  env.PLAYWRIGHT_USE_PREVIEW === 'true' || env.PLAYWRIGHT_USE_PREVIEW === '1';
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
     "allowJs": false,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Summary
- remove redundant Prettier overrides for arrow function style rules now enforced by the formatter
- align the application TypeScript config with the React 19 JSX runtime expectations
- update the Playwright configuration to use typed process environment access under the stricter lint rules

## Testing
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d89f5c6848832fbef604ac07d93153