### PR TITLE
fix: refine charm stack alignment

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2075,6 +2075,7 @@ h6 {
   );
   --charm-indent: calc((var(--charm-track-size) + var(--charm-gap)) / 2);
 
+  display: contents;
   overflow-x: auto;
   padding-bottom: 0.5rem;
 }
@@ -2446,7 +2447,6 @@ h6 {
   display: grid;
   grid-template-columns: repeat(10, minmax(0, var(--charm-track-size)));
   column-gap: var(--charm-gap);
-  width: max-content;
   transform: translateX(calc(var(--charm-indent) * -0.5));
 }
 
@@ -2457,6 +2457,7 @@ h6 {
 .charm-slot {
   display: grid;
   place-items: center;
+  width: calc(var(--charm-size) * 0.9);
   min-height: var(--charm-track-size);
 }
 
@@ -2478,6 +2479,13 @@ h6 {
   border: none;
   background: none;
   cursor: pointer;
+
+  --charm-token-translate-x: 0%;
+  --charm-token-translate-y: 0%;
+  --charm-token-scale: 1;
+
+  transform: translate(var(--charm-token-translate-x), var(--charm-token-translate-y))
+    scale(var(--charm-token-scale));
   transition:
     transform 150ms ease,
     filter 180ms ease,
@@ -2490,7 +2498,8 @@ h6 {
 }
 
 .charm-token:not(:disabled):hover {
-  transform: translateY(-2px) scale(1.03);
+  --charm-token-translate-y: calc(var(--charm-token-translate-y) - 2px);
+  --charm-token-scale: 1.03;
 }
 
 .charm-token--idle {
@@ -2517,7 +2526,10 @@ h6 {
   inset: auto;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+
+  --charm-token-translate-x: -50%;
+  --charm-token-translate-y: -50%;
+
   width: calc(var(--charm-track-size) * 0.98);
   height: calc(var(--charm-track-size) * 0.98);
   z-index: 2;
@@ -2536,8 +2548,10 @@ h6 {
   inset: auto;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%)
-    translate(calc(var(--charm-track-size) * -0.1), calc(var(--charm-track-size) * -0.1));
+
+  --charm-token-translate-x: calc(-50% - (var(--charm-track-size) * 0.1));
+  --charm-token-translate-y: calc(-50% - (var(--charm-track-size) * 0.1));
+
   width: calc(var(--charm-track-size) * 0.9);
   height: calc(var(--charm-track-size) * 0.9);
   filter: grayscale(0.95) brightness(0.42) saturate(0.55);


### PR DESCRIPTION
## Summary
- adopt the provided charm grid layout adjustments to match the latest alternating design
- stabilize stacked charm transforms so hover effects keep icons aligned
- tweak slot sizing to better match the intended visual proportions

## Testing
- pnpm lint
- pnpm test
- pnpm test:e2e --reporter=dot

------
https://chatgpt.com/codex/tasks/task_e_68dc9ee6cb08832f91e8e948cd17699f