### PR TITLE
refactor: extract shared sequence context hook

### DIFF
--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -11,15 +11,13 @@ import type { Charm } from '../../data';
 import {
   bossMap,
   bosses,
-  bossSequenceMap,
   bossSequences,
   charmMap,
-  getSequenceConditionValues,
   nailUpgrades,
-  resolveSequenceEntries,
   spells,
   supportedCharmIds,
 } from '../../data';
+import { useSequenceContext } from '../fight-state/useSequenceContext';
 
 const orderCharmIds = (selected: string[]) => {
   const ordered = supportedCharmIds.filter((charmId) => selected.includes(charmId));
@@ -101,9 +99,18 @@ export const useBuildConfiguration = () => {
   const selectedBossId = useFightStateSelector((state) => state.selectedBossId);
   const customTargetHp = useFightStateSelector((state) => state.customTargetHp);
   const build = useFightStateSelector((state) => state.build);
-  const activeSequenceId = useFightStateSelector((state) => state.activeSequenceId);
-  const sequenceIndex = useFightStateSelector((state) => state.sequenceIndex);
-  const sequenceConditions = useFightStateSelector((state) => state.sequenceConditions);
+
+  const {
+    activeSequenceId,
+    activeSequence,
+    sequenceEntries,
+    sequenceConditionValues,
+    cappedSequenceIndex,
+    currentSequenceEntry,
+    isSequenceActive,
+    hasNextSequenceStage,
+    hasPreviousSequenceStage,
+  } = useSequenceContext();
 
   const selectedTarget = useMemo(() => bossMap.get(selectedBossId), [selectedBossId]);
 
@@ -117,41 +124,6 @@ export const useBuildConfiguration = () => {
 
   const selectedVersion = selectedTarget?.version;
 
-  const activeSequence = useMemo(
-    () => (activeSequenceId ? bossSequenceMap.get(activeSequenceId) : undefined),
-    [activeSequenceId],
-  );
-
-  const sequenceConditionOverrides = activeSequenceId
-    ? sequenceConditions[activeSequenceId]
-    : undefined;
-
-  const sequenceEntries = useMemo(
-    () =>
-      activeSequence
-        ? resolveSequenceEntries(activeSequence, sequenceConditionOverrides)
-        : [],
-    [activeSequence, sequenceConditionOverrides],
-  );
-
-  const sequenceConditionValues = useMemo(
-    () =>
-      activeSequence
-        ? getSequenceConditionValues(activeSequence, sequenceConditionOverrides)
-        : {},
-    [activeSequence, sequenceConditionOverrides],
-  );
-
-  const cappedSequenceIndex = sequenceEntries.length
-    ? Math.min(Math.max(sequenceIndex, 0), sequenceEntries.length - 1)
-    : 0;
-
-  const currentSequenceEntry =
-    sequenceEntries.length > 0 ? sequenceEntries[cappedSequenceIndex] : undefined;
-  const isSequenceActive = Boolean(activeSequence);
-  const hasPreviousSequenceStage = isSequenceActive && cappedSequenceIndex > 0;
-  const hasNextSequenceStage =
-    isSequenceActive && cappedSequenceIndex < sequenceEntries.length - 1;
   const sequenceSelectValue = activeSequenceId ?? '';
 
   const bossSelectValue =

--- a/src/features/fight-state/useSequenceContext.test.tsx
+++ b/src/features/fight-state/useSequenceContext.test.tsx
@@ -1,0 +1,139 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { FC, PropsWithChildren } from 'react';
+
+import { bossSequenceMap } from '../../data';
+import { FightStateProvider, useFightActions } from './FightStateContext';
+import { useSequenceContext } from './useSequenceContext';
+
+const wrapper: FC<PropsWithChildren> = ({ children }) => (
+  <FightStateProvider>{children}</FightStateProvider>
+);
+
+describe('useSequenceContext', () => {
+  it('exposes the active sequence context and clamps the stage index', () => {
+    const masterSequence = bossSequenceMap.get('pantheon-of-the-master');
+    if (!masterSequence) {
+      throw new Error('Missing pantheon sequence fixture for tests');
+    }
+
+    const { result } = renderHook(
+      () => ({
+        context: useSequenceContext(),
+        actions: useFightActions(),
+      }),
+      { wrapper },
+    );
+
+    expect(result.current.context.isSequenceActive).toBe(false);
+
+    act(() => {
+      result.current.actions.startSequence(masterSequence.id);
+    });
+
+    expect(result.current.context.isSequenceActive).toBe(true);
+    expect(result.current.context.activeSequence?.id).toBe(masterSequence.id);
+    expect(result.current.context.sequenceEntries).toHaveLength(
+      masterSequence.entries.length,
+    );
+    expect(result.current.context.cappedSequenceIndex).toBe(0);
+    expect(result.current.context.currentSequenceEntry?.id).toBe(
+      masterSequence.entries[0]?.id,
+    );
+    expect(result.current.context.labels?.sequenceName).toBe(masterSequence.name);
+    expect(result.current.context.labels?.stageNumber).toBe(1);
+    expect(result.current.context.labels?.stageLabel).toBe(
+      masterSequence.entries[0]?.target.bossName,
+    );
+
+    act(() => {
+      result.current.actions.setSequenceStage(masterSequence.entries.length + 3);
+    });
+
+    expect(result.current.context.sequenceIndex).toBe(masterSequence.entries.length - 1);
+    expect(result.current.context.cappedSequenceIndex).toBe(
+      masterSequence.entries.length - 1,
+    );
+    expect(result.current.context.currentSequenceEntry?.id).toBe(
+      masterSequence.entries.at(-1)?.id,
+    );
+    expect(result.current.context.labels?.stageLabel).toBe(
+      masterSequence.entries.at(-1)?.target.bossName,
+    );
+    expect(result.current.context.labels?.stageNumber).toBe(
+      masterSequence.entries.length,
+    );
+    expect(result.current.context.hasNextSequenceStage).toBe(false);
+    expect(result.current.context.hasPreviousSequenceStage).toBe(true);
+  });
+
+  it('resolves conditional sequence entries and replacement targets', () => {
+    const hallownest = bossSequenceMap.get('pantheon-of-hallownest');
+    if (!hallownest) {
+      throw new Error('Missing pantheon sequence fixture for tests');
+    }
+
+    const mantisIndex = hallownest.entries.findIndex(
+      (entry) => entry.condition?.id === 'replace-mantis-lords',
+    );
+    if (mantisIndex === -1) {
+      throw new Error('Failed to locate Mantis Lords stage in test data');
+    }
+
+    const { result } = renderHook(
+      () => ({
+        context: useSequenceContext(),
+        actions: useFightActions(),
+      }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.actions.startSequence(hallownest.id);
+      result.current.actions.setSequenceStage(mantisIndex);
+    });
+
+    expect(result.current.context.sequenceEntries[mantisIndex]?.target.bossName).toBe(
+      'Mantis Lords',
+    );
+    expect(result.current.context.labels?.stageLabel).toBe('Mantis Lords');
+    const initialLength = result.current.context.sequenceEntries.length;
+    expect(result.current.context.sequenceConditionValues['replace-mantis-lords']).toBe(
+      false,
+    );
+
+    act(() => {
+      result.current.actions.setSequenceCondition(
+        hallownest.id,
+        'replace-mantis-lords',
+        true,
+      );
+    });
+
+    expect(result.current.context.sequenceEntries[mantisIndex]?.target.bossName).toBe(
+      'Sisters of Battle',
+    );
+    expect(result.current.context.labels?.stageLabel).toBe('Sisters of Battle');
+    expect(result.current.context.sequenceConditionValues['replace-mantis-lords']).toBe(
+      true,
+    );
+
+    act(() => {
+      result.current.actions.setSequenceCondition(
+        hallownest.id,
+        'include-grey-prince-zote',
+        true,
+      );
+    });
+
+    expect(
+      result.current.context.sequenceConditionValues['include-grey-prince-zote'],
+    ).toBe(true);
+    expect(result.current.context.sequenceEntries.length).toBe(initialLength + 1);
+    expect(
+      result.current.context.sequenceEntries.some(
+        (entry) => entry.target.bossName === 'Grey Prince Zote',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/features/fight-state/useSequenceContext.ts
+++ b/src/features/fight-state/useSequenceContext.ts
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+
+import {
+  bossSequenceMap,
+  getSequenceConditionValues,
+  resolveSequenceEntries,
+  type BossSequence,
+  type BossSequenceEntry,
+} from '../../data';
+import { useFightStateSelector } from './FightStateContext';
+
+type SequenceLabels = {
+  sequenceName: string;
+  stageLabel: string | null;
+  stageNumber: number;
+};
+
+export interface SequenceContextValue {
+  activeSequenceId: string | null;
+  activeSequence: BossSequence | undefined;
+  sequenceIndex: number;
+  sequenceEntries: BossSequenceEntry[];
+  sequenceConditionValues: Record<string, boolean>;
+  cappedSequenceIndex: number;
+  currentSequenceEntry: BossSequenceEntry | undefined;
+  labels: SequenceLabels | null;
+  isSequenceActive: boolean;
+  hasPreviousSequenceStage: boolean;
+  hasNextSequenceStage: boolean;
+}
+
+const buildLabels = (
+  sequence: BossSequence,
+  entries: BossSequenceEntry[],
+  sequenceIndex: number,
+): SequenceLabels => {
+  const stage = entries.at(sequenceIndex) ?? null;
+
+  return {
+    sequenceName: sequence.name,
+    stageLabel: stage?.target.bossName ?? null,
+    stageNumber: sequenceIndex + 1,
+  } satisfies SequenceLabels;
+};
+
+export const useSequenceContext = (): SequenceContextValue => {
+  const activeSequenceId = useFightStateSelector((state) => state.activeSequenceId);
+  const sequenceIndex = useFightStateSelector((state) => state.sequenceIndex);
+  const sequenceConditions = useFightStateSelector((state) => state.sequenceConditions);
+
+  return useMemo<SequenceContextValue>(() => {
+    if (!activeSequenceId) {
+      return {
+        activeSequenceId,
+        activeSequence: undefined,
+        sequenceIndex,
+        sequenceEntries: [],
+        sequenceConditionValues: {},
+        cappedSequenceIndex: 0,
+        currentSequenceEntry: undefined,
+        labels: null,
+        isSequenceActive: false,
+        hasPreviousSequenceStage: false,
+        hasNextSequenceStage: false,
+      } satisfies SequenceContextValue;
+    }
+
+    const activeSequence = bossSequenceMap.get(activeSequenceId);
+    if (!activeSequence) {
+      return {
+        activeSequenceId,
+        activeSequence: undefined,
+        sequenceIndex,
+        sequenceEntries: [],
+        sequenceConditionValues: {},
+        cappedSequenceIndex: 0,
+        currentSequenceEntry: undefined,
+        labels: null,
+        isSequenceActive: false,
+        hasPreviousSequenceStage: false,
+        hasNextSequenceStage: false,
+      } satisfies SequenceContextValue;
+    }
+
+    const overrides = sequenceConditions[activeSequenceId] ?? undefined;
+    const sequenceEntries = resolveSequenceEntries(activeSequence, overrides);
+    const sequenceConditionValues = getSequenceConditionValues(activeSequence, overrides);
+    const cappedSequenceIndex = sequenceEntries.length
+      ? Math.min(Math.max(sequenceIndex, 0), sequenceEntries.length - 1)
+      : 0;
+    const currentSequenceEntry =
+      sequenceEntries.length > 0 ? sequenceEntries[cappedSequenceIndex] : undefined;
+    const labels = buildLabels(activeSequence, sequenceEntries, sequenceIndex);
+
+    return {
+      activeSequenceId,
+      activeSequence,
+      sequenceIndex,
+      sequenceEntries,
+      sequenceConditionValues,
+      cappedSequenceIndex,
+      currentSequenceEntry,
+      labels,
+      isSequenceActive: true,
+      hasPreviousSequenceStage: cappedSequenceIndex > 0,
+      hasNextSequenceStage: cappedSequenceIndex < sequenceEntries.length - 1,
+    } satisfies SequenceContextValue;
+  }, [activeSequenceId, sequenceConditions, sequenceIndex]);
+};


### PR DESCRIPTION
## Summary
- extract sequence resolution logic into a shared `useSequenceContext` hook
- update build configuration and combat log components to consume the shared hook
- add unit tests covering sequence transitions and conditional overrides

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d98a0b35dc832f8daca0c7e4ba0f2a