### PR TITLE
fix: hide shortcut labels on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2689,6 +2689,10 @@ h6 {
 }
 
 @media (width <= 720px) {
+  .app-button__shortcut {
+    display: none;
+  }
+
   .encounter-hud {
     position: static;
     top: auto;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2693,6 +2693,11 @@ h6 {
     display: none;
   }
 
+  .app-button--has-shortcut {
+    justify-content: center;
+    min-width: auto;
+  }
+
   .encounter-hud {
     position: static;
     top: auto;


### PR DESCRIPTION
## Summary
- hide keyboard shortcut labels on app buttons for narrow viewports to match attack button behavior

## Testing
- CI=1 pnpm format:check

------
https://chatgpt.com/codex/tasks/task_e_68df5b050bc4832f9dc9c198a9a07059