### PR TITLE
feat: extract boss health bar component

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,7 @@ import {
 import { HelpModal } from '../features/help/HelpModal';
 import { formatDecimal, formatNumber, formatStopwatch } from '../utils/format';
 import { useVisualViewportCssVars } from './useVisualViewportCssVars';
+import { BossHealthBar } from './components/BossHealthBar';
 
 type StageTimelineProps = {
   readonly stageLabel: string | null;
@@ -134,8 +135,6 @@ const TargetScoreboard: FC<TargetScoreboardProps> = ({
     attacksLogged,
     totalDamage,
   } = derived;
-  const percentRemaining = targetHp > 0 ? Math.max(0, remainingHp / targetHp) : 0;
-
   const metrics = useMemo(
     () => [
       { id: 'elapsed', label: 'Elapsed', value: formatStopwatch(elapsedMs) },
@@ -177,30 +176,16 @@ const TargetScoreboard: FC<TargetScoreboardProps> = ({
   return (
     <section className="hud-scoreboard" aria-label="Encounter scoreboard">
       <div className="hud-scoreboard__status">
-        <div
+        <BossHealthBar
           className="hud-health summary-chip summary-chip--accent"
           role="group"
           aria-label="Boss HP"
-        >
-          <span className="hud-health__label">HP</span>
-          <div
-            className="hud-health__track"
-            role="progressbar"
-            aria-label="Boss HP"
-            aria-valuemin={0}
-            aria-valuemax={targetHp}
-            aria-valuenow={remainingHp}
-          >
-            <div
-              className="hud-health__fill"
-              style={{ width: `${Math.round(percentRemaining * 100)}%` }}
-              aria-hidden="true"
-            />
-          </div>
-          <span className="hud-health__value">
-            {formatNumber(remainingHp)} / {formatNumber(targetHp)}
-          </span>
-        </div>
+          label="HP"
+          current={remainingHp}
+          total={targetHp}
+          progressbarAriaLabel="Boss HP"
+          valueLabel={`${formatNumber(remainingHp)} / ${formatNumber(targetHp)}`}
+        />
         <StageTimeline
           stageLabel={stageLabel}
           stageProgress={stageProgress}
@@ -234,33 +219,23 @@ type MobilePinnedHudProps = {
 
 const MobilePinnedHud: FC<MobilePinnedHudProps> = ({ derived, encounterName }) => {
   const { targetHp, remainingHp } = derived;
-  const percentRemaining = targetHp > 0 ? Math.max(0, remainingHp / targetHp) : 0;
-
   return (
     <div className="mobile-hud-sentinel">
       <div className="mobile-hud" role="group" aria-label="Boss status">
         <span className="mobile-hud__title" aria-live="polite">
           {encounterName}
         </span>
-        <div className="mobile-hud__health" role="group" aria-label="Boss HP">
-          <div
-            className="hud-health__track mobile-hud__track"
-            role="progressbar"
-            aria-valuemin={0}
-            aria-valuemax={targetHp}
-            aria-valuenow={remainingHp}
-            aria-label="Boss HP"
-          >
-            <div
-              className="hud-health__fill"
-              style={{ width: `${Math.round(percentRemaining * 100)}%` }}
-              aria-hidden="true"
-            />
-          </div>
-          <span className="mobile-hud__value">
-            {formatNumber(remainingHp)} / {formatNumber(targetHp)}
-          </span>
-        </div>
+        <BossHealthBar
+          className="mobile-hud__health"
+          role="group"
+          aria-label="Boss HP"
+          current={remainingHp}
+          total={targetHp}
+          progressbarAriaLabel="Boss HP"
+          trackClassName="mobile-hud__track"
+          valueLabel={`${formatNumber(remainingHp)} / ${formatNumber(targetHp)}`}
+          valueClassName="mobile-hud__value"
+        />
       </div>
     </div>
   );

--- a/src/app/components/BossHealthBar.test.tsx
+++ b/src/app/components/BossHealthBar.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+
+import { BossHealthBar } from './BossHealthBar';
+
+describe('BossHealthBar', () => {
+  it('exposes progressbar semantics for the desktop scoreboard', () => {
+    render(
+      <BossHealthBar
+        className="hud-health summary-chip summary-chip--accent"
+        role="group"
+        aria-label="Boss HP"
+        label="HP"
+        current={450}
+        total={1000}
+        progressbarAriaLabel="Boss HP"
+        valueLabel="450 / 1000"
+      />,
+    );
+
+    const wrapper = screen.getByRole('group', { name: 'Boss HP' });
+    expect(wrapper).toHaveClass('hud-health', 'summary-chip', 'summary-chip--accent');
+
+    const progressbar = screen.getByRole('progressbar', { name: 'Boss HP' });
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '1000');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '450');
+    expect(progressbar).toHaveClass('hud-health__track');
+
+    expect(screen.getByText('HP')).toHaveClass('hud-health__label');
+    expect(screen.getByText('450 / 1000')).toHaveClass('hud-health__value');
+  });
+
+  it('supports the compact mobile HUD layout', () => {
+    render(
+      <BossHealthBar
+        className="mobile-hud__health"
+        role="group"
+        aria-label="Boss HP"
+        current={250}
+        total={1000}
+        progressbarAriaLabel="Boss HP"
+        trackClassName="mobile-hud__track"
+        valueLabel="250 / 1000"
+        valueClassName="mobile-hud__value"
+      />,
+    );
+
+    const wrapper = screen.getByRole('group', { name: 'Boss HP' });
+    expect(wrapper).toHaveClass('mobile-hud__health');
+
+    const progressbar = screen.getByRole('progressbar', { name: 'Boss HP' });
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '1000');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '250');
+    expect(progressbar).toHaveClass('hud-health__track', 'mobile-hud__track');
+
+    expect(screen.getByText('250 / 1000')).toHaveClass('mobile-hud__value');
+  });
+});

--- a/src/app/components/BossHealthBar.tsx
+++ b/src/app/components/BossHealthBar.tsx
@@ -1,0 +1,73 @@
+import { type ComponentPropsWithoutRef, type FC } from 'react';
+
+type BossHealthBarProps = Omit<ComponentPropsWithoutRef<'div'>, 'children'> & {
+  readonly current: number;
+  readonly total: number;
+  readonly label?: string;
+  readonly labelClassName?: string;
+  readonly valueLabel?: string;
+  readonly valueClassName?: string;
+  readonly trackClassName?: string;
+  readonly fillClassName?: string;
+  readonly progressbarAriaLabel?: string;
+};
+
+const combineClassNames = (...classes: ReadonlyArray<string | undefined>): string =>
+  classes.filter(Boolean).join(' ');
+
+export const BossHealthBar: FC<BossHealthBarProps> = ({
+  current,
+  total,
+  label,
+  labelClassName,
+  valueLabel,
+  valueClassName,
+  className,
+  trackClassName,
+  fillClassName,
+  progressbarAriaLabel,
+  ...wrapperProps
+}) => {
+  const percentRemaining = total > 0 ? Math.max(0, Math.min(1, current / total)) : 0;
+
+  return (
+    <div className={className} {...wrapperProps}>
+      {label ? (
+        <span
+          className={
+            labelClassName === undefined
+              ? 'hud-health__label'
+              : combineClassNames(labelClassName)
+          }
+        >
+          {label}
+        </span>
+      ) : null}
+      <div
+        className={combineClassNames('hud-health__track', trackClassName)}
+        role="progressbar"
+        aria-label={progressbarAriaLabel ?? label}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={current}
+      >
+        <div
+          className={combineClassNames('hud-health__fill', fillClassName)}
+          style={{ width: `${Math.round(percentRemaining * 100)}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      {valueLabel ? (
+        <span
+          className={
+            valueClassName === undefined
+              ? 'hud-health__value'
+              : combineClassNames(valueClassName)
+          }
+        >
+          {valueLabel}
+        </span>
+      ) : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a reusable BossHealthBar component to centralize health bar semantics and styling hooks
- replace the scoreboard and mobile HUD progress bars with the shared component
- cover the desktop and mobile use cases with focused unit tests for the new component

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d90d441c34832fbec9ad20ca91af6b