### PR TITLE
fix: keep modals within viewport on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1621,7 +1621,8 @@ h6 {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: clamp(1rem, 4vw, 2rem);
+  overflow-y: auto;
 }
 
 .modal__backdrop {
@@ -1654,6 +1655,12 @@ h6 {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+@supports (height: 100dvh) {
+  .modal__content {
+    max-height: min(90dvh, 900px);
+  }
 }
 
 .modal__content::before {


### PR DESCRIPTION
## Summary
- allow modal overlays to scroll and adjust padding so dialogs stay visible on small screens
- cap modal content height using dynamic viewport units to avoid overflow under mobile browser chrome

## Testing
- pnpm test:unit


------
https://chatgpt.com/codex/tasks/task_e_68d8e075083c832fa9f15afb5fefa212