### PR TITLE
fix: prevent modal clipping on mobile viewports

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,7 @@ import {
   useFightDerivedStats,
 } from '../features/fight-state/FightStateContext';
 import { HelpModal } from '../features/help/HelpModal';
+import { useVisualViewportCssVars } from './useVisualViewportCssVars';
 
 const formatNumber = (value: number) => value.toLocaleString();
 
@@ -650,6 +651,8 @@ const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
 );
 
 const AppContent: FC = () => {
+  useVisualViewportCssVars();
+
   const [isModalOpen, setModalOpen] = useState(false);
   const [isSetupOpen, setSetupOpen] = useState(false);
   const [isHelpOpen, setHelpOpen] = useState(false);

--- a/src/app/useVisualViewportCssVars.test.tsx
+++ b/src/app/useVisualViewportCssVars.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useVisualViewportCssVars } from './useVisualViewportCssVars';
+
+declare global {
+  interface Window {
+    visualViewport?: VisualViewport;
+  }
+}
+
+type ListenerMap = Map<string, Set<EventListener>>;
+
+const createListenerMap = (): ListenerMap => new Map();
+
+const getViewportVar = (name: string) =>
+  document.documentElement.style.getPropertyValue(name).trim();
+
+const createMockVisualViewport = (listeners: ListenerMap) => {
+  let height = 540;
+  let offsetTop = 12;
+
+  const addEventListener = (type: string, listener: EventListener) => {
+    const entry = listeners.get(type) ?? new Set<EventListener>();
+    entry.add(listener);
+    listeners.set(type, entry);
+  };
+
+  const removeEventListener = (type: string, listener: EventListener) => {
+    const entry = listeners.get(type);
+    if (!entry) {
+      return;
+    }
+    entry.delete(listener);
+    if (entry.size === 0) {
+      listeners.delete(type);
+    }
+  };
+
+  return {
+    get height() {
+      return height;
+    },
+    set height(value: number) {
+      height = value;
+    },
+    get offsetTop() {
+      return offsetTop;
+    },
+    set offsetTop(value: number) {
+      offsetTop = value;
+    },
+    addEventListener,
+    removeEventListener,
+  } as unknown as VisualViewport;
+};
+
+describe('useVisualViewportCssVars', () => {
+  const originalInnerHeight = window.innerHeight;
+  const originalVisualViewport = window.visualViewport;
+  const listeners = createListenerMap();
+
+  beforeEach(() => {
+    listeners.clear();
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 812,
+    });
+
+    window.visualViewport = createMockVisualViewport(listeners);
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--visual-viewport-height');
+    document.documentElement.style.removeProperty('--visual-viewport-offset-top');
+    document.documentElement.style.removeProperty('--visual-viewport-offset-bottom');
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: originalInnerHeight,
+    });
+    window.visualViewport = originalVisualViewport;
+  });
+
+  it('applies CSS variables using the current visual viewport metrics', async () => {
+    const { unmount } = renderHook(() => useVisualViewportCssVars());
+
+    await waitFor(() => {
+      expect(getViewportVar('--visual-viewport-height')).toBe('540.00px');
+    });
+    expect(getViewportVar('--visual-viewport-offset-top')).toBe('12.00px');
+    expect(getViewportVar('--visual-viewport-offset-bottom')).toBe('260.00px');
+
+    unmount();
+  });
+
+  it('updates CSS variables when the visual viewport changes', async () => {
+    const { unmount } = renderHook(() => useVisualViewportCssVars());
+
+    const resizeListeners = listeners.get('resize');
+    expect(resizeListeners?.size).toBeGreaterThanOrEqual(1);
+
+    act(() => {
+      if (!window.visualViewport || !resizeListeners) {
+        throw new Error('Expected visualViewport listeners to exist');
+      }
+      window.visualViewport.height = 620;
+      window.visualViewport.offsetTop = 0;
+      resizeListeners.forEach((listener) => listener(new Event('resize')));
+    });
+
+    await waitFor(() => {
+      expect(getViewportVar('--visual-viewport-height')).toBe('620.00px');
+    });
+    expect(getViewportVar('--visual-viewport-offset-top')).toBe('0.00px');
+    expect(getViewportVar('--visual-viewport-offset-bottom')).toBe('192.00px');
+
+    unmount();
+  });
+});

