### PR TITLE
feat: streamline charm loadout interactions

### DIFF
--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -444,7 +444,13 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
                               return null;
                             }
 
-                            const renderVariantButton = (charmId: string) => {
+                            const renderVariantButton = (
+                              charmId: string,
+                              {
+                                isStacked,
+                                isBackdrop,
+                              }: { isStacked?: boolean; isBackdrop?: boolean } = {},
+                            ) => {
                               const variantCharm = charmDetails.get(charmId);
                               if (!variantCharm) {
                                 return null;
@@ -456,7 +462,8 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
                               const canEquipVariant = canEquipCharm(variantCharm.id);
                               const variantClasses = [
                                 'charm-token',
-                                'charm-token--variant-layer',
+                                isStacked ? 'charm-token--stacked' : '',
+                                isBackdrop ? 'charm-token--backdrop' : '',
                                 isVariantActive
                                   ? 'charm-token--active'
                                   : 'charm-token--idle',
@@ -467,6 +474,11 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
                                 .filter(Boolean)
                                 .join(' ');
                               const handleVariantClick = () => {
+                                if (isBackdrop) {
+                                  cycleCharmSlot(options, variantCharm.id);
+                                  return;
+                                }
+
                                 if (isVariantActive) {
                                   cycleCharmSlot(options);
                                 } else {
@@ -516,11 +528,21 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
                               return renderVariantButton(displayCharm.id);
                             }
 
+                            const stackedVariants = options.filter(
+                              (variantId) => variantId !== displayCharm.id,
+                            );
+
                             return (
-                              <div className="charm-token-multi">
-                                {options.map((variantId) =>
-                                  renderVariantButton(variantId),
+                              <div className="charm-token-stack">
+                                {stackedVariants.map((variantId) =>
+                                  renderVariantButton(variantId, {
+                                    isStacked: true,
+                                    isBackdrop: true,
+                                  }),
                                 )}
+                                {renderVariantButton(displayCharm.id, {
+                                  isStacked: true,
+                                })}
                               </div>
                             );
                           })()}

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -183,17 +183,30 @@ export const useBuildConfiguration = () => {
   );
 
   const cycleCharmSlot = useCallback(
-    (charmIds: readonly string[]) => {
+    (charmIds: readonly string[], targetId?: string) => {
       if (charmIds.length === 0) {
+        return;
+      }
+
+      if (targetId) {
+        const isActive = activeCharmIds.includes(targetId);
+        if (isActive) {
+          setActiveCharms(activeCharmIds.filter((id) => id !== targetId));
+          return;
+        }
+
+        const withoutSlot = activeCharmIds.filter((id) => !charmIds.includes(id));
+        const withoutConflict = resolveCharmConflict(withoutSlot, targetId);
+        setActiveCharms([...withoutConflict, targetId]);
         return;
       }
 
       const activeIndex = charmIds.findIndex((id) => activeCharmIds.includes(id));
 
       if (activeIndex === -1) {
-        const targetId = charmIds[0];
-        const withoutConflict = resolveCharmConflict(activeCharmIds, targetId);
-        setActiveCharms([...withoutConflict, targetId]);
+        const target = charmIds[0];
+        const withoutConflict = resolveCharmConflict(activeCharmIds, target);
+        setActiveCharms([...withoutConflict, target]);
         return;
       }
 
@@ -202,8 +215,8 @@ export const useBuildConfiguration = () => {
 
       if (nextIndex < charmIds.length) {
         const nextId = charmIds[nextIndex];
-        const withoutCurrent = activeCharmIds.filter((id) => id !== currentId);
-        const withoutConflict = resolveCharmConflict(withoutCurrent, nextId);
+        const withoutSlot = activeCharmIds.filter((id) => !charmIds.includes(id));
+        const withoutConflict = resolveCharmConflict(withoutSlot, nextId);
         setActiveCharms([...withoutConflict, nextId]);
         return;
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2074,6 +2074,7 @@ h6 {
     var(--charm-track-min),
     min(var(--charm-size), var(--charm-track-base))
   );
+  --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
 
   overflow-x: auto;
   padding-bottom: 0.5rem;
@@ -2435,8 +2436,6 @@ h6 {
 }
 
 .charm-grid {
-  --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
-
   display: grid;
   gap: calc(var(--charm-gap) * 0.9);
   width: 100%;
@@ -2520,6 +2519,15 @@ h6 {
   z-index: 2;
 }
 
+.charm-token__icon {
+  position: relative;
+  z-index: 1;
+  width: calc(var(--charm-track-size) * 0.96);
+  height: calc(var(--charm-track-size) * 0.96);
+  object-fit: contain;
+  pointer-events: none;
+}
+
 .charm-token--backdrop {
   filter: grayscale(0.95) brightness(0.42) saturate(0.55);
   opacity: 0.38;
@@ -2539,15 +2547,6 @@ h6 {
   filter: blur(12px);
   opacity: 0.5;
   z-index: -1;
-}
-
-.charm-token__icon {
-  position: relative;
-  z-index: 1;
-  width: calc(var(--charm-track-size) * 0.96);
-  height: calc(var(--charm-track-size) * 0.96);
-  object-fit: contain;
-  pointer-events: none;
 }
 
 .charm-token--backdrop .charm-token__icon {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2041,8 +2041,23 @@ h6 {
 }
 
 .charm-workbench {
+  position: relative;
   display: grid;
   gap: 1.25rem;
+}
+
+.charm-animation-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.charm-flight {
+  position: absolute;
+  will-change: transform;
+  transition: transform 280ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  filter: drop-shadow(0 10px 18px rgb(0 0 0 / 35%));
 }
 
 .charm-workbench__overview {
@@ -2432,94 +2447,82 @@ h6 {
 
 .charm-slot {
   display: grid;
-  gap: 0.45rem;
-  justify-items: center;
-  min-height: calc(var(--charm-size) + 1.2rem);
-}
-
-.charm-slot--paired {
-  min-height: calc(var(--charm-size) * 1.85);
+  place-items: center;
+  min-height: var(--charm-size);
 }
 
 .charm-token {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.45rem;
+  display: grid;
+  place-items: center;
   width: var(--charm-size);
-  min-height: calc(var(--charm-size) + 1.4rem);
-  padding: 0.65rem 0.55rem 0.9rem;
-  border-radius: 18px;
-  border: 1px solid rgb(255 255 255 / 12%);
-  background: radial-gradient(
-    circle at 30% 25%,
-    rgb(130 207 255 / 22%),
-    rgb(8 10 24 / 92%)
-  );
-  color: inherit;
+  height: var(--charm-size);
+  padding: 0;
+  border: none;
+  background: none;
   cursor: pointer;
   transition:
     transform 150ms ease,
-    border-color 150ms ease,
-    box-shadow 150ms ease,
-    filter 150ms ease,
-    opacity 150ms ease;
+    filter 180ms ease,
+    opacity 180ms ease;
 }
 
-.charm-token:not(:disabled):hover,
-.charm-token:not(:disabled):focus-visible {
-  outline: none;
-  transform: translateY(-2px);
-  border-color: rgb(130 207 255 / 55%);
-  box-shadow: 0 16px 36px rgb(5 8 26 / 38%);
+.charm-token:focus-visible {
+  outline: 2px solid rgb(130 207 255 / 65%);
+  outline-offset: 4px;
+}
+
+.charm-token:not(:disabled):hover {
+  transform: translateY(-2px) scale(1.03);
 }
 
 .charm-token--idle {
-  filter: saturate(0.65) brightness(0.9);
-  opacity: 0.9;
+  filter: saturate(0.85) brightness(0.95);
 }
 
 .charm-token--active {
-  border-color: rgb(255 199 126 / 85%);
-  box-shadow:
-    0 18px 42px rgb(255 199 126 / 32%),
-    inset 0 0 14px rgb(255 199 126 / 22%);
-  filter: saturate(1.05) brightness(1.05);
+  filter: grayscale(0.9) brightness(0.7);
+  opacity: 0.78;
 }
 
 .charm-token--locked {
   cursor: not-allowed;
-  opacity: 0.4;
-  filter: grayscale(0.25);
-}
-
-.charm-token:disabled:not(.charm-token--active) {
-  transform: none;
+  filter: grayscale(0.95) brightness(0.55);
+  opacity: 0.45;
 }
 
 .charm-token__icon {
-  width: calc(var(--charm-size) * 0.85);
-  height: calc(var(--charm-size) * 0.85);
+  width: calc(var(--charm-size) * 0.92);
+  height: calc(var(--charm-size) * 0.92);
   object-fit: contain;
+  pointer-events: none;
 }
 
-.charm-token__name {
-  font-size: 0.68rem;
-  text-align: center;
-  color: var(--color-muted);
-}
-
-.charm-token__cost {
+.charm-token__hover-label {
   position: absolute;
-  inset: 0.45rem 0.45rem auto auto;
-  border-radius: 999px;
-  padding: 0.15rem 0.45rem;
+  top: calc(100% + 0.35rem);
+  left: 50%;
+  transform: translate(-50%, 10%);
+  padding: 0.25rem 0.45rem;
+  border-radius: 8px;
+  background: rgb(9 11 28 / 92%);
+  color: var(--color-text);
   font-size: var(--font-size-caption);
-  letter-spacing: 0.05em;
-  text-transform: none;
-  background: rgb(0 0 0 / 55%);
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  white-space: nowrap;
+  z-index: 2;
+  box-shadow: 0 6px 14px rgb(0 0 0 / 35%);
+}
+
+.charm-token:focus-visible .charm-token__hover-label,
+.charm-token:not(:disabled):hover .charm-token__hover-label {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .spell-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2069,9 +2069,11 @@ h6 {
   --charm-size: clamp(2.8rem, 6vw, 4.6rem);
   --charm-gap-max: clamp(0.5rem, 0.8vw, 0.8rem);
   --charm-gap: min(var(--charm-gap-max), calc(100% / 18));
-  --charm-track-size: min(
-    var(--charm-size),
-    max(0px, calc((100% - (9 * var(--charm-gap))) / 10))
+  --charm-track-base: max(0px, calc((100% - (9 * var(--charm-gap))) / 10));
+  --charm-track-min: calc(var(--charm-size) * 0.45);
+  --charm-track-size: max(
+    var(--charm-track-min),
+    min(var(--charm-size), var(--charm-track-base))
   );
 
   overflow-x: auto;
@@ -2455,6 +2457,15 @@ h6 {
   min-height: var(--charm-track-size);
 }
 
+.charm-token-multi {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: calc(var(--charm-track-size) * 0.12);
+  width: var(--charm-track-size);
+}
+
 .charm-token {
   position: relative;
   display: grid;
@@ -2469,6 +2480,11 @@ h6 {
     transform 150ms ease,
     filter 180ms ease,
     opacity 180ms ease;
+}
+
+.charm-token--variant-layer {
+  width: calc(var(--charm-track-size) * 0.85);
+  height: calc(var(--charm-track-size) * 0.85);
 }
 
 .charm-token:focus-visible {
@@ -2502,6 +2518,11 @@ h6 {
   height: calc(var(--charm-track-size) * 0.92);
   object-fit: contain;
   pointer-events: none;
+}
+
+.charm-token--variant-layer .charm-token__icon {
+  width: 100%;
+  height: 100%;
 }
 
 .charm-token__hover-label {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2068,7 +2068,7 @@ h6 {
 .charm-workbench__grid {
   --charm-size: clamp(3.15rem, 6.8vw, 5rem);
   --charm-gap: clamp(0.18rem, 0.5vw, 0.45rem);
-  --charm-track-base: max(0px, calc((100% - (9 * var(--charm-gap))) / 10));
+  --charm-track-base: max(0px, calc((100% - (9.5 * var(--charm-gap))) / 10.5));
   --charm-track-min: calc(var(--charm-size) * 0.62);
   --charm-track-size: max(
     var(--charm-track-min),
@@ -2435,9 +2435,11 @@ h6 {
 }
 
 .charm-grid {
+  --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
+
   display: grid;
   gap: calc(var(--charm-gap) * 0.9);
-  --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
+  width: 100%;
 }
 
 .charm-grid__row {
@@ -2539,10 +2541,6 @@ h6 {
   z-index: -1;
 }
 
-.charm-token--backdrop .charm-token__icon {
-  opacity: 0.65;
-}
-
 .charm-token__icon {
   position: relative;
   z-index: 1;
@@ -2550,6 +2548,10 @@ h6 {
   height: calc(var(--charm-track-size) * 0.96);
   object-fit: contain;
   pointer-events: none;
+}
+
+.charm-token--backdrop .charm-token__icon {
+  opacity: 0.65;
 }
 
 .charm-token__hover-label {
@@ -2716,7 +2718,7 @@ h6 {
   }
 
   .charm-grid__row--offset {
-    margin-left: calc((var(--charm-track-size) + var(--charm-gap)) / 1.6);
+    margin-left: var(--charm-indent);
   }
 
   .button-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2067,7 +2067,12 @@ h6 {
 
 .charm-workbench__grid {
   --charm-size: clamp(2.8rem, 6vw, 4.6rem);
-  --charm-gap: clamp(0.5rem, 0.8vw, 0.8rem);
+  --charm-gap-max: clamp(0.5rem, 0.8vw, 0.8rem);
+  --charm-gap: min(var(--charm-gap-max), calc(100% / 18));
+  --charm-track-size: min(
+    var(--charm-size),
+    max(0px, calc((100% - (9 * var(--charm-gap))) / 10))
+  );
 
   overflow-x: auto;
   padding-bottom: 0.5rem;
@@ -2092,7 +2097,7 @@ h6 {
 @media (width >= 1280px) {
   .charm-workbench__grid {
     --charm-size: 4.9rem;
-    --charm-gap: 0.85rem;
+    --charm-gap-max: 0.85rem;
   }
 }
 
@@ -2432,31 +2437,30 @@ h6 {
 .charm-grid {
   display: grid;
   gap: calc(var(--charm-gap) * 1.1);
-  min-width: max-content;
 }
 
 .charm-grid__row {
   display: grid;
-  grid-template-columns: repeat(10, var(--charm-size));
+  grid-template-columns: repeat(10, minmax(0, var(--charm-track-size)));
   gap: var(--charm-gap);
 }
 
 .charm-grid__row--offset {
-  margin-left: calc((var(--charm-size) + var(--charm-gap)) / 2);
+  margin-left: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
 }
 
 .charm-slot {
   display: grid;
   place-items: center;
-  min-height: var(--charm-size);
+  min-height: var(--charm-track-size);
 }
 
 .charm-token {
   position: relative;
   display: grid;
   place-items: center;
-  width: var(--charm-size);
-  height: var(--charm-size);
+  width: var(--charm-track-size);
+  height: var(--charm-track-size);
   padding: 0;
   border: none;
   background: none;
@@ -2492,8 +2496,10 @@ h6 {
 }
 
 .charm-token__icon {
-  width: calc(var(--charm-size) * 0.92);
-  height: calc(var(--charm-size) * 0.92);
+  position: relative;
+  z-index: 1;
+  width: calc(var(--charm-track-size) * 0.92);
+  height: calc(var(--charm-track-size) * 0.92);
   object-fit: contain;
   pointer-events: none;
 }
@@ -2515,7 +2521,7 @@ h6 {
     opacity 120ms ease,
     transform 120ms ease;
   white-space: nowrap;
-  z-index: 2;
+  z-index: 4;
   box-shadow: 0 6px 14px rgb(0 0 0 / 35%);
 }
 
@@ -2662,7 +2668,7 @@ h6 {
   }
 
   .charm-grid__row--offset {
-    margin-left: calc((var(--charm-size) + var(--charm-gap)) / 1.6);
+    margin-left: calc((var(--charm-track-size) + var(--charm-gap)) / 1.6);
   }
 
   .button-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2516,6 +2516,11 @@ h6 {
 }
 
 .charm-token--stacked:not(.charm-token--backdrop) {
+  inset: auto;
+  top: calc(var(--charm-track-size) * 0.38);
+  left: calc(var(--charm-track-size) * 0.34);
+  width: calc(var(--charm-track-size) * 0.82);
+  height: calc(var(--charm-track-size) * 0.82);
   z-index: 2;
 }
 
@@ -2529,12 +2534,13 @@ h6 {
 }
 
 .charm-token--backdrop {
+  inset: auto;
+  top: calc(var(--charm-track-size) * -0.24);
+  left: calc(var(--charm-track-size) * -0.22);
+  width: calc(var(--charm-track-size) * 0.82);
+  height: calc(var(--charm-track-size) * 0.82);
   filter: grayscale(0.95) brightness(0.42) saturate(0.55);
   opacity: 0.38;
-  transform: translate(
-    calc(var(--charm-track-size) * -0.16),
-    calc(var(--charm-track-size) * -0.14)
-  );
   z-index: 1;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2066,11 +2066,10 @@ h6 {
 }
 
 .charm-workbench__grid {
-  --charm-size: clamp(2.8rem, 6vw, 4.6rem);
-  --charm-gap-max: clamp(0.5rem, 0.8vw, 0.8rem);
-  --charm-gap: min(var(--charm-gap-max), calc(100% / 18));
+  --charm-size: clamp(3.15rem, 6.8vw, 5rem);
+  --charm-gap: clamp(0.18rem, 0.5vw, 0.45rem);
   --charm-track-base: max(0px, calc((100% - (9 * var(--charm-gap))) / 10));
-  --charm-track-min: calc(var(--charm-size) * 0.45);
+  --charm-track-min: calc(var(--charm-size) * 0.62);
   --charm-track-size: max(
     var(--charm-track-min),
     min(var(--charm-size), var(--charm-track-base))
@@ -2099,7 +2098,6 @@ h6 {
 @media (width >= 1280px) {
   .charm-workbench__grid {
     --charm-size: 4.9rem;
-    --charm-gap-max: 0.85rem;
   }
 }
 
@@ -2438,17 +2436,25 @@ h6 {
 
 .charm-grid {
   display: grid;
-  gap: calc(var(--charm-gap) * 1.1);
+  gap: calc(var(--charm-gap) * 0.9);
+  --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
 }
 
 .charm-grid__row {
   display: grid;
   grid-template-columns: repeat(10, minmax(0, var(--charm-track-size)));
   gap: var(--charm-gap);
+  width: max-content;
 }
 
 .charm-grid__row--offset {
-  margin-left: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
+  justify-self: end;
+  margin-left: var(--charm-indent);
+}
+
+.charm-grid__row:not(.charm-grid__row--offset) {
+  justify-self: start;
+  margin-right: var(--charm-indent);
 }
 
 .charm-slot {
@@ -2457,13 +2463,10 @@ h6 {
   min-height: var(--charm-track-size);
 }
 
-.charm-token-multi {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  gap: calc(var(--charm-track-size) * 0.12);
+.charm-token-stack {
+  position: relative;
   width: var(--charm-track-size);
+  height: var(--charm-track-size);
 }
 
 .charm-token {
@@ -2480,11 +2483,6 @@ h6 {
     transform 150ms ease,
     filter 180ms ease,
     opacity 180ms ease;
-}
-
-.charm-token--variant-layer {
-  width: calc(var(--charm-track-size) * 0.85);
-  height: calc(var(--charm-track-size) * 0.85);
 }
 
 .charm-token:focus-visible {
@@ -2511,18 +2509,47 @@ h6 {
   opacity: 0.45;
 }
 
+.charm-token--stacked {
+  position: absolute;
+  inset: 0;
+}
+
+.charm-token--stacked:not(.charm-token--backdrop) {
+  z-index: 2;
+}
+
+.charm-token--backdrop {
+  filter: grayscale(0.95) brightness(0.42) saturate(0.55);
+  opacity: 0.38;
+  transform: translate(
+    calc(var(--charm-track-size) * -0.16),
+    calc(var(--charm-track-size) * -0.14)
+  );
+  z-index: 1;
+}
+
+.charm-token--backdrop::after {
+  content: '';
+  position: absolute;
+  inset: 6%;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 55%);
+  filter: blur(12px);
+  opacity: 0.5;
+  z-index: -1;
+}
+
+.charm-token--backdrop .charm-token__icon {
+  opacity: 0.65;
+}
+
 .charm-token__icon {
   position: relative;
   z-index: 1;
-  width: calc(var(--charm-track-size) * 0.92);
-  height: calc(var(--charm-track-size) * 0.92);
+  width: calc(var(--charm-track-size) * 0.96);
+  height: calc(var(--charm-track-size) * 0.96);
   object-fit: contain;
   pointer-events: none;
-}
-
-.charm-token--variant-layer .charm-token__icon {
-  width: 100%;
-  height: 100%;
 }
 
 .charm-token__hover-label {


### PR DESCRIPTION
## Summary
- replace the loadout grid buttons with icon-based charm slots that cycle multi-version charms, surface hover labels, and animate newly equipped charms into the bracelet
- update build configuration helpers to preserve chronological equip order, keep Void Heart anchored to the left slot, and provide slot-level cycling behavior
- refresh charm grid styling so equipped charms dim appropriately and tooltip labels and flight animations render cleanly on the modal canvas

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68db3b896be0832fb6a7b437cd05fdd9