### PR TITLE
Use Playwright container for screenshot workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,12 @@ jobs:
             playwright-report/
             test-results/
           if-no-files-found: warn
+
+      - name: Upload landing page screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: landing-page-${{ matrix.browser }}-screenshot
+          path: |
+            test-results/**/initial-state-${{ matrix.browser }}.png
+          if-no-files-found: warn

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   screenshot:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.1-jammy
+    env:
+      HOME: /root
     permissions:
       contents: write
     steps:
@@ -25,9 +29,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
 
       - name: Create the screenshot
         run: pnpm exec playwright test --project=chromium tests/e2e/screenshot.spec.ts

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Create the screenshot
         run: pnpm exec playwright test --project=chromium tests/e2e/screenshot.spec.ts
 
+      - name: Upload screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-demo-screenshot
+          path: docs/demo.png
+
       - name: Commit screenshot
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,7 +56,7 @@ const basePlugins = {
 
 export default [
   {
-    ignores: ['dist/**'],
+    ignores: ['dist/**', 'playwright-report/**', 'test-results/**'],
   },
   js.configs.recommended,
   {


### PR DESCRIPTION
## Summary
- run the screenshot job inside the official Playwright container to avoid re-installing browsers
- drop the manual Playwright installation step while keeping the pnpm dependency install

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8b4b3c8d0832fa60e86e922547eb7