### PR TITLE
fix: constrain combat log scroll area

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1533,12 +1533,15 @@ h6 {
 
 .combat-log__wrapper {
   position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .combat-log {
   position: relative;
-  min-height: 220px;
-  flex: 1 1 220px;
+  flex: 1 1 auto;
+  min-height: clamp(200px, 42vh, 520px);
   max-height: 100%;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- make the combat log container flex so it fills the panel and scrolls instead of growing endlessly
- tune the combat log minimum height with a viewport clamp for better mobile behavior

## Testing
- pnpm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68db02dc4800832f8fb18f10b060e0e0