### PR TITLE
chore: automate screenshot generation

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   screenshot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,37 @@
+name: '📸 Screenshot'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  screenshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Create the screenshot
+        run: pnpm exec playwright test --project=chromium tests/e2e/screenshot.spec.ts
+
+      - name: Commit screenshot
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'docs: update demo screenshot'
+          file_pattern: 'docs/demo.png'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
 
 > ✨ Designed for co-pilots, commentators, and VOD reviewers—let a trusted spectator log hits live or replay the action later while you stay locked in on the battle.
 
-[![Demo of Hollow Knight Damage Tracker in action](https://placehold.co/1200x675/0b0b16/ffffff.png?text=Demo+GIF+Coming+Soon)](#)
+![A screenshot of the Hollow Knight Damage Tracker showing a mid-combat scenario against the Gruz Mother. The tracker displays the player's loadout, attack log, and real-time combat statistics.](docs/demo.png)
 
 **Live Demo:** [kabaka.github.io/hollow-knight-damage-tracker](https://kabaka.github.io/hollow-knight-damage-tracker/)
 

--- a/tests/e2e/screenshot.spec.ts
+++ b/tests/e2e/screenshot.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
+const STORAGE_VERSION = 4;
+
+const MID_COMBAT_STATE = {
+  selectedBossId: 'gruz-mother__radiant',
+  customTargetHp: 945,
+  build: {
+    nailUpgradeId: 'pure-nail',
+    activeCharmIds: [
+      'shaman-stone',
+      'quick-slash',
+      'unbreakable-strength',
+      'steady-body',
+    ],
+    spellLevels: {
+      'vengeful-spirit': 'upgrade',
+      'desolate-dive': 'upgrade',
+      'howling-wraiths': 'upgrade',
+    },
+    notchLimit: 11,
+  },
+  damageLog: [
+    {
+      id: 'nail-strike-1',
+      label: 'Nail Strike',
+      damage: 32,
+      category: 'nail',
+      timestamp: 1727492581000,
+    },
+    {
+      id: 'nail-strike-2',
+      label: 'Nail Strike',
+      damage: 32,
+      category: 'nail',
+      timestamp: 1727492581500,
+    },
+    {
+      id: 'great-slash-1',
+      label: 'Great Slash',
+      damage: 80,
+      category: 'nail-art',
+      timestamp: 1727492582000,
+    },
+    {
+      id: 'shade-soul-1',
+      label: 'Shade Soul',
+      damage: 40,
+      category: 'spell',
+      timestamp: 1727492582500,
+    },
+  ],
+  redoStack: [],
+};
+
+test('generate a mid-combat screenshot', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(
+    ([storageKey, version, state]) => {
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          version,
+          state,
+        }),
+      );
+    },
+    [STORAGE_KEY, STORAGE_VERSION, MID_COMBAT_STATE],
+  );
+
+  await page.reload();
+  await expect(
+    page.getByRole('heading', { name: 'Hollow Knight Damage Tracker' }),
+  ).toBeVisible();
+
+  await page.screenshot({ path: 'docs/demo.png', fullPage: true });
+});


### PR DESCRIPTION
## Summary
- add a Playwright end-to-end spec that seeds a mid-combat fight state and captures `docs/demo.png`
- wire up a GitHub Actions workflow that regenerates the screenshot on pushes to `main`
- update the README hero section to embed the generated screenshot asset

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit
- pnpm exec playwright test --project=chromium tests/e2e/screenshot.spec.ts *(fails locally because Playwright browsers are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a9707410832f9c4c6b1e5d2d60eb