### PR TITLE
refactor: cache damage log aggregates for derived stats

### DIFF
--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -283,6 +283,10 @@ export const mergePersistedState = (
 
   const damageLog = sanitizeAttackEvents(persisted.damageLog, fallback.damageLog);
   const redoStack = sanitizeAttackEvents(persisted.redoStack, fallback.redoStack);
+  const damageLogVersion = sanitizeNonNegativeInteger(
+    persisted.damageLogVersion,
+    fallback.damageLogVersion,
+  );
 
   const activeSequenceId =
     typeof persisted.activeSequenceId === 'string' ? persisted.activeSequenceId : null;
@@ -346,6 +350,7 @@ export const mergePersistedState = (
         notchLimit,
       },
       damageLog,
+      damageLogVersion,
       redoStack,
       activeSequenceId,
       sequenceIndex,


### PR DESCRIPTION
## Summary
- cache damage log aggregates inside the fight state provider and reuse them during animation frame updates
- add a damage log version counter in the reducer/persistence layer so the cache invalidates whenever entries change
- add a regression test that spies on the aggregate helper to ensure recomputation happens only when the log mutates

## Testing
- pnpm lint:js
- pnpm vitest run src/features/fight-state/FightStateContext.test.tsx
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dadf55ec78832f96a29265155a2139