### PR TITLE
feat: align standalone fight haptics with sequences

### DIFF
--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -209,6 +209,30 @@ describe('AttackLogPanel', () => {
     expect(endFightButton).not.toBeDisabled();
   });
 
+  it('plays the sequence completion haptic when ending standalone fights', async () => {
+    const user = userEvent.setup();
+
+    renderWithFightProvider(
+      <AttackLogProvider>
+        <AttackLogActions />
+        <AttackLogPanel />
+      </AttackLogProvider>,
+    );
+
+    const fightButton = screen.getByRole('button', { name: /fight/i });
+
+    await user.click(fightButton);
+    const endFightButton = await screen.findByRole('button', { name: /end fight/i });
+
+    triggerMock.mockClear();
+
+    await user.click(endFightButton);
+
+    await waitFor(() => {
+      expect(triggerMock).toHaveBeenCalledWith('sequence-complete');
+    });
+  });
+
   it('starts fights via the Enter key without logging damage', async () => {
     const user = userEvent.setup();
 

--- a/src/features/attack-log/AttackLogPanel.tsx
+++ b/src/features/attack-log/AttackLogPanel.tsx
@@ -193,11 +193,11 @@ export const AttackLogProvider: FC<AttackLogProviderProps> = ({ children }) => {
   const handleToggleFight = useCallback(() => {
     if (canEndFight) {
       actions.endFight();
-      triggerHaptics('fight-complete');
+      triggerHaptics(isSequenceActive ? 'fight-complete' : 'sequence-complete');
     } else if (canStartFight) {
       actions.startFight();
     }
-  }, [actions, canEndFight, canStartFight, triggerHaptics]);
+  }, [actions, canEndFight, canStartFight, isSequenceActive, triggerHaptics]);
 
   const handleLogAttack = useCallback(
     (attack: {

--- a/src/utils/haptics.test.ts
+++ b/src/utils/haptics.test.ts
@@ -7,7 +7,7 @@ const EXPECTED_VIBRATION_PATTERNS = {
   'fight-complete': [0, 40, 30, 60, 30, 80],
   'sequence-advance': [0, 25, 20, 25, 20, 25],
   'sequence-stage-complete': [0, 35, 25, 35, 25, 35, 25, 70],
-  'sequence-complete': [0, 45, 30, 45, 30, 70, 40, 120],
+  'sequence-complete': [0, 70, 45, 70, 45, 105, 60, 180],
   warning: [0, 30, 15, 30, 15, 30, 15, 60],
   success: [0, 20, 25, 40, 30, 60],
 } as const satisfies (typeof __TESTING__)['VIBRATION_PATTERNS'];

--- a/src/utils/haptics.ts
+++ b/src/utils/haptics.ts
@@ -14,7 +14,7 @@ const VIBRATION_PATTERNS: Record<HapticFeedbackType, VibratePattern> = {
   'fight-complete': [0, 40, 30, 60, 30, 80],
   'sequence-advance': [0, 25, 20, 25, 20, 25],
   'sequence-stage-complete': [0, 35, 25, 35, 25, 35, 25, 70],
-  'sequence-complete': [0, 45, 30, 45, 30, 70, 40, 120],
+  'sequence-complete': [0, 70, 45, 70, 45, 105, 60, 180],
   warning: [0, 30, 15, 30, 15, 30, 15, 60],
   success: [0, 20, 25, 40, 30, 60],
 };


### PR DESCRIPTION
## Summary
- trigger the sequence completion haptic when ending standalone fights while keeping fight completions for active sequences
- lengthen the sequence completion vibration pattern and refresh unit expectations

## Testing
- pnpm vitest run src/features/attack-log/AttackLogPanel.test.tsx src/utils/haptics.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc8eb2fbcc832fb5b07b5f462646b4