### PR TITLE
docs: fix README mobile screenshot sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
   <img
     src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app.png"
     alt="Mobile screenshot of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
-    style="max-width: 480px; width: 100%; height: auto;"
+    width="320"
   />
 </div>
 


### PR DESCRIPTION
## Summary
- replace the inline CSS on the mobile screenshot with an HTML width attribute so GitHub respects the constrained size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e5c01850832f98fd5fc99a5e1518