### PR TITLE
refactor: centralize modal handling

### DIFF
--- a/src/components/Modal.test.tsx
+++ b/src/components/Modal.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from './Modal';
+
+describe('Modal', () => {
+  it('locks body scroll while open and restores on unmount', () => {
+    document.body.style.overflow = 'auto';
+
+    const handleClose = vi.fn();
+    const { unmount } = render(
+      <Modal isOpen onClose={handleClose} titleId="modal-title" title="Example">
+        <p>Content</p>
+      </Modal>,
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('focuses the close button when opened', async () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={handleClose} titleId="modal-title" title="Example">
+        <p>Content</p>
+      </Modal>,
+    );
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+  });
+
+  it('invokes onClose when Escape is pressed', () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={handleClose} titleId="modal-title" title="Example">
+        <p>Content</p>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose when the backdrop is clicked', () => {
+    const handleClose = vi.fn();
+
+    render(
+      <Modal isOpen onClose={handleClose} titleId="modal-title" title="Example">
+        <p>Content</p>
+      </Modal>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, type FC, type ReactNode } from 'react';
+
+type ModalProps = {
+  readonly isOpen: boolean;
+  readonly titleId: string;
+  readonly title: ReactNode;
+  readonly subtitle?: ReactNode;
+  readonly onClose: () => void;
+  readonly children: ReactNode;
+};
+
+const useModalLifecycle = (isOpen: boolean, onClose: () => void) => {
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    queueMicrotask(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  return closeButtonRef;
+};
+
+export const Modal: FC<ModalProps> = ({
+  isOpen,
+  titleId,
+  title,
+  subtitle,
+  onClose,
+  children,
+}) => {
+  const closeButtonRef = useModalLifecycle(isOpen, onClose);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <button
+        type="button"
+        className="modal__backdrop"
+        aria-label="Close dialog"
+        onClick={onClose}
+      />
+      <div className="modal__content">
+        <header className="modal__header">
+          <div>
+            <h2 id={titleId} className="modal__title">
+              {title}
+            </h2>
+            {subtitle ? <p className="modal__subtitle">{subtitle}</p> : null}
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="modal__close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </header>
+        <div className="modal__body">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export type { ModalProps };

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -6,6 +6,7 @@ import type { Charm } from '../../data';
 import { MAX_NOTCH_LIMIT, MIN_NOTCH_LIMIT } from '../fight-state/fightReducer';
 import { charmGridLayout, useBuildConfiguration } from './useBuildConfiguration';
 import { useHapticFeedback } from '../../utils/haptics';
+import { Modal } from '../../components/Modal';
 
 const CHARM_PRESETS = [
   {
@@ -148,9 +149,7 @@ const CharmFlightSprite: FC<{
   );
 };
 
-const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
-  onClose,
-}) => {
+const PlayerConfigModalContent: FC = () => {
   const {
     notchLimit,
     activeCharmIds,
@@ -168,8 +167,6 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
     build,
   } = useBuildConfiguration();
 
-  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const onCloseRef = useRef<PlayerConfigModalProps['onClose']>(onClose);
   const charmIconMap = useMemo(createCharmIconMap, []);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
   const charmSlotRefs = useRef(new Map<string, HTMLButtonElement | null>());
@@ -208,10 +205,6 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
   );
 
   useEffect(() => {
-    onCloseRef.current = onClose;
-  }, [onClose]);
-
-  useEffect(() => {
     const wasOvercharmed = overcharmRef.current;
     if (isOvercharmed && !wasOvercharmed) {
       triggerHaptics('warning');
@@ -223,28 +216,6 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
 
     overcharmRef.current = isOvercharmed;
   }, [isOvercharmed, triggerHaptics]);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onCloseRef.current();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    queueMicrotask(() => {
-      closeButtonRef.current?.focus();
-    });
-
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
 
   useEffect(() => {
     const previous = previousCharmIdsRef.current;
@@ -315,383 +286,340 @@ const PlayerConfigModalContent: FC<Pick<PlayerConfigModalProps, 'onClose'>> = ({
   }, []);
 
   return (
-    <div
-      className="modal"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="player-config-title"
-    >
-      <button
-        type="button"
-        className="modal__backdrop"
-        aria-label="Close dialog"
-        onClick={onClose}
-      />
-      <div className="modal__content">
-        <header className="modal__header">
-          <div>
-            <h2 id="player-config-title" className="modal__title">
-              Player Loadout
-            </h2>
-            <p className="modal__subtitle">
-              Tune your charms, spells, and advanced fight options. Changes apply
-              instantly.
-            </p>
+    <>
+      <section className="modal-section" aria-labelledby="charm-workbench-heading">
+        <div className="modal-section__header">
+          <h3 id="charm-workbench-heading">Charm Workbench</h3>
+        </div>
+        <p className="modal-section__description">
+          Manage equipped charms, adjust your notch bracelet, and browse the staggered
+          inventory grid.
+        </p>
+        <div className="charm-workbench" ref={workbenchRef}>
+          <div className="charm-animation-layer" aria-hidden="true">
+            {charmFlights.map((flight) => (
+              <CharmFlightSprite
+                key={flight.key}
+                animation={flight}
+                onComplete={handleCharmFlightComplete}
+              />
+            ))}
           </div>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            className="modal__close"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </header>
-
-        <div className="modal__body">
-          <section className="modal-section" aria-labelledby="charm-workbench-heading">
-            <div className="modal-section__header">
-              <h3 id="charm-workbench-heading">Charm Workbench</h3>
-            </div>
-            <p className="modal-section__description">
-              Manage equipped charms, adjust your notch bracelet, and browse the staggered
-              inventory grid.
-            </p>
-            <div className="charm-workbench" ref={workbenchRef}>
-              <div className="charm-animation-layer" aria-hidden="true">
-                {charmFlights.map((flight) => (
-                  <CharmFlightSprite
-                    key={flight.key}
-                    animation={flight}
-                    onComplete={handleCharmFlightComplete}
-                  />
-                ))}
+          <div className="charm-workbench__overview">
+            <div className="equipped-panel">
+              <h4 className="equipped-panel__title">Equipped</h4>
+              <div className="equipped-panel__grid" role="list" aria-live="polite">
+                {equippedCharms.length > 0 ? (
+                  equippedCharms.map((charm) => {
+                    const icon = charmIconMap.get(charm.id);
+                    return (
+                      <div
+                        key={charm.id}
+                        role="listitem"
+                        className="equipped-panel__item"
+                        title={getCharmTooltip(charm)}
+                        ref={(element) => {
+                          if (element) {
+                            equippedCharmRefs.current.set(charm.id, element);
+                          } else {
+                            equippedCharmRefs.current.delete(charm.id);
+                          }
+                        }}
+                      >
+                        {icon ? (
+                          <img
+                            src={icon}
+                            alt=""
+                            className="equipped-panel__icon"
+                            aria-hidden="true"
+                          />
+                        ) : null}
+                        <span className="visually-hidden">
+                          {getCharmAriaLabel(charm)}
+                        </span>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <p className="equipped-panel__empty">No charms equipped.</p>
+                )}
               </div>
-              <div className="charm-workbench__overview">
-                <div className="equipped-panel">
-                  <h4 className="equipped-panel__title">Equipped</h4>
-                  <div className="equipped-panel__grid" role="list" aria-live="polite">
-                    {equippedCharms.length > 0 ? (
-                      equippedCharms.map((charm) => {
-                        const icon = charmIconMap.get(charm.id);
-                        return (
-                          <div
-                            key={charm.id}
-                            role="listitem"
-                            className="equipped-panel__item"
-                            title={getCharmTooltip(charm)}
-                            ref={(element) => {
-                              if (element) {
-                                equippedCharmRefs.current.set(charm.id, element);
-                              } else {
-                                equippedCharmRefs.current.delete(charm.id);
-                              }
-                            }}
-                          >
-                            {icon ? (
-                              <img
-                                src={icon}
-                                alt=""
-                                className="equipped-panel__icon"
+            </div>
+            <div
+              className={`notch-panel${isOvercharmed ? ' notch-panel--overcharmed' : ''}`}
+            >
+              <div className="notch-panel__header">
+                <h4 className="notch-panel__title">Notches</h4>
+                <span className="notch-panel__usage">{notchUsage}</span>
+              </div>
+              <div className="notch-panel__bracelet" role="presentation">
+                {notchIndicators.map((indicator, index) => {
+                  const classes = ['notch-dot'];
+                  if (indicator.isWithinLimit) {
+                    classes.push('notch-dot--available');
+                  } else {
+                    classes.push('notch-dot--locked');
+                  }
+                  if (indicator.isUsed) {
+                    classes.push('notch-dot--filled');
+                  }
+                  if (indicator.isOverfill) {
+                    classes.push('notch-dot--overfill');
+                  }
+                  return (
+                    <span key={index} className={classes.join(' ')} aria-hidden="true" />
+                  );
+                })}
+              </div>
+              <label className="notch-panel__slider" htmlFor="notch-limit">
+                <span className="notch-panel__slider-label">Notch limit</span>
+                <input
+                  id="notch-limit"
+                  type="range"
+                  min={MIN_NOTCH_LIMIT}
+                  max={MAX_NOTCH_LIMIT}
+                  value={notchLimit}
+                  onChange={(event) => setNotchLimit(Number(event.target.value))}
+                />
+              </label>
+              <p className="notch-panel__description">
+                Set this to match your save file&apos;s available notches. Reducing the
+                limit below your equipped cost cracks the bracelet to warn you that you
+                are overcharmed.
+              </p>
+            </div>
+          </div>
+          {isOvercharmed ? (
+            <div className="overcharm-banner" role="status" aria-live="assertive">
+              <span className="overcharm-banner__label">Overcharmed</span>
+              <span className="overcharm-banner__message">
+                You&apos;ll take double damage until you unequip a charm.
+              </span>
+            </div>
+          ) : null}
+          <div className="charm-workbench__grid">
+            <div className="charm-grid" role="grid" aria-label="Charm inventory">
+              {charmGridLayout.map((row, rowIndex) => (
+                <div
+                  key={`row-${rowIndex}`}
+                  role="row"
+                  className={`charm-grid__row${rowIndex % 2 === 1 ? ' charm-grid__row--offset' : ''}`}
+                >
+                  {row.map((options, columnIndex) => (
+                    <div
+                      key={`${rowIndex}-${columnIndex}`}
+                      role="gridcell"
+                      className="charm-slot"
+                    >
+                      {(() => {
+                        const activeId = options.find((id) =>
+                          activeCharmIds.includes(id),
+                        );
+                        const displayId = activeId ?? options[0];
+                        const displayCharm = charmDetails.get(displayId);
+                        if (!displayCharm) {
+                          return null;
+                        }
+
+                        const renderVariantButton = (
+                          charmId: string,
+                          {
+                            isStacked,
+                            isBackdrop,
+                          }: { isStacked?: boolean; isBackdrop?: boolean } = {},
+                        ) => {
+                          const variantCharm = charmDetails.get(charmId);
+                          if (!variantCharm) {
+                            return null;
+                          }
+                          const variantIcon = charmIconMap.get(variantCharm.id);
+                          const isVariantActive = activeCharmIds.includes(
+                            variantCharm.id,
+                          );
+                          const canEquipVariant = canEquipCharm(variantCharm.id);
+                          const variantClasses = [
+                            'charm-token',
+                            isStacked ? 'charm-token--stacked' : '',
+                            isBackdrop ? 'charm-token--backdrop' : '',
+                            isVariantActive ? 'charm-token--active' : 'charm-token--idle',
+                            !isVariantActive && !canEquipVariant
+                              ? 'charm-token--locked'
+                              : '',
+                          ]
+                            .filter(Boolean)
+                            .join(' ');
+                          const handleVariantClick = () => {
+                            if (isBackdrop) {
+                              cycleCharmSlot(options, variantCharm.id);
+                              return;
+                            }
+
+                            if (isVariantActive) {
+                              cycleCharmSlot(options);
+                            } else {
+                              cycleCharmSlot(options, variantCharm.id);
+                            }
+                          };
+                          return (
+                            <button
+                              key={variantCharm.id}
+                              type="button"
+                              className={variantClasses}
+                              onClick={handleVariantClick}
+                              disabled={!isVariantActive && !canEquipVariant}
+                              aria-pressed={isVariantActive}
+                              aria-label={getCharmAriaLabel(variantCharm)}
+                              title={getCharmTooltip(variantCharm)}
+                              ref={(element) => {
+                                if (element) {
+                                  charmSlotRefs.current.set(variantCharm.id, element);
+                                } else {
+                                  charmSlotRefs.current.delete(variantCharm.id);
+                                }
+                              }}
+                            >
+                              {variantIcon ? (
+                                <img
+                                  src={variantIcon}
+                                  alt=""
+                                  className="charm-token__icon"
+                                  aria-hidden="true"
+                                />
+                              ) : null}
+                              <span
+                                className="charm-token__hover-label"
                                 aria-hidden="true"
-                              />
-                            ) : null}
-                            <span className="visually-hidden">
-                              {getCharmAriaLabel(charm)}
-                            </span>
+                              >
+                                {variantCharm.name}
+                              </span>
+                              <span className="visually-hidden">
+                                {getCharmAriaLabel(variantCharm)}
+                              </span>
+                            </button>
+                          );
+                        };
+
+                        if (options.length === 1) {
+                          return renderVariantButton(displayCharm.id);
+                        }
+
+                        const stackedVariants = options.filter(
+                          (variantId) => variantId !== displayCharm.id,
+                        );
+
+                        return (
+                          <div className="charm-token-stack">
+                            {stackedVariants.map((variantId) =>
+                              renderVariantButton(variantId, {
+                                isStacked: true,
+                                isBackdrop: true,
+                              }),
+                            )}
+                            {renderVariantButton(displayCharm.id, { isStacked: true })}
                           </div>
                         );
-                      })
-                    ) : (
-                      <p className="equipped-panel__empty">No charms equipped.</p>
-                    )}
-                  </div>
-                </div>
-                <div
-                  className={`notch-panel${isOvercharmed ? ' notch-panel--overcharmed' : ''}`}
-                >
-                  <div className="notch-panel__header">
-                    <h4 className="notch-panel__title">Notches</h4>
-                    <span className="notch-panel__usage">{notchUsage}</span>
-                  </div>
-                  <div className="notch-panel__bracelet" role="presentation">
-                    {notchIndicators.map((indicator, index) => {
-                      const classes = ['notch-dot'];
-                      if (indicator.isWithinLimit) {
-                        classes.push('notch-dot--available');
-                      } else {
-                        classes.push('notch-dot--locked');
-                      }
-                      if (indicator.isUsed) {
-                        classes.push('notch-dot--filled');
-                      }
-                      if (indicator.isOverfill) {
-                        classes.push('notch-dot--overfill');
-                      }
-                      return (
-                        <span
-                          key={index}
-                          className={classes.join(' ')}
-                          aria-hidden="true"
-                        />
-                      );
-                    })}
-                  </div>
-                  <label className="notch-panel__slider" htmlFor="notch-limit">
-                    <span className="notch-panel__slider-label">Notch limit</span>
-                    <input
-                      id="notch-limit"
-                      type="range"
-                      min={MIN_NOTCH_LIMIT}
-                      max={MAX_NOTCH_LIMIT}
-                      value={notchLimit}
-                      onChange={(event) => setNotchLimit(Number(event.target.value))}
-                    />
-                  </label>
-                  <p className="notch-panel__description">
-                    Set this to match your save file&apos;s available notches. Reducing
-                    the limit below your equipped cost cracks the bracelet to warn you
-                    that you are overcharmed.
-                  </p>
-                </div>
-              </div>
-              {isOvercharmed ? (
-                <div className="overcharm-banner" role="status" aria-live="assertive">
-                  <span className="overcharm-banner__label">Overcharmed</span>
-                  <span className="overcharm-banner__message">
-                    You&apos;ll take double damage until you unequip a charm.
-                  </span>
-                </div>
-              ) : null}
-              <div className="charm-workbench__grid">
-                <div className="charm-grid" role="grid" aria-label="Charm inventory">
-                  {charmGridLayout.map((row, rowIndex) => (
-                    <div
-                      key={`row-${rowIndex}`}
-                      role="row"
-                      className={`charm-grid__row${rowIndex % 2 === 1 ? ' charm-grid__row--offset' : ''}`}
-                    >
-                      {row.map((options, columnIndex) => (
-                        <div
-                          key={`${rowIndex}-${columnIndex}`}
-                          role="gridcell"
-                          className="charm-slot"
-                        >
-                          {(() => {
-                            const activeId = options.find((id) =>
-                              activeCharmIds.includes(id),
-                            );
-                            const displayId = activeId ?? options[0];
-                            const displayCharm = charmDetails.get(displayId);
-                            if (!displayCharm) {
-                              return null;
-                            }
-
-                            const renderVariantButton = (
-                              charmId: string,
-                              {
-                                isStacked,
-                                isBackdrop,
-                              }: { isStacked?: boolean; isBackdrop?: boolean } = {},
-                            ) => {
-                              const variantCharm = charmDetails.get(charmId);
-                              if (!variantCharm) {
-                                return null;
-                              }
-                              const variantIcon = charmIconMap.get(variantCharm.id);
-                              const isVariantActive = activeCharmIds.includes(
-                                variantCharm.id,
-                              );
-                              const canEquipVariant = canEquipCharm(variantCharm.id);
-                              const variantClasses = [
-                                'charm-token',
-                                isStacked ? 'charm-token--stacked' : '',
-                                isBackdrop ? 'charm-token--backdrop' : '',
-                                isVariantActive
-                                  ? 'charm-token--active'
-                                  : 'charm-token--idle',
-                                !isVariantActive && !canEquipVariant
-                                  ? 'charm-token--locked'
-                                  : '',
-                              ]
-                                .filter(Boolean)
-                                .join(' ');
-                              const handleVariantClick = () => {
-                                if (isBackdrop) {
-                                  cycleCharmSlot(options, variantCharm.id);
-                                  return;
-                                }
-
-                                if (isVariantActive) {
-                                  cycleCharmSlot(options);
-                                } else {
-                                  cycleCharmSlot(options, variantCharm.id);
-                                }
-                              };
-                              return (
-                                <button
-                                  key={variantCharm.id}
-                                  type="button"
-                                  className={variantClasses}
-                                  onClick={handleVariantClick}
-                                  disabled={!isVariantActive && !canEquipVariant}
-                                  aria-pressed={isVariantActive}
-                                  aria-label={getCharmAriaLabel(variantCharm)}
-                                  title={getCharmTooltip(variantCharm)}
-                                  ref={(element) => {
-                                    if (element) {
-                                      charmSlotRefs.current.set(variantCharm.id, element);
-                                    } else {
-                                      charmSlotRefs.current.delete(variantCharm.id);
-                                    }
-                                  }}
-                                >
-                                  {variantIcon ? (
-                                    <img
-                                      src={variantIcon}
-                                      alt=""
-                                      className="charm-token__icon"
-                                      aria-hidden="true"
-                                    />
-                                  ) : null}
-                                  <span
-                                    className="charm-token__hover-label"
-                                    aria-hidden="true"
-                                  >
-                                    {variantCharm.name}
-                                  </span>
-                                  <span className="visually-hidden">
-                                    {getCharmAriaLabel(variantCharm)}
-                                  </span>
-                                </button>
-                              );
-                            };
-
-                            if (options.length === 1) {
-                              return renderVariantButton(displayCharm.id);
-                            }
-
-                            const stackedVariants = options.filter(
-                              (variantId) => variantId !== displayCharm.id,
-                            );
-
-                            return (
-                              <div className="charm-token-stack">
-                                {stackedVariants.map((variantId) =>
-                                  renderVariantButton(variantId, {
-                                    isStacked: true,
-                                    isBackdrop: true,
-                                  }),
-                                )}
-                                {renderVariantButton(displayCharm.id, {
-                                  isStacked: true,
-                                })}
-                              </div>
-                            );
-                          })()}
-                        </div>
-                      ))}
+                      })()}
                     </div>
                   ))}
                 </div>
-              </div>
-              <div className="preset-panel">
-                <h4 className="preset-panel__title">Presets</h4>
-                <p className="preset-panel__description">
-                  Apply quick loadouts or clear your charms with a single tap.
-                </p>
-                <div className="preset-buttons" role="group" aria-label="Charm presets">
-                  {CHARM_PRESETS.map((preset) => (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      className="preset-buttons__button"
-                      onClick={() => applyCharmPreset(preset.charmIds)}
-                    >
-                      {preset.label}
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    className="preset-buttons__button"
-                    onClick={() => applyCharmPreset([])}
-                  >
-                    Clear charms
-                  </button>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="modal-section" aria-labelledby="spell-focus-heading">
-            <div className="modal-section__header">
-              <h3 id="spell-focus-heading">Spell Focus</h3>
-            </div>
-            <div className="spell-grid">
-              {spells.map((spell) => (
-                <fieldset key={spell.id} className="spell-card">
-                  <legend>{spell.name}</legend>
-                  <label className="spell-card__option spell-card__option--muted">
-                    <input
-                      type="radio"
-                      name={`spell-${spell.id}`}
-                      value="none"
-                      checked={build.spellLevels[spell.id] === 'none'}
-                      onChange={() => setSpellLevel(spell.id, 'none')}
-                    />
-                    <span>Not acquired</span>
-                  </label>
-                  <label className="spell-card__option">
-                    <input
-                      type="radio"
-                      name={`spell-${spell.id}`}
-                      value="base"
-                      checked={build.spellLevels[spell.id] === 'base'}
-                      onChange={() => setSpellLevel(spell.id, 'base')}
-                    />
-                    <span>{spell.base.name}</span>
-                  </label>
-                  {spell.upgrade ? (
-                    <label className="spell-card__option">
-                      <input
-                        type="radio"
-                        name={`spell-${spell.id}`}
-                        value="upgrade"
-                        checked={build.spellLevels[spell.id] === 'upgrade'}
-                        onChange={() => setSpellLevel(spell.id, 'upgrade')}
-                      />
-                      <span>{spell.upgrade.name}</span>
-                    </label>
-                  ) : null}
-                </fieldset>
               ))}
             </div>
-          </section>
-
-          <section className="modal-section" aria-labelledby="equipment-heading">
-            <div className="modal-section__header">
-              <h3 id="equipment-heading">Equipment Setup</h3>
-            </div>
-            <div className="form-grid">
-              <label className="form-grid__field" htmlFor="nail-level">
-                <span>Nail upgrade</span>
-                <select
-                  id="nail-level"
-                  value={build.nailUpgradeId}
-                  onChange={(event) => setNailUpgrade(event.target.value)}
+          </div>
+          <div className="preset-panel">
+            <h4 className="preset-panel__title">Presets</h4>
+            <p className="preset-panel__description">
+              Apply quick loadouts or clear your charms with a single tap.
+            </p>
+            <div className="preset-buttons" role="group" aria-label="Charm presets">
+              {CHARM_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  className="preset-buttons__button"
+                  onClick={() => applyCharmPreset(preset.charmIds)}
                 >
-                  {nailUpgrades.map((upgrade) => (
-                    <option key={upgrade.id} value={upgrade.id}>
-                      {upgrade.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
+                  {preset.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                className="preset-buttons__button"
+                onClick={() => applyCharmPreset([])}
+              >
+                Clear charms
+              </button>
             </div>
-          </section>
+          </div>
         </div>
-      </div>
-    </div>
+      </section>
+
+      <section className="modal-section" aria-labelledby="spell-focus-heading">
+        <div className="modal-section__header">
+          <h3 id="spell-focus-heading">Spell Focus</h3>
+        </div>
+        <div className="spell-grid">
+          {spells.map((spell) => (
+            <fieldset key={spell.id} className="spell-card">
+              <legend>{spell.name}</legend>
+              <label className="spell-card__option spell-card__option--muted">
+                <input
+                  type="radio"
+                  name={`spell-${spell.id}`}
+                  value="none"
+                  checked={build.spellLevels[spell.id] === 'none'}
+                  onChange={() => setSpellLevel(spell.id, 'none')}
+                />
+                <span>Not acquired</span>
+              </label>
+              <label className="spell-card__option">
+                <input
+                  type="radio"
+                  name={`spell-${spell.id}`}
+                  value="base"
+                  checked={build.spellLevels[spell.id] === 'base'}
+                  onChange={() => setSpellLevel(spell.id, 'base')}
+                />
+                <span>{spell.base.name}</span>
+              </label>
+              {spell.upgrade ? (
+                <label className="spell-card__option">
+                  <input
+                    type="radio"
+                    name={`spell-${spell.id}`}
+                    value="upgrade"
+                    checked={build.spellLevels[spell.id] === 'upgrade'}
+                    onChange={() => setSpellLevel(spell.id, 'upgrade')}
+                  />
+                  <span>{spell.upgrade.name}</span>
+                </label>
+              ) : null}
+            </fieldset>
+          ))}
+        </div>
+      </section>
+
+      <section className="modal-section" aria-labelledby="equipment-heading">
+        <div className="modal-section__header">
+          <h3 id="equipment-heading">Equipment Setup</h3>
+        </div>
+        <div className="form-grid">
+          <label className="form-grid__field" htmlFor="nail-level">
+            <span>Nail upgrade</span>
+            <select
+              id="nail-level"
+              value={build.nailUpgradeId}
+              onChange={(event) => setNailUpgrade(event.target.value)}
+            >
+              {nailUpgrades.map((upgrade) => (
+                <option key={upgrade.id} value={upgrade.id}>
+                  {upgrade.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </section>
+    </>
   );
 };
 
@@ -700,5 +628,15 @@ export const PlayerConfigModal: FC<PlayerConfigModalProps> = ({ isOpen, onClose 
     return null;
   }
 
-  return <PlayerConfigModalContent onClose={onClose} />;
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      titleId="player-config-title"
+      title="Player Loadout"
+      subtitle="Tune your charms, spells, and advanced fight options. Changes apply instantly."
+    >
+      <PlayerConfigModalContent />
+    </Modal>
+  );
 };

--- a/src/features/help/HelpModal.tsx
+++ b/src/features/help/HelpModal.tsx
@@ -1,180 +1,114 @@
-import { useEffect, useRef, type FC } from 'react';
+import type { FC } from 'react';
+
+import { Modal } from '../../components/Modal';
 
 type HelpModalProps = {
   readonly isOpen: boolean;
   readonly onClose: () => void;
 };
 
-const HelpModalContent: FC<Pick<HelpModalProps, 'onClose'>> = ({ onClose }) => {
-  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    queueMicrotask(() => {
-      closeButtonRef.current?.focus();
-    });
-
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [onClose]);
-
-  return (
-    <div
-      className="modal"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="app-help-title"
-    >
-      <button
-        type="button"
-        className="modal__backdrop"
-        aria-label="Close dialog"
-        onClick={onClose}
-      />
-      <div className="modal__content">
-        <header className="modal__header">
-          <div>
-            <h2 id="app-help-title" className="modal__title">
-              App help
-            </h2>
-            <p className="modal__subtitle">
-              Learn how to practice encounters, log attacks, and interpret performance
-              metrics.
-            </p>
-          </div>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            className="modal__close"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </header>
-        <div className="modal__body">
-          <section
-            className="modal-section"
-            aria-labelledby="help-getting-started-heading"
-          >
-            <div className="modal-section__header">
-              <h3 id="help-getting-started-heading">Getting started</h3>
-            </div>
-            <p className="modal-section__description">
-              Use <strong>Setup</strong> to pick a Hollow Knight boss, version, and arena.
-              For custom practice scenarios, choose the Custom option and provide an HP
-              target. The selected encounter drives the numbers shown throughout the
-              tracker.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-attack-log-heading">
-            <div className="modal-section__header">
-              <h3 id="help-attack-log-heading">Logging attacks</h3>
-            </div>
-            <p className="modal-section__description">
-              The <strong>Attack</strong> panel lists every strike you record. Use the
-              attack buttons or their keyboard shortcuts to subtract damage while you
-              practice. Nail strikes, arts, spells, and charm effects automatically apply
-              the modifiers from your loadout, and you can hover each button to see its
-              shortcut and damage value.
-            </p>
-            <p>
-              Made a mistake? Remove the most recent entry from the log to restore the
-              boss HP and associated metrics.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-encounter-hud-heading">
-            <div className="modal-section__header">
-              <h3 id="help-encounter-hud-heading">Reading the encounter HUD</h3>
-            </div>
-            <p className="modal-section__description">
-              The header scoreboard tracks elapsed time, estimated remaining duration,
-              DPS, average damage per action, and actions per minute. Cumulative damage
-              and action totals appear beneath their metrics so you can gauge pacing at a
-              glance without opening another panel.
-            </p>
-            <p>
-              Keep an eye on these values to confirm your build can finish the fight
-              before enrages and to measure the consistency of your attempts.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-combat-log-heading">
-            <div className="modal-section__header">
-              <h3 id="help-combat-log-heading">Reviewing the Combat Log</h3>
-            </div>
-            <p className="modal-section__description">
-              The <strong>Combat Log</strong> lists every action in timestamped order,
-              starting with the opening HP and ending when the fight concludes. The log
-              persists between attempts and notes resets, sequence transitions, and fight
-              completions so you always have context for your runs.
-            </p>
-            <p>
-              Scroll through the feed to understand pacing, identify missed opportunities,
-              and cross-check totals against the encounter HUD.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-loadout-heading">
-            <div className="modal-section__header">
-              <h3 id="help-loadout-heading">Loadout and advanced setup</h3>
-            </div>
-            <p className="modal-section__description">
-              Open <strong>Loadout</strong> to configure nail upgrades, spells, and
-              charms. Presets offer quick starting points, and you can toggle individual
-              charms to match your build. The tracker automatically adjusts damage values
-              and charm effects based on your selection.
-            </p>
-            <p>
-              Need stage-specific practice? Expand the encounter setup drawer to select
-              sequences, control stage progression, and enable conditional modifiers.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-shortcuts-heading">
-            <div className="modal-section__header">
-              <h3 id="help-shortcuts-heading">Keyboard shortcuts</h3>
-            </div>
-            <p className="modal-section__description">
-              Attack buttons support dedicated shortcuts for rapid practice reps. Use the
-              bracket keys <kbd>[</kbd> and <kbd>]</kbd> to move between sequence stages
-              when available. The Escape key closes any open modal.
-            </p>
-          </section>
-
-          <section className="modal-section" aria-labelledby="help-progress-heading">
-            <div className="modal-section__header">
-              <h3 id="help-progress-heading">Saving progress</h3>
-            </div>
-            <p className="modal-section__description">
-              Your encounter, loadout, and attack history persist automatically in the
-              browser. Reload the page or return later to continue from where you left
-              off.
-            </p>
-          </section>
-        </div>
+export const HelpModal: FC<HelpModalProps> = ({ isOpen, onClose }) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    titleId="app-help-title"
+    title="App help"
+    subtitle="Learn how to practice encounters, log attacks, and interpret performance metrics."
+  >
+    <section className="modal-section" aria-labelledby="help-getting-started-heading">
+      <div className="modal-section__header">
+        <h3 id="help-getting-started-heading">Getting started</h3>
       </div>
-    </div>
-  );
-};
+      <p className="modal-section__description">
+        Use <strong>Setup</strong> to pick a Hollow Knight boss, version, and arena. For
+        custom practice scenarios, choose the Custom option and provide an HP target. The
+        selected encounter drives the numbers shown throughout the tracker.
+      </p>
+    </section>
 
-export const HelpModal: FC<HelpModalProps> = ({ isOpen, onClose }) => {
-  if (!isOpen) {
-    return null;
-  }
+    <section className="modal-section" aria-labelledby="help-attack-log-heading">
+      <div className="modal-section__header">
+        <h3 id="help-attack-log-heading">Logging attacks</h3>
+      </div>
+      <p className="modal-section__description">
+        The <strong>Attack</strong> panel lists every strike you record. Use the attack
+        buttons or their keyboard shortcuts to subtract damage while you practice. Nail
+        strikes, arts, spells, and charm effects automatically apply the modifiers from
+        your loadout, and you can hover each button to see its shortcut and damage value.
+      </p>
+      <p>
+        Made a mistake? Remove the most recent entry from the log to restore the boss HP
+        and associated metrics.
+      </p>
+    </section>
 
-  return <HelpModalContent onClose={onClose} />;
-};
+    <section className="modal-section" aria-labelledby="help-encounter-hud-heading">
+      <div className="modal-section__header">
+        <h3 id="help-encounter-hud-heading">Reading the encounter HUD</h3>
+      </div>
+      <p className="modal-section__description">
+        The header scoreboard tracks elapsed time, estimated remaining duration, DPS,
+        average damage per action, and actions per minute. Cumulative damage and action
+        totals appear beneath their metrics so you can gauge pacing at a glance without
+        opening another panel.
+      </p>
+      <p>
+        Keep an eye on these values to confirm your build can finish the fight before
+        enrages and to measure the consistency of your attempts.
+      </p>
+    </section>
+
+    <section className="modal-section" aria-labelledby="help-combat-log-heading">
+      <div className="modal-section__header">
+        <h3 id="help-combat-log-heading">Reviewing the Combat Log</h3>
+      </div>
+      <p className="modal-section__description">
+        The <strong>Combat Log</strong> lists every action in timestamped order, starting
+        with the opening HP and ending when the fight concludes. The log persists between
+        attempts and notes resets, sequence transitions, and fight completions so you
+        always have context for your runs.
+      </p>
+      <p>
+        Scroll through the feed to understand pacing, identify missed opportunities, and
+        cross-check totals against the encounter HUD.
+      </p>
+    </section>
+
+    <section className="modal-section" aria-labelledby="help-loadout-heading">
+      <div className="modal-section__header">
+        <h3 id="help-loadout-heading">Loadout and advanced setup</h3>
+      </div>
+      <p className="modal-section__description">
+        Open <strong>Loadout</strong> to configure nail upgrades, spells, and charms.
+        Presets offer quick starting points, and you can toggle individual charms to match
+        your build. The tracker automatically adjusts damage values and charm effects
+        based on your selection.
+      </p>
+      <p>
+        Need stage-specific practice? Expand the encounter setup drawer to select
+        sequences, control stage progression, and enable conditional modifiers.
+      </p>
+    </section>
+
+    <section className="modal-section" aria-labelledby="help-shortcuts-heading">
+      <div className="modal-section__header">
+        <h3 id="help-shortcuts-heading">Keyboard shortcuts</h3>
+      </div>
+      <p className="modal-section__description">
+        Attack buttons support dedicated shortcuts for rapid practice reps. Use the
+        bracket keys <kbd>[</kbd> and <kbd>]</kbd> to move between sequence stages when
+        available. The Escape key closes any open modal.
+      </p>
+    </section>
+
+    <section className="modal-section" aria-labelledby="help-progress-heading">
+      <div className="modal-section__header">
+        <h3 id="help-progress-heading">Saving progress</h3>
+      </div>
+      <p className="modal-section__description">
+        Your encounter, loadout, and attack history persist automatically in the browser.
+        Reload the page or return later to continue from where you left off.
+      </p>
+    </section>
+  </Modal>
+);


### PR DESCRIPTION
## Summary
- add a shared Modal component that standardizes the dialog shell, focus management, body scroll locking, and escape key handling
- refactor HelpModal and PlayerConfigModal to consume the shared component while preserving their content
- add unit coverage for the shared Modal component and adjust existing tests to exercise the refactored modals

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68deeec22d04832fabbc7233339af905