### PR TITLE
chore: mark screenshot workflow repo as safe directory

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,6 +40,9 @@ jobs:
           name: docs-demo-screenshot
           path: docs/demo.png
 
+      - name: Mark repository as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Commit screenshot
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
## Summary
- mark the GitHub workspace as a safe directory before running the auto-commit action in the screenshot workflow to avoid dubious ownership errors

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8b9ee570c832fb6e4b1ecfc297a83