### PR TITLE
Improve mobile attack grid layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2490,6 +2490,52 @@ h6 {
   .charm-grid__row--offset {
     margin-left: calc((var(--charm-size) + var(--charm-gap)) / 1.6);
   }
+
+  .button-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .button-grid__button {
+    padding: 0.65rem;
+    gap: 0.35rem;
+    border-radius: 12px;
+    clip-path: none;
+    background-image: none;
+    box-shadow: none;
+    text-shadow: none;
+  }
+
+  .button-grid__button::after {
+    display: none;
+  }
+
+  .button-grid__header {
+    align-items: center;
+  }
+
+  .button-grid__label {
+    font-size: 1rem;
+  }
+
+  .button-grid__hotkey,
+  .button-grid__description {
+    display: none;
+  }
+
+  .button-grid__meta {
+    font-size: 0.75rem;
+    gap: 0.25rem;
+  }
+
+  .button-grid__damage {
+    font-size: 1.1rem;
+  }
+
+  .button-grid__soul,
+  .button-grid__hits {
+    padding: 0.1rem 0.5rem;
+  }
 }
 
 @keyframes panel-shimmer-victory {


### PR DESCRIPTION
## Summary
- ensure the attack grid renders three buttons per row on small screens while simplifying the mobile button styling
- hide keyboard shortcut badges and effect descriptions on mobile to reduce vertical scroll

## Testing
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8ecef7810832f8725885db35587e8