### PR TITLE
fix: prevent loadout modal from scrolling on charm selection

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -147,6 +147,29 @@ describe('App', () => {
     expect(modalBody.scrollTop).toBe(200);
   });
 
+  it('does not scroll the loadout modal to the top when selecting a charm', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: /open loadout configuration/i }));
+    const modal = await screen.findByRole('dialog', { name: /player loadout/i });
+    const modalBody = modal.querySelector('.modal__body') as HTMLElement | null;
+    if (!modalBody) {
+      throw new Error('Expected the modal body to be present');
+    }
+
+    modalBody.scrollTop = 200;
+
+    const [compassButton] = within(modal).getAllByRole('button', {
+      name: /wayward compass/i,
+    });
+    await user.click(compassButton);
+
+    await waitFor(() => {
+      expect(modalBody.scrollTop).toBe(200);
+    });
+  });
+
   it('cleans up charm flights when cycling multi-state charms', async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 
 import {
   AttackLogActions,
@@ -29,6 +29,8 @@ const AppContent: FC = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isSetupOpen, setSetupOpen] = useState(false);
   const [isHelpOpen, setHelpOpen] = useState(false);
+  const handleCloseLoadout = useCallback(() => setModalOpen(false), [setModalOpen]);
+  const handleCloseHelp = useCallback(() => setHelpOpen(false), [setHelpOpen]);
 
   const {
     bosses,
@@ -210,8 +212,8 @@ const AppContent: FC = () => {
         </CombatLogProvider>
       </main>
 
-      <PlayerConfigModal isOpen={isModalOpen} onClose={() => setModalOpen(false)} />
-      <HelpModal isOpen={isHelpOpen} onClose={() => setHelpOpen(false)} />
+      <PlayerConfigModal isOpen={isModalOpen} onClose={handleCloseLoadout} />
+      <HelpModal isOpen={isHelpOpen} onClose={handleCloseHelp} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep the loadout and help modal close handlers stable so charm selections no longer reset focus
- add a regression test that verifies the loadout modal retains its scroll position when a charm is equipped

## Testing
- pnpm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e1ab98b134832f91dddfbe1e56d837