### PR TITLE
fix: validate persisted boss selection

### DIFF
--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -232,6 +232,29 @@ describe('fight-state persistence', () => {
     expect(restored.damageLogAggregates.attacksLogged).toBe(0);
   });
 
+  it('falls back to a safe boss id when the persisted selection is unknown', () => {
+    const baseFallback = ensureSequenceState(ensureSpellLevels(createInitialState()));
+    const fallback: FightState = {
+      ...baseFallback,
+      selectedBossId: CUSTOM_BOSS_ID,
+      customTargetHp: 777,
+    };
+
+    const persisted = {
+      version: 5,
+      state: {
+        selectedBossId: 'unknown-target',
+        customTargetHp: 321,
+      },
+    } satisfies Record<string, unknown>;
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+
+    const restored = restorePersistedState(fallback);
+    expect(restored.selectedBossId).toBe(CUSTOM_BOSS_ID);
+    expect(restored.customTargetHp).toBe(321);
+  });
+
   it('ignores malformed or incompatible persisted payloads', () => {
     const fallback = ensureSequenceState(ensureSpellLevels(createInitialState()));
 

--- a/src/features/fight-state/persistence.ts
+++ b/src/features/fight-state/persistence.ts
@@ -1,6 +1,7 @@
 import {
   AttackCategory,
   AttackEvent,
+  CUSTOM_BOSS_ID,
   DamageLogAggregates,
   FightState,
   MAX_NOTCH_LIMIT,
@@ -12,6 +13,7 @@ import {
 } from './fightReducer';
 import { NAIL_ART_IDS } from '../attack-log/attackData';
 import type { NailArtId } from '../attack-log/attackData';
+import { bossMap } from '../../data';
 
 const isNailArtId = (id: string): id is NailArtId => NAIL_ART_IDS.has(id as NailArtId);
 
@@ -252,14 +254,36 @@ const sanitizeBooleanRecord = (
   return sanitized;
 };
 
+const resolveSelectedBossId = (value: unknown, fallbackBossId: string): string => {
+  const persistedBossId = typeof value === 'string' ? value : null;
+
+  if (persistedBossId === CUSTOM_BOSS_ID) {
+    return CUSTOM_BOSS_ID;
+  }
+
+  if (persistedBossId && bossMap.has(persistedBossId)) {
+    return persistedBossId;
+  }
+
+  if (fallbackBossId === CUSTOM_BOSS_ID) {
+    return CUSTOM_BOSS_ID;
+  }
+
+  if (bossMap.has(fallbackBossId)) {
+    return fallbackBossId;
+  }
+
+  return CUSTOM_BOSS_ID;
+};
+
 export const mergePersistedState = (
   persisted: Record<string, unknown>,
   fallback: FightState,
 ): FightState => {
-  const selectedBossId =
-    typeof persisted.selectedBossId === 'string'
-      ? persisted.selectedBossId
-      : fallback.selectedBossId;
+  const selectedBossId = resolveSelectedBossId(
+    persisted.selectedBossId,
+    fallback.selectedBossId,
+  );
   const customTargetHp = sanitizePositiveInteger(
     persisted.customTargetHp,
     fallback.customTargetHp,


### PR DESCRIPTION
## Summary
- verify persisted boss selections exist before restoring state and fall back safely
- maintain custom target HP when the custom boss is selected and add regression coverage

## Testing
- pnpm test src/features/fight-state/persistence.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de0c9839d4832f88df8bc656848b97