### PR TITLE
fix: expand combat log viewport

### DIFF
--- a/src/features/combat-log/CombatLogPanel.tsx
+++ b/src/features/combat-log/CombatLogPanel.tsx
@@ -146,6 +146,11 @@ export const CombatLogPanel: FC = () => {
     const currentFight = currentFightRef.current;
 
     const hasTargetChanged = currentFight.targetId !== selectedBossId;
+    const isSequenceTransition =
+      activeSequenceId != null &&
+      (currentFight.sequenceId !== activeSequenceId ||
+        currentFight.sequenceIndex !== sequenceIndex ||
+        hasTargetChanged);
     if (hasTargetChanged) {
       currentFight.targetId = selectedBossId;
       currentFight.sequenceId = activeSequenceId;
@@ -207,11 +212,13 @@ export const CombatLogPanel: FC = () => {
       redoStack.length === 0 &&
       fightEndTimestamp == null
     ) {
-      nextEntries.push({
-        id: allocateEntryId('fight-reset'),
-        type: 'banner',
-        message: 'Fight reset',
-      });
+      if (!isSequenceTransition) {
+        nextEntries.push({
+          id: allocateEntryId('fight-reset'),
+          type: 'banner',
+          message: 'Fight reset',
+        });
+      }
       currentFight.startTimestamp = null;
       runningDamageRef.current = 0;
       targetHpRef.current = null;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1188,6 +1188,7 @@ h6 {
     inset 0 0 0 1px rgb(255 255 255 / 10%),
     var(--frame-etch);
   overflow: hidden;
+  min-height: 0;
 }
 
 .app-panel::before {
@@ -1255,6 +1256,8 @@ h6 {
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .app-panel--stats .app-panel__body {
@@ -1275,7 +1278,8 @@ h6 {
 .combat-log {
   position: relative;
   min-height: 220px;
-  max-height: clamp(220px, 48vh, 420px);
+  flex: 1 1 220px;
+  max-height: 100%;
   overflow-y: auto;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1335,6 +1335,11 @@ h6 {
   color: rgb(240 243 255 / 62%);
 }
 
+.combat-log__context {
+  display: block;
+  margin-top: 0.15rem;
+}
+
 .combat-log__placeholder {
   font-size: var(--font-size-body);
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- allow app panels to stretch their body content so interior sections can use the full column height
- let the combat log viewport flex with its container to remove excess padding while keeping scroll behavior

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8bcbba8f4832f9ea57a828df99b91