### PR TITLE
fix: stabilize stopwatch counters

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,9 @@
   font-weight: 400;
 
   --font-display: 'Cinzel', 'Times New Roman', serif;
+  --font-numeric:
+    'Source Sans 3', system-ui, -apple-system, 'BlinkMacSystemFont', 'Segoe UI',
+    sans-serif;
   --color-bg: #030612;
   --color-bg-deep: #000104;
   --color-surface: #0c1020;
@@ -693,7 +696,7 @@ h6 {
 }
 
 .hud-metrics__value-primary {
-  font-family: var(--font-display);
+  font-family: var(--font-numeric);
   font-size: var(--font-size-title);
   letter-spacing: 0.03em;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- add a dedicated numeric font stack for scoreboard metrics
- render stopwatch values with tabular numerals so elapsed and estimated times stay aligned

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8cbe3d2fc832f81f3c1bd9f7edb44