### PR TITLE
test: co-locate util tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ pnpm install
 | `pnpm test:watch`                   | Watch unit tests while iterating on features.                      |
 | `pnpm test:e2e`                     | Run Playwright end-to-end tests.                                   |
 
+### Testing conventions
+
+- Co-locate unit test files (`*.test.ts[x]`) next to the modules they cover. This keeps helpers like `src/utils/format.ts` and
+  `src/utils/format.test.ts` together, while Playwright suites remain under `tests/`.
+
 A `pre-commit` hook powered by [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks) automatically runs formatting, linting, and unit tests before every commit.
 
 ## Roadmap

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -5,7 +5,7 @@ import {
   formatNumber,
   formatRelativeTime,
   formatStopwatch,
-} from '../format';
+} from './format';
 
 describe('format helpers', () => {
   describe('formatNumber', () => {


### PR DESCRIPTION
## Summary
- document the unit test co-location convention in the README so utility helpers use a consistent structure
- move the `format` unit test next to its module and update the relative import accordingly

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68df590546dc832f95c5afb9d57e1639