### PR TITLE
refactor: centralize formatting helpers

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,38 +10,8 @@ import {
   useFightDerivedStats,
 } from '../features/fight-state/FightStateContext';
 import { HelpModal } from '../features/help/HelpModal';
+import { formatDecimal, formatNumber, formatStopwatch } from '../utils/format';
 import { useVisualViewportCssVars } from './useVisualViewportCssVars';
-
-const formatNumber = (value: number) => value.toLocaleString();
-
-const formatDecimal = (value: number | null, fractionDigits = 1) => {
-  if (value == null || Number.isNaN(value)) {
-    return '—';
-  }
-  return value.toLocaleString(undefined, {
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits,
-  });
-};
-
-const formatStopwatch = (value: number | null) => {
-  if (value == null || Number.isNaN(value)) {
-    return '—';
-  }
-
-  if (value <= 0) {
-    return '0:00.00';
-  }
-
-  const hundredths = Math.floor(value / 10);
-  const minutes = Math.floor(hundredths / 6000);
-  const seconds = Math.floor((hundredths / 100) % 60);
-  const remainingHundredths = hundredths % 100;
-
-  return `${minutes}:${seconds.toString().padStart(2, '0')}.${remainingHundredths
-    .toString()
-    .padStart(2, '0')}`;
-};
 
 type StageTimelineProps = {
   readonly stageLabel: string | null;

--- a/src/features/combat-log/CombatLogPanel.tsx
+++ b/src/features/combat-log/CombatLogPanel.tsx
@@ -2,22 +2,12 @@ import type { FC } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { bossMap, bossSequenceMap, resolveSequenceEntries } from '../../data';
+import { formatNumber, formatRelativeTime } from '../../utils/format';
 import {
   useFightDerivedStats,
   useFightState,
   type AttackEvent,
 } from '../fight-state/FightStateContext';
-
-const formatNumber = (value: number) => value.toLocaleString();
-
-const formatRelativeTime = (start: number | null, timestamp: number | null) => {
-  if (start == null || timestamp == null) {
-    return '—';
-  }
-
-  const elapsedSeconds = Math.max(0, (timestamp - start) / 1000);
-  return `${elapsedSeconds.toFixed(2)}s`;
-};
 
 type CombatLogEntry =
   | {

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDecimal,
+  formatNumber,
+  formatRelativeTime,
+  formatStopwatch,
+} from '../format';
+
+describe('format helpers', () => {
+  describe('formatNumber', () => {
+    it('uses locale-specific group separators', () => {
+      const value = 1234567.89;
+      expect(formatNumber(value)).toBe(value.toLocaleString());
+    });
+  });
+
+  describe('formatDecimal', () => {
+    it('formats to a single decimal place by default', () => {
+      const value = 1234.567;
+      const expected = value.toLocaleString(undefined, {
+        maximumFractionDigits: 1,
+        minimumFractionDigits: 1,
+      });
+      expect(formatDecimal(value)).toBe(expected);
+    });
+
+    it('formats to the specified precision', () => {
+      const value = 98.7654;
+      const expected = value.toLocaleString(undefined, {
+        maximumFractionDigits: 3,
+        minimumFractionDigits: 3,
+      });
+      expect(formatDecimal(value, 3)).toBe(expected);
+    });
+
+    it('returns an em dash for nullish or NaN values', () => {
+      expect(formatDecimal(null)).toBe('—');
+      expect(formatDecimal(Number.NaN)).toBe('—');
+    });
+  });
+
+  describe('formatStopwatch', () => {
+    it('returns an em dash for nullish or NaN values', () => {
+      expect(formatStopwatch(null)).toBe('—');
+      expect(formatStopwatch(Number.NaN)).toBe('—');
+    });
+
+    it('clamps zero or negative values', () => {
+      expect(formatStopwatch(-100)).toBe('0:00.00');
+      expect(formatStopwatch(0)).toBe('0:00.00');
+    });
+
+    it('formats positive durations', () => {
+      expect(formatStopwatch(90320)).toBe('1:30.32');
+      expect(formatStopwatch(60000)).toBe('1:00.00');
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    it('returns an em dash when timing information is missing', () => {
+      expect(formatRelativeTime(null, 1000)).toBe('—');
+      expect(formatRelativeTime(1000, null)).toBe('—');
+    });
+
+    it('returns the elapsed time with two decimal places', () => {
+      expect(formatRelativeTime(0, 2500)).toBe('2.50s');
+    });
+
+    it('does not return negative values', () => {
+      expect(formatRelativeTime(1000, 500)).toBe('0.00s');
+    });
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,43 @@
+export const formatNumber = (value: number): string => value.toLocaleString();
+
+export const formatDecimal = (value: number | null, fractionDigits = 1): string => {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  });
+};
+
+export const formatStopwatch = (value: number | null): string => {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
+  if (value <= 0) {
+    return '0:00.00';
+  }
+
+  const hundredths = Math.floor(value / 10);
+  const minutes = Math.floor(hundredths / 6000);
+  const seconds = Math.floor((hundredths / 100) % 60);
+  const remainingHundredths = hundredths % 100;
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${remainingHundredths
+    .toString()
+    .padStart(2, '0')}`;
+};
+
+export const formatRelativeTime = (
+  start: number | null,
+  timestamp: number | null,
+): string => {
+  if (start == null || timestamp == null) {
+    return '—';
+  }
+
+  const elapsedSeconds = Math.max(0, (timestamp - start) / 1000);
+  return `${elapsedSeconds.toFixed(2)}s`;
+};


### PR DESCRIPTION
## Summary
- extract formatting helpers into `src/utils/format.ts` for reuse across the app
- update HUD and combat log components to import the shared helpers
- add unit coverage for the formatting utilities

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d905eab04c832fa56bdfbde6bb5c90