### PR TITLE
fix: prevent combat log from growing with entries

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1541,8 +1541,7 @@ h6 {
 .combat-log {
   position: relative;
   flex: 1 1 auto;
-  min-height: clamp(200px, 42vh, 520px);
-  max-height: 100%;
+  block-size: clamp(200px, 42vh, 520px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- keep the combat log panel at its initial height by constraining it with a fixed block-size so new entries scroll instead of expanding the container

## Testing
- pnpm test:unit --run

------
https://chatgpt.com/codex/tasks/task_e_68db4f490384832fa30702f31bfaa11e