--- a/src/app/useVisualViewportCssVars.ts
+++ b/src/app/useVisualViewportCssVars.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+
+const formatPx = (value: number) => `${Math.max(0, value).toFixed(2)}px`;
+
+const getLayoutViewportHeight = () => {
+  const docElement = document.documentElement;
+  const layoutHeightCandidates = [window.innerHeight, docElement.clientHeight];
+  return Math.max(...layoutHeightCandidates.filter(Number.isFinite));
+};
+
+const updateViewportCssVars = (
+  root: HTMLElement,
+  viewport: VisualViewport | undefined,
+) => {
+  const layoutHeight = getLayoutViewportHeight();
+  const visualHeight = viewport?.height ?? layoutHeight;
+  const offsetTop = viewport?.offsetTop ?? 0;
+  const offsetBottom = viewport
+    ? Math.max(0, layoutHeight - (viewport.height + viewport.offsetTop))
+    : 0;
+
+  root.style.setProperty('--visual-viewport-height', formatPx(visualHeight));
+  root.style.setProperty('--visual-viewport-offset-top', formatPx(offsetTop));
+  root.style.setProperty('--visual-viewport-offset-bottom', formatPx(offsetBottom));
+};
+
+export const useVisualViewportCssVars = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+
+    const viewport = window.visualViewport;
+    const handleChange = () =>
+      updateViewportCssVars(root, window.visualViewport ?? viewport);
+
+    updateViewportCssVars(root, viewport);
+
+    window.addEventListener('resize', handleChange);
+    window.addEventListener('orientationchange', handleChange);
+
+    viewport?.addEventListener('resize', handleChange);
+    viewport?.addEventListener('scroll', handleChange);
+
+    return () => {
+      window.removeEventListener('resize', handleChange);
+      window.removeEventListener('orientationchange', handleChange);
+      viewport?.removeEventListener('resize', handleChange);
+      viewport?.removeEventListener('scroll', handleChange);
+    };
+  }, []);
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -51,6 +51,9 @@
   --frame-highlight: inset 0 1px 0 rgb(255 255 255 / 16%);
   --frame-outline: 0 0 0 1px var(--color-border-soft);
   --frame-outline-strong: 0 0 0 1.5px rgb(214 217 231 / 55%);
+  --visual-viewport-height: 100vh;
+  --visual-viewport-offset-top: 0px;
+  --visual-viewport-offset-bottom: 0px;
   --shape-tablet: polygon(
     14px 0,
     calc(100% - 14px) 0,
@@ -72,6 +75,18 @@
 
   background-color: var(--color-bg);
   color: var(--color-text);
+}
+
+@supports (height: 100svh) {
+  :root {
+    --visual-viewport-height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --visual-viewport-height: 100dvh;
+  }
 }
 
 * {
@@ -1621,7 +1636,19 @@ h6 {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1rem, 4vw, 2rem);
+
+  --modal-padding-inline: clamp(1rem, 4vw, 2rem);
+  --modal-padding-block: clamp(1.5rem, 6vh, 3rem);
+  --modal-top-inset: calc(
+    env(safe-area-inset-top, 0px) + var(--visual-viewport-offset-top)
+  );
+  --modal-bottom-inset: calc(
+    env(safe-area-inset-bottom, 0px) + var(--visual-viewport-offset-bottom)
+  );
+
+  padding-inline: var(--modal-padding-inline);
+  padding-top: calc(var(--modal-padding-block) + var(--modal-top-inset));
+  padding-bottom: calc(var(--modal-padding-block) + var(--modal-bottom-inset));
   overflow-y: auto;
 }
 
@@ -1638,7 +1665,18 @@ h6 {
   position: relative;
   z-index: 1;
   width: min(100%, 980px);
-  max-height: min(90vh, 900px);
+
+  --modal-available-height-offset: calc(
+    var(--modal-padding-block) * 2 + var(--modal-top-inset) + var(--modal-bottom-inset)
+  );
+
+  max-height: min(
+    max(
+      calc(var(--visual-viewport-height) - var(--modal-available-height-offset)),
+      320px
+    ),
+    900px
+  );
   overflow-y: auto;
   clip-path: var(--shape-tablet);
   background-color: var(--color-surface);
@@ -1655,12 +1693,6 @@ h6 {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-}
-
-@supports (height: 100dvh) {
-  .modal__content {
-    max-height: min(90dvh, 900px);
-  }
 }
 
 .modal__content::before {
@@ -2379,11 +2411,8 @@ h6 {
 
 @media (width <= 720px) {
   .modal {
-    padding: 1rem;
-  }
-
-  .modal__content {
-    max-height: 100vh;
+    --modal-padding-inline: 1rem;
+    --modal-padding-block: clamp(1.5rem, 10vh, 3.5rem);
   }
 
   .charm-grid__row--offset {


### PR DESCRIPTION
## Summary
- adjust modal layout variables to respect safe-area insets and dynamic viewport height
- introduce a visual viewport hook that synchronizes CSS custom properties with runtime metrics
- add unit coverage around the viewport hook to guard against regressions

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8e5228b50832fa2826f4d31575e1e