### PR TITLE
fix: reduce persistence jank and improve combat log

### DIFF
--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -105,21 +105,24 @@ describe('FightStateProvider persistence', () => {
 
     await user.click(screen.getByRole('button'));
 
-    await waitFor(() => {
-      const stored = window.localStorage.getItem(STORAGE_KEY);
-      expect(stored).not.toBeNull();
-      if (!stored) {
-        throw new Error('Expected persisted fight state');
-      }
+    await waitFor(
+      () => {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        expect(stored).not.toBeNull();
+        if (!stored) {
+          throw new Error('Expected persisted fight state');
+        }
 
-      const parsed = JSON.parse(stored) as {
-        version: number;
-        state: { selectedBossId: string; customTargetHp: number };
-      };
-      expect(parsed.version).toBe(5);
-      expect(parsed.state.selectedBossId).toBe(CUSTOM_BOSS_ID);
-      expect(parsed.state.customTargetHp).toBe(4321);
-    });
+        const parsed = JSON.parse(stored) as {
+          version: number;
+          state: { selectedBossId: string; customTargetHp: number };
+        };
+        expect(parsed.version).toBe(5);
+        expect(parsed.state.selectedBossId).toBe(CUSTOM_BOSS_ID);
+        expect(parsed.state.customTargetHp).toBe(4321);
+      },
+      { timeout: 2000 },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- move combat log persistence work into idle tasks with throttling so JSON serialization no longer runs every render
- update combat log auto-scroll logic to respect user scroll position and cover it with a unit test
- throttle fight state persistence, extend its tests to cover the new behavior, and allow more time for localStorage writes during UI tests

## Testing
- pnpm vitest run src/features/combat-log/CombatLogPanel.test.tsx src/features/fight-state/persistence.test.ts src/features/fight-state/FightStateContext.test.tsx
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68db43192968832fbd7f6134ce081abe