### PR TITLE
docs: add second mobile screenshot and resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
 
 <div align="center" style="display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;">
   <img
-    src="https://raw.githubusercontent.com/kabaka/hollow-knight-damage-tracker/1a9c143/docs/mobile-app-overview.png"
+    src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app-overview.png"
     alt="Mobile screenshot of the Hollow Knight Damage Tracker showing the encounter scoreboard, combat metrics, and attack controls."
     width="360"
     style="max-width: 100%; height: auto;"
   />
   <img
-    src="https://raw.githubusercontent.com/kabaka/hollow-knight-damage-tracker/1a9c143/docs/mobile-app-log.png"
+    src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app-log.png"
     alt="Mobile screenshot of the Hollow Knight Damage Tracker scrolled down to reveal the attack buttons and combat history log."
     width="360"
     style="max-width: 100%; height: auto;"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ Hollow Knight Damage Tracker is a responsive companion app that captures your Kn
   />
 </div>
 
-<div align="center">
+<div align="center" style="display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;">
   <img
-    src="https://kabaka.github.io/hollow-knight-damage-tracker/docs/mobile-app.png"
-    alt="Mobile screenshot of the Hollow Knight Damage Tracker interface showing combat controls and analytics."
-    style="max-width: 480px; width: 100%; height: auto;"
+    src="https://raw.githubusercontent.com/kabaka/hollow-knight-damage-tracker/1a9c143/docs/mobile-app-overview.png"
+    alt="Mobile screenshot of the Hollow Knight Damage Tracker showing the encounter scoreboard, combat metrics, and attack controls."
+    width="360"
+    style="max-width: 100%; height: auto;"
+  />
+  <img
+    src="https://raw.githubusercontent.com/kabaka/hollow-knight-damage-tracker/1a9c143/docs/mobile-app-log.png"
+    alt="Mobile screenshot of the Hollow Knight Damage Tracker scrolled down to reveal the attack buttons and combat history log."
+    width="360"
+    style="max-width: 100%; height: auto;"
   />
 </div>
 

--- a/tests/e2e/screenshot.spec.ts
+++ b/tests/e2e/screenshot.spec.ts
@@ -132,18 +132,40 @@ test('generate a mid-combat screenshot', async ({ page }) => {
 
   await page.screenshot({ path: 'test-results/demo.png', fullPage: true });
 
-  await test.step('capture a mobile layout screenshot', async () => {
-    await page.setViewportSize({ width: 430, height: 932 });
+  await test.step('capture mobile layout screenshots', async () => {
+    await page.setViewportSize({ width: 390, height: 844 });
     await page.waitForTimeout(250);
     await page.evaluate(() => window.scrollTo(0, 0));
+
+    const header = page.locator('header[role="banner"]');
 
     await expect(
       page.getByRole('region', { name: 'Encounter scoreboard' }),
     ).toBeVisible();
 
     await page.screenshot({
-      path: 'test-results/mobile-app.png',
-      fullPage: true,
+      path: 'test-results/mobile-app-overview.png',
+    });
+
+    const headerHeight = await header.evaluate(
+      (element) => element.getBoundingClientRect().height,
+    );
+
+    await page.evaluate((offset) => {
+      window.scrollTo({ top: offset, behavior: 'instant' });
+    }, headerHeight + 360);
+    await page.waitForTimeout(250);
+
+    const headerBottom = await header.evaluate(
+      (element) => element.getBoundingClientRect().bottom,
+    );
+    expect(headerBottom).toBeLessThanOrEqual(1);
+
+    await expect(page.getByRole('group', { name: 'Attack log controls' })).toBeVisible();
+    await expect(page.getByRole('log', { name: 'Combat history' })).toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/mobile-app-log.png',
     });
   });
 });


### PR DESCRIPTION
## Summary
- capture two mobile screenshots and display them side-by-side in the README
- also reduce the size of the mobile screenshots, as GitHub was replacing `max-width: 480px` with `max-width: 100%`.

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d9e5c01850832f98fd5fc99a5e1518