### PR TITLE
fix: preserve loadout modal scroll position

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -104,6 +104,27 @@ describe('App', () => {
     expect(fragileStrengthButton).toBeDisabled();
   });
 
+  it('preserves the loadout modal scroll position while editing settings', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: /player loadout/i }));
+    const modal = await screen.findByRole('dialog', { name: /player loadout/i });
+    const modalBody = modal.querySelector('.modal__body') as HTMLElement | null;
+    if (!modalBody) {
+      throw new Error('Expected the modal body to be present');
+    }
+
+    modalBody.scrollTop = 200;
+
+    await user.selectOptions(
+      within(modal).getByLabelText(/nail upgrade/i),
+      'channelled-nail',
+    );
+
+    expect(modalBody.scrollTop).toBe(200);
+  });
+
   it('surfaces sequence conditions in the setup tray when selecting a pantheon', async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -95,6 +95,7 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
   } = useBuildConfiguration();
 
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const onCloseRef = useRef<PlayerConfigModalProps['onClose']>(onClose);
   const charmIconMap = useMemo(createCharmIconMap, []);
 
   const notchUsage = `${activeCharmCost}/${notchLimit}`;
@@ -120,13 +121,17 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
   );
 
   useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
       }
     };
 
@@ -139,7 +144,7 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
       document.body.style.overflow = previousOverflow;
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onClose]);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- keep the loadout modal from refocusing by caching the close handler in a ref so the escape listener remains stable
- add a regression test to ensure updating loadout controls does not reset the modal scroll position

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8ed176524832fb914503ee20f998d