### PR TITLE
fix: restore charm selector layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2443,16 +2443,15 @@ h6 {
 }
 
 .charm-grid__row {
-  display: flex;
-  justify-content: center;
-  gap: var(--charm-gap);
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, var(--charm-track-size)));
+  column-gap: var(--charm-gap);
+  width: max-content;
+  transform: translateX(calc(var(--charm-indent) * -0.5));
 }
 
-.charm-grid__row--offset::before,
-.charm-grid__row--offset::after {
-  content: '';
-  flex: 0 0 max(0px, calc(var(--charm-indent) - var(--charm-gap)));
-  display: block;
+.charm-grid__row--offset {
+  transform: translateX(calc(var(--charm-indent) * 0.5));
 }
 
 .charm-slot {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2435,26 +2435,22 @@ h6 {
 }
 
 .charm-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: calc(var(--charm-gap) * 0.9);
   width: 100%;
 }
 
 .charm-grid__row {
-  display: grid;
-  grid-template-columns: repeat(10, minmax(0, var(--charm-track-size)));
+  display: flex;
   gap: var(--charm-gap);
-  width: max-content;
 }
 
-.charm-grid__row--offset {
-  justify-self: end;
-  margin-left: var(--charm-indent);
-}
-
-.charm-grid__row:not(.charm-grid__row--offset) {
-  justify-self: start;
-  margin-right: var(--charm-indent);
+.charm-grid__row--offset::before {
+  content: '';
+  flex: 0 0 var(--charm-indent);
+  display: block;
 }
 
 .charm-slot {
@@ -2516,10 +2512,10 @@ h6 {
 
 .charm-token--stacked:not(.charm-token--backdrop) {
   inset: auto;
-  top: calc(var(--charm-track-size) * 0.38);
-  left: calc(var(--charm-track-size) * 0.34);
-  width: calc(var(--charm-track-size) * 0.82);
-  height: calc(var(--charm-track-size) * 0.82);
+  top: calc(var(--charm-track-size) * 0.08);
+  left: calc(var(--charm-track-size) * 0.08);
+  width: calc(var(--charm-track-size) * 0.98);
+  height: calc(var(--charm-track-size) * 0.98);
   z-index: 2;
 }
 
@@ -2534,10 +2530,10 @@ h6 {
 
 .charm-token--backdrop {
   inset: auto;
-  top: calc(var(--charm-track-size) * -0.24);
-  left: calc(var(--charm-track-size) * -0.22);
-  width: calc(var(--charm-track-size) * 0.82);
-  height: calc(var(--charm-track-size) * 0.82);
+  top: calc(var(--charm-track-size) * -0.1);
+  left: calc(var(--charm-track-size) * -0.1);
+  width: calc(var(--charm-track-size) * 0.9);
+  height: calc(var(--charm-track-size) * 0.9);
   filter: grayscale(0.95) brightness(0.42) saturate(0.55);
   opacity: 0.38;
   z-index: 1;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2444,10 +2444,12 @@ h6 {
 
 .charm-grid__row {
   display: flex;
+  justify-content: center;
   gap: var(--charm-gap);
 }
 
-.charm-grid__row--offset::before {
+.charm-grid__row--offset::before,
+.charm-grid__row--offset::after {
   content: '';
   flex: 0 0 max(0px, calc(var(--charm-indent) - var(--charm-gap)));
   display: block;
@@ -2461,6 +2463,8 @@ h6 {
 
 .charm-token-stack {
   position: relative;
+  display: grid;
+  place-items: center;
   width: var(--charm-track-size);
   height: var(--charm-track-size);
 }
@@ -2512,8 +2516,9 @@ h6 {
 
 .charm-token--stacked:not(.charm-token--backdrop) {
   inset: auto;
-  top: calc(var(--charm-track-size) * 0.08);
-  left: calc(var(--charm-track-size) * 0.08);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: calc(var(--charm-track-size) * 0.98);
   height: calc(var(--charm-track-size) * 0.98);
   z-index: 2;
@@ -2530,8 +2535,10 @@ h6 {
 
 .charm-token--backdrop {
   inset: auto;
-  top: calc(var(--charm-track-size) * -0.1);
-  left: calc(var(--charm-track-size) * -0.1);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%)
+    translate(calc(var(--charm-track-size) * -0.1), calc(var(--charm-track-size) * -0.1));
   width: calc(var(--charm-track-size) * 0.9);
   height: calc(var(--charm-track-size) * 0.9);
   filter: grayscale(0.95) brightness(0.42) saturate(0.55);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2449,7 +2449,7 @@ h6 {
 
 .charm-grid__row--offset::before {
   content: '';
-  flex: 0 0 var(--charm-indent);
+  flex: 0 0 max(0px, calc(var(--charm-indent) - var(--charm-gap)));
   display: block;
 }
 
@@ -2715,10 +2715,6 @@ h6 {
   .modal {
     --modal-padding-inline: 1rem;
     --modal-padding-block: clamp(1.5rem, 10vh, 3.5rem);
-  }
-
-  .charm-grid__row--offset {
-    margin-left: var(--charm-indent);
   }
 
   .button-grid {


### PR DESCRIPTION
## Summary
- center the charm selector grid using flex rows and pseudo-spacers to restore the staggered layout
- tighten the stacked charm positioning so inactive variants subtly peek from behind

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db6bc92e28832fbfe46948fe3bec43