### PR TITLE
fix: align combat log clear button with panel header

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState, type FC } from 'react';
 import { AttackLogPanel } from '../features/attack-log/AttackLogPanel';
 import { PlayerConfigModal } from '../features/build-config/PlayerConfigModal';
 import { useBuildConfiguration } from '../features/build-config/useBuildConfiguration';
-import { CombatLogPanel } from '../features/combat-log/CombatLogPanel';
+import {
+  CombatLogClearButton,
+  CombatLogPanel,
+  CombatLogProvider,
+} from '../features/combat-log/CombatLogPanel';
 import {
   FightStateProvider,
   useFightDerivedStats,
@@ -186,17 +190,20 @@ const AppContent: FC = () => {
             <AttackLogPanel />
           </div>
         </section>
-        <section
-          className={`app-panel app-panel--log${panelGlowClass ? ` ${panelGlowClass}` : ''}`}
-          aria-labelledby="combat-log-heading"
-        >
-          <div className="app-panel__header">
-            <h2 id="combat-log-heading">Combat Log</h2>
-          </div>
-          <div className="app-panel__body">
-            <CombatLogPanel />
-          </div>
-        </section>
+        <CombatLogProvider>
+          <section
+            className={`app-panel app-panel--log${panelGlowClass ? ` ${panelGlowClass}` : ''}`}
+            aria-labelledby="combat-log-heading"
+          >
+            <div className="app-panel__header app-panel__header--with-actions">
+              <h2 id="combat-log-heading">Combat Log</h2>
+              <CombatLogClearButton />
+            </div>
+            <div className="app-panel__body">
+              <CombatLogPanel />
+            </div>
+          </section>
+        </CombatLogProvider>
       </main>
 
       <PlayerConfigModal isOpen={isModalOpen} onClose={() => setModalOpen(false)} />

--- a/src/features/combat-log/CombatLogPanel.test.tsx
+++ b/src/features/combat-log/CombatLogPanel.test.tsx
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { useEffect } from 'react';
 
-import { CombatLogPanel } from './CombatLogPanel';
+import {
+  CombatLogClearButton,
+  CombatLogPanel,
+  CombatLogProvider,
+} from './CombatLogPanel';
 import { useFightActions } from '../fight-state/FightStateContext';
 import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
 
@@ -26,14 +30,15 @@ describe('CombatLogPanel', () => {
     let actions: FightActions | null = null;
 
     renderWithFightProvider(
-      <>
+      <CombatLogProvider>
         <ActionsBridge
           onReady={(value) => {
             actions = value;
           }}
         />
+        <CombatLogClearButton />
         <CombatLogPanel />
-      </>,
+      </CombatLogProvider>,
     );
 
     await waitFor(() => {
@@ -84,14 +89,15 @@ describe('CombatLogPanel', () => {
     let actions: FightActions | null = null;
 
     renderWithFightProvider(
-      <>
+      <CombatLogProvider>
         <ActionsBridge
           onReady={(value) => {
             actions = value;
           }}
         />
+        <CombatLogClearButton />
         <CombatLogPanel />
-      </>,
+      </CombatLogProvider>,
     );
 
     await waitFor(() => {
@@ -141,14 +147,15 @@ describe('CombatLogPanel', () => {
     let actions: FightActions | null = null;
 
     renderWithFightProvider(
-      <>
+      <CombatLogProvider>
         <ActionsBridge
           onReady={(value) => {
             actions = value;
           }}
         />
+        <CombatLogClearButton />
         <CombatLogPanel />
-      </>,
+      </CombatLogProvider>,
     );
 
     await waitFor(() => {
@@ -195,14 +202,15 @@ describe('CombatLogPanel', () => {
     let actions: FightActions | null = null;
 
     renderWithFightProvider(
-      <>
+      <CombatLogProvider>
         <ActionsBridge
           onReady={(value) => {
             actions = value;
           }}
         />
+        <CombatLogClearButton />
         <CombatLogPanel />
-      </>,
+      </CombatLogProvider>,
     );
 
     await waitFor(() => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1305,6 +1305,17 @@ h6 {
   gap: 0.45rem;
 }
 
+.app-panel__header--with-actions {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.75rem, 1.6vw, 1.4rem);
+}
+
+.app-panel__header--with-actions h2 {
+  flex: 1 1 auto;
+}
+
 .app-panel__header h2 {
   margin: 0;
   font-size: var(--font-size-headline);
@@ -1421,35 +1432,38 @@ h6 {
 }
 
 .combat-log__reset-button {
-  position: absolute;
-  top: clamp(0.45rem, 1.6vw, 0.85rem);
-  right: clamp(0.6rem, 1.8vw, 1.1rem);
-  padding: 0.25rem 0.65rem;
-  border: 1px solid rgb(255 255 255 / 8%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid rgb(200 220 255 / 26%);
   border-radius: 999px;
-  background-color: rgb(17 26 45 / 65%);
-  color: rgb(224 235 255 / 72%);
+  background-color: rgb(16 28 52 / 45%);
+  color: rgb(224 235 255 / 78%);
   font-size: var(--font-size-caption);
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
   transition:
     color 160ms ease,
     border-color 160ms ease,
-    background-color 160ms ease;
-  z-index: 2;
+    background-color 160ms ease,
+    transform 160ms ease;
 }
 
 .combat-log__reset-button:hover,
 .combat-log__reset-button:focus-visible {
   outline: none;
   color: var(--color-accent);
-  border-color: var(--color-accent);
-  background-color: rgb(30 47 76 / 80%);
+  border-color: rgb(130 207 255 / 55%);
+  background-color: rgb(28 44 74 / 65%);
+  transform: translateY(-1px);
 }
 
 .combat-log__reset-button:active {
-  background-color: rgb(24 38 64 / 88%);
+  background-color: rgb(24 38 64 / 76%);
+  transform: translateY(0);
 }
 
 .quick-actions__button {


### PR DESCRIPTION
## Summary
- add a combat log context provider so the header can host the clear control while the log retains its existing behavior
- restyle the combat log clear button and header layout to align with other buttons and present beside the heading
- update combat log tests to render through the new provider and cover the relocated clear control

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d9e5d2d690832f97e4266f7a771f63