### PR TITLE
perf: cache fight damage aggregates

### DIFF
--- a/src/features/combat-log/CombatLogPanel.tsx
+++ b/src/features/combat-log/CombatLogPanel.tsx
@@ -281,7 +281,23 @@ const useCombatLogController = (): CombatLogContextValue => {
       lastFightEndRef.current = null;
     }
 
-    for (const event of damageLog) {
+    const previousCount = lastDamageCountRef.current;
+    let startIndex = previousCount;
+
+    if (previousCount > damageLog.length) {
+      startIndex = damageLog.length;
+      processedEventIds.clear();
+      runningDamageRef.current = 0;
+      for (const event of damageLog) {
+        processedEventIds.add(event.id);
+        runningDamageRef.current += event.damage;
+      }
+    } else {
+      startIndex = Math.max(0, Math.min(previousCount, damageLog.length));
+    }
+
+    for (let index = startIndex; index < damageLog.length; index += 1) {
+      const event = damageLog[index];
       if (processedEventIds.has(event.id)) {
         continue;
       }

--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -27,7 +27,7 @@ describe('FightStateProvider persistence', () => {
 
   it('hydrates state from localStorage when data is available', () => {
     const persistedState = {
-      version: 4,
+      version: 5,
       state: {
         selectedBossId: CUSTOM_BOSS_ID,
         customTargetHp: 3333.7,
@@ -116,7 +116,7 @@ describe('FightStateProvider persistence', () => {
         version: number;
         state: { selectedBossId: string; customTargetHp: number };
       };
-      expect(parsed.version).toBe(4);
+      expect(parsed.version).toBe(5);
       expect(parsed.state.selectedBossId).toBe(CUSTOM_BOSS_ID);
       expect(parsed.state.customTargetHp).toBe(4321);
     });

--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -165,6 +165,9 @@ describe('fight-state persistence', () => {
       label: 'Stage Hit',
       damage: 50,
     });
+    expect(merged.damageLogAggregates.totalDamage).toBe(50);
+    expect(merged.damageLogAggregates.attacksLogged).toBe(1);
+    expect(merged.damageLogAggregates.firstAttackTimestamp).toBe(12);
     expect(merged.redoStack).toHaveLength(1);
     expect(merged.fightEndTimestamp).toBe(42);
     expect(merged.fightManuallyEnded).toBe(true);
@@ -179,6 +182,7 @@ describe('fight-state persistence', () => {
       damage: 50,
       category: 'nail',
     });
+    expect(merged.sequenceLogAggregates[stageKey]?.totalDamage).toBe(50);
     expect(merged.sequenceRedoStacks[stageKey]).toHaveLength(1);
     expect(merged.sequenceFightEndTimestamps[stageKey]).toBe(42);
     expect(merged.sequenceManualEndFlags[stageKey]).toBe(true);
@@ -193,7 +197,7 @@ describe('fight-state persistence', () => {
     const fallback = ensureSequenceState(ensureSpellLevels(createInitialState()));
 
     const persisted = {
-      version: 4,
+      version: 5,
       state: {
         selectedBossId: CUSTOM_BOSS_ID,
         customTargetHp: 4242,
@@ -225,6 +229,7 @@ describe('fight-state persistence', () => {
     expect(restored.build.nailUpgradeId).toBe('coiled-nail');
     expect(restored.build.spellLevels['howling-wraiths']).toBe('upgrade');
     expect(restored.build.notchLimit).toBe(4);
+    expect(restored.damageLogAggregates.attacksLogged).toBe(0);
   });
 
   it('ignores malformed or incompatible persisted payloads', () => {
@@ -254,7 +259,7 @@ describe('fight-state persistence', () => {
     }
 
     const parsed = JSON.parse(stored) as { version: number; state: unknown };
-    expect(parsed.version).toBe(4);
+    expect(parsed.version).toBe(5);
     expect(parsed.state).toBeTruthy();
   });
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
-const STORAGE_VERSION = 4;
+const STORAGE_VERSION = 5;
 type SpellLevel = 'none' | 'base' | 'upgrade';
 
 const numberFormatter = new Intl.NumberFormat('en-US');

--- a/tests/e2e/screenshot.spec.ts
+++ b/tests/e2e/screenshot.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 const STORAGE_KEY = 'hollow-knight-damage-tracker:fight-state';
-const STORAGE_VERSION = 4;
+const STORAGE_VERSION = 5;
 
 const MID_COMBAT_STATE = {
   selectedBossId: 'gruz-mother__radiant',


### PR DESCRIPTION
## Summary
- maintain running damage aggregates on fight state, persisting them and updating reducer logic
- reuse cached totals in FightStateContext and process only new combat log entries to avoid repeated iteration
- bump persistence schema and update tests to cover the new aggregate fields

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db0c88c180832fa071aced1ad51e42