### PR TITLE
feat: add mobile pinned boss status header

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -23,7 +23,9 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: /player loadout/i })).toBeVisible();
     const changeEncounter = screen.getByRole('button', { name: /change encounter/i });
     expect(changeEncounter).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getByRole('progressbar', { name: /boss hp/i })).toBeInTheDocument();
+    expect(
+      within(screen.getByRole('banner')).getByRole('progressbar', { name: /boss hp/i }),
+    ).toBeInTheDocument();
   });
 
   it('allows selecting a custom boss target and updating HP from the HUD', async () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -256,6 +256,45 @@ const TargetScoreboard: FC<TargetScoreboardProps> = ({
   );
 };
 
+type MobilePinnedHudProps = {
+  readonly derived: ReturnType<typeof useFightDerivedStats>;
+  readonly encounterName: string;
+};
+
+const MobilePinnedHud: FC<MobilePinnedHudProps> = ({ derived, encounterName }) => {
+  const { targetHp, remainingHp } = derived;
+  const percentRemaining = targetHp > 0 ? Math.max(0, remainingHp / targetHp) : 0;
+
+  return (
+    <div className="mobile-hud-sentinel">
+      <div className="mobile-hud" role="group" aria-label="Boss status">
+        <span className="mobile-hud__title" aria-live="polite">
+          {encounterName}
+        </span>
+        <div className="mobile-hud__health" role="group" aria-label="Boss HP">
+          <div
+            className="hud-health__track mobile-hud__track"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={targetHp}
+            aria-valuenow={remainingHp}
+            aria-label="Boss HP"
+          >
+            <div
+              className="hud-health__fill"
+              style={{ width: `${Math.round(percentRemaining * 100)}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <span className="mobile-hud__value">
+            {formatNumber(remainingHp)} / {formatNumber(targetHp)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 type HeaderBarProps = {
   readonly derived: ReturnType<typeof useFightDerivedStats>;
   readonly encounterName: string;
@@ -782,6 +821,7 @@ const AppContent: FC = () => {
         hasNextStage={hasNextSequenceStage}
         hasPreviousStage={hasPreviousSequenceStage}
       />
+      <MobilePinnedHud derived={derived} encounterName={encounterName} />
 
       <EncounterSetupPanel
         isOpen={isSetupOpen}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -678,6 +678,54 @@ h6 {
   min-width: 88px;
 }
 
+.mobile-hud-sentinel {
+  display: none;
+}
+
+.mobile-hud {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0 0 12px 12px;
+  background-color: rgb(9 14 27 / 92%);
+  box-shadow:
+    0 8px 18px rgb(0 0 0 / 55%),
+    inset 0 0 0 1px rgb(214 217 231 / 38%);
+}
+
+.mobile-hud__title {
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobile-hud__health {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mobile-hud__track {
+  width: 100%;
+  min-width: 0;
+  height: 0.38rem;
+  border-radius: 999px;
+  border: none;
+  box-shadow: none;
+}
+
+.mobile-hud__value {
+  font-family: var(--font-numeric);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
 .hud-metrics__label {
   font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
@@ -2378,6 +2426,30 @@ h6 {
 }
 
 @media (width <= 720px) {
+  .encounter-hud {
+    position: static;
+    top: auto;
+  }
+
+  .mobile-hud-sentinel {
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 15;
+  }
+
+  .mobile-hud {
+    backdrop-filter: blur(8px);
+  }
+
+  .mobile-hud__title {
+    font-size: 0.9rem;
+  }
+
+  .mobile-hud__value {
+    font-size: 0.76rem;
+  }
+
   .modal {
     padding: 1rem;
   }


### PR DESCRIPTION
## Summary
- add a mobile-only pinned boss status HUD with the encounter name and health meter
- tweak responsive styles to disable the large sticky header on small screens and style the compact HUD
- update the app smoke test to scope the boss health assertion to the main banner

## Testing
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8e38d3a70832fa368564da2be88b3