### PR TITLE
docs: clarify app composition directory guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@
 
 - Place source code under `src/` with feature-based subdirectories.
 - Store reusable UI elements in `src/components/` and domain logic in `src/features/`.
+- Reserve `src/app/` (and its `components/` subfolder) for application wiring: compose providers, layouts, and other glue that
+  stitches features together. When a piece becomes a reusable widget, graduate it into `src/components/`.
 - Keep integration/end-to-end tests inside `tests/` at the project root.
 - Configuration files belong in the repository root (e.g., `vite.config.ts`, `.eslintrc.cjs`).
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Hollow Knight Damage Tracker is a responsive companion app for players, co-comme
 - Responsive UI tuned for Hollow Knight’s aesthetic and readability during frantic fights.
 - Modular data models in `src/data/` feed typed combat calculations via `FightStateProvider`.
 - Core panels (`BuildConfigPanel`, `AttackLogPanel`, `CombatLogPanel`) share that state to surface presets, controls, and stats.
+- App composition (providers, layouts, and feature glue) lives in `src/app/`, while reusable widgets belong in `src/components/`.
 - Automated GitHub Actions pipelines handle linting, testing, and GitHub Pages deploys.
 
 ## Tech Stack

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -1,0 +1,17 @@
+# App Composition Guidelines
+
+The `src/app/` directory (including its `components/` subfolder) exists for application wiring:
+
+- Compose providers, layouts, and page-level shells here.
+- Keep routing glue, context bridges, and feature orchestration at this level.
+- Do **not** place reusable, presentation-only widgets in this tree—move them to `src/components/` instead.
+
+## Component Placement Checklist
+
+Use this quick guide when creating a component:
+
+- **It wires providers, fetches data, or controls page-level layout?** Keep it in `src/app/`.
+- **It is a reusable widget driven by props and free of app-specific state?** Build it in `src/components/`.
+- **It started as wiring but no longer owns app state?** Refactor it into `src/components/`.
+
+When in doubt, default to `src/components/` and promote it into `src/app/` only if it needs to orchestrate app state.


### PR DESCRIPTION
## Summary
- add an AGENTS.md to src/app describing how the folder and its components subdirectory are reserved for application-level composition
- reinforce the app-versus-components placement guidance in the root AGENTS.md and README snapshot
- provide a quick checklist to decide when to build something in src/app or src/components

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68df5a1d4a88832fb60671a8c8356420