### PR TITLE
feat: capture mobile marketing screenshot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Move screenshot to dist/docs
+      - name: Move screenshots to dist/docs
         run: |
           mkdir -p dist/docs
           mv artifacts/test-results/demo.png dist/docs/app.png
+          mv artifacts/test-results/mobile-app.png dist/docs/mobile-app.png
 
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -11,16 +11,21 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
 
 > ✨ Designed for co-pilots, commentators, and VOD reviewers—let a trusted spectator log hits live or replay the action later while you stay locked in on the battle.
 
-<picture>
-  <source
-    media="(max-width: 768px)"
-    srcset="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app.png"
-  />
+<div align="center">
   <img
     src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/app.png"
-    alt="Screenshots of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
+    alt="Desktop screenshot of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
+    style="max-width: 960px; width: 100%; height: auto;"
   />
-</picture>
+</div>
+
+<div align="center">
+  <img
+    src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app.png"
+    alt="Mobile screenshot of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
+    style="max-width: 480px; width: 100%; height: auto;"
+  />
+</div>
 
 **Live Demo:** [kabaka.github.io/hollow-knight-damage-tracker](https://kabaka.github.io/hollow-knight-damage-tracker/)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
 
 > ✨ Designed for co-pilots, commentators, and VOD reviewers—let a trusted spectator log hits live or replay the action later while you stay locked in on the battle.
 
-![A screenshot of the Hollow Knight Damage Tracker showing the combat loadout, attack log, and real-time combat statistics.](https://kabaka.github.io/hollow-knight-damage-tracker/docs/app.png)
+<picture>
+  <source
+    media="(max-width: 768px)"
+    srcset="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app.png"
+  />
+  <img
+    src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/app.png"
+    alt="Screenshots of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
+  />
+</picture>
 
 **Live Demo:** [kabaka.github.io/hollow-knight-damage-tracker](https://kabaka.github.io/hollow-knight-damage-tracker/)
 

--- a/tests/e2e/screenshot.spec.ts
+++ b/tests/e2e/screenshot.spec.ts
@@ -131,4 +131,19 @@ test('generate a mid-combat screenshot', async ({ page }) => {
   expect(remainingMinutes).toBeLessThan(10);
 
   await page.screenshot({ path: 'test-results/demo.png', fullPage: true });
+
+  await test.step('capture a mobile layout screenshot', async () => {
+    await page.setViewportSize({ width: 430, height: 932 });
+    await page.waitForTimeout(250);
+    await page.evaluate(() => window.scrollTo(0, 0));
+
+    await expect(
+      page.getByRole('region', { name: 'Encounter scoreboard' }),
+    ).toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/mobile-app.png',
+      fullPage: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- capture a second Playwright screenshot of the mid-combat demo using a mobile viewport and publish it alongside the desktop asset
- render the hero image in the README with a responsive `<picture>` element so mobile GitHub clients display the mobile capture

## Testing
- pnpm format:check
- pnpm test:e2e --project=chromium --reporter=list tests/e2e/screenshot.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8ffb60ae4832fbe69a61425a0aefd