### PR TITLE
feat: streamline attack button metadata

### DIFF
--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -116,18 +116,28 @@ describe('AttackLogPanel', () => {
     );
 
     const nailStrikeButton = screen.getByRole('button', { name: /nail strike/i });
-    const hitsDisplay = within(nailStrikeButton).getByLabelText(/hits to finish/i);
-    expect(hitsDisplay).toHaveAttribute(
-      'aria-label',
-      `Hits to finish: ${initialHitsToFinish}`,
-    );
+    const hitsDisplay = within(nailStrikeButton).getByLabelText(/to end/i);
+    expect(hitsDisplay).toHaveAttribute('aria-label', `To end: ${initialHitsToFinish}`);
 
     await user.click(nailStrikeButton);
 
     expect(hitsDisplay).toHaveAttribute(
       'aria-label',
-      `Hits to finish: ${hitsToFinishAfterOneHit}`,
+      `To end: ${hitsToFinishAfterOneHit}`,
     );
+  });
+
+  it('hides soul cost metadata for spell attacks', () => {
+    renderWithFightProvider(
+      <AttackLogProvider>
+        <AttackLogActions />
+        <AttackLogPanel />
+      </AttackLogProvider>,
+    );
+
+    const spellsGroup = screen.getByRole('group', { name: /spells/i });
+
+    expect(within(spellsGroup).queryByLabelText(/soul cost/i)).not.toBeInTheDocument();
   });
 
   it('supports undo, redo, and quick reset controls', async () => {

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -500,7 +500,8 @@ export const AttackLogPanel: FC = () => {
                     <span className="button-grid__damage" aria-label="Damage per hit">
                       {attack.damage}
                     </span>
-                    {typeof attack.soulCost === 'number' ? (
+                    {typeof attack.soulCost === 'number' &&
+                    attack.category !== 'spell' ? (
                       <span className="button-grid__soul" aria-label="Soul cost">
                         {attack.soulCost} SOUL
                       </span>
@@ -508,9 +509,9 @@ export const AttackLogPanel: FC = () => {
                     {typeof attack.hitsRemaining === 'number' ? (
                       <span
                         className="button-grid__hits"
-                        aria-label={`Hits to finish: ${attack.hitsRemaining}`}
+                        aria-label={`To end: ${attack.hitsRemaining}`}
                       >
-                        Hits to finish: {attack.hitsRemaining}
+                        To end: {attack.hitsRemaining}
                       </span>
                     ) : null}
                   </span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1721,8 +1721,7 @@ h6 {
   color: var(--color-text);
 }
 
-.button-grid__soul,
-.button-grid__hits {
+.button-grid__soul {
   font-size: var(--font-size-caption);
   letter-spacing: 0.05em;
   text-transform: none;
@@ -1735,6 +1734,16 @@ h6 {
   box-shadow:
     inset 0 0 0 1px rgb(255 255 255 / 8%),
     inset 0 -1px 0 rgb(0 0 0 / 55%);
+}
+
+.button-grid__hits {
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.05em;
+  text-transform: none;
+  padding: 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
 }
 
 .button-grid__description {
@@ -2691,9 +2700,12 @@ h6 {
     font-size: 1.1rem;
   }
 
-  .button-grid__soul,
-  .button-grid__hits {
+  .button-grid__soul {
     padding: 0.1rem 0.5rem;
+  }
+
+  .button-grid__hits {
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- shorten the attack button hit counter label to "To end" and align its aria label
- remove the decorative background from the remaining-hit indicator while preserving soul styling
- suppress soul cost badges for spell attacks and add coverage to assert the new behaviour

## Testing
- pnpm test -- --runTestsByPath src/features/attack-log/AttackLogPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da3466d5a4832fa4b8e08d6e7e9b16