### PR TITLE
feat: add encounter mode toggle and summary

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -189,7 +189,12 @@ describe('App', () => {
     render(<App />);
 
     await user.click(screen.getByRole('button', { name: /setup/i }));
-    await user.selectOptions(screen.getByLabelText(/mode/i), 'pantheon-of-the-sage');
+    await user.click(screen.getByRole('tab', { name: /sequence run/i }));
+    const sequencePanel = screen.getByRole('tabpanel', { name: /sequence run/i });
+    await user.selectOptions(
+      within(sequencePanel).getByRole('combobox', { name: /sequence/i }),
+      'pantheon-of-the-sage',
+    );
 
     const conditionsGroup = await screen.findByRole('group', {
       name: /sequence conditions/i,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -139,6 +139,42 @@ const AppContent: FC = () => {
       }
     : null;
   const stageLabel = currentSequenceEntry ? currentSequenceEntry.target.bossName : null;
+  const encounterMode: 'single-target' | 'sequence' = activeSequence
+    ? 'sequence'
+    : 'single-target';
+  const targetSummaryName =
+    encounterMode === 'sequence' && currentSequenceEntry
+      ? currentSequenceEntry.target.bossName
+      : encounterName;
+  const stageVersionTitle = currentSequenceEntry?.target.version.title ?? null;
+  const stageLocation = currentSequenceEntry?.target.location ?? null;
+  const customTargetLabel = `${customTargetHp.toLocaleString()} HP`;
+  let targetSummaryDetail: string | null = null;
+  if (encounterMode === 'sequence') {
+    targetSummaryDetail = stageVersionTitle;
+  } else if (selectedVersion?.title) {
+    targetSummaryDetail = selectedVersion.title;
+  } else if (!selectedTarget) {
+    targetSummaryDetail = customTargetLabel;
+  }
+  const targetSummaryLocation = encounterMode === 'sequence' ? stageLocation : arenaLabel;
+  const sequenceSummary =
+    encounterMode === 'sequence'
+      ? {
+          name: activeSequence?.name ?? null,
+          stageLabel,
+          progress: stageProgress,
+        }
+      : null;
+  const encounterSummary = {
+    mode: encounterMode,
+    target: {
+      name: targetSummaryName,
+      detail: targetSummaryDetail,
+      location: targetSummaryLocation,
+    },
+    sequence: sequenceSummary,
+  } as const;
 
   return (
     <div className="app-shell">
@@ -157,6 +193,7 @@ const AppContent: FC = () => {
         onRewindStage={handleRewindSequence}
         hasNextStage={hasNextSequenceStage}
         hasPreviousStage={hasPreviousSequenceStage}
+        encounterSummary={encounterSummary}
       />
       <MobilePinnedHud derived={derived} encounterName={encounterName} />
 

--- a/src/app/components/HeaderBar.tsx
+++ b/src/app/components/HeaderBar.tsx
@@ -1,6 +1,12 @@
 import type { FC } from 'react';
 
-import { AppButton, EncounterBrand, SurfaceSection } from '../../components';
+import {
+  AppButton,
+  EncounterBrand,
+  EncounterSummary,
+  SurfaceSection,
+  type EncounterSummaryProps,
+} from '../../components';
 import type { useFightDerivedStats } from '../../features/fight-state/FightStateContext';
 import { TargetScoreboard } from './TargetScoreboard';
 
@@ -19,6 +25,7 @@ export type HeaderBarProps = {
   readonly onRewindStage: () => void;
   readonly hasNextStage: boolean;
   readonly hasPreviousStage: boolean;
+  readonly encounterSummary: EncounterSummaryProps;
 };
 
 export const HeaderBar: FC<HeaderBarProps> = ({
@@ -36,6 +43,7 @@ export const HeaderBar: FC<HeaderBarProps> = ({
   onRewindStage,
   hasNextStage,
   hasPreviousStage,
+  encounterSummary,
 }) => (
   <SurfaceSection
     as="header"
@@ -45,11 +53,14 @@ export const HeaderBar: FC<HeaderBarProps> = ({
     titleId="app-header-title"
     titleAs="div"
     title={
-      <EncounterBrand
-        encounterName={encounterName}
-        versionLabel={versionLabel}
-        arenaLabel={arenaLabel}
-      />
+      <div className="hud-branding">
+        <EncounterBrand
+          encounterName={encounterName}
+          versionLabel={versionLabel}
+          arenaLabel={arenaLabel}
+        />
+        <EncounterSummary {...encounterSummary} />
+      </div>
     }
     actions={
       <div className="hud-actions">

--- a/src/components/EncounterSummary.tsx
+++ b/src/components/EncounterSummary.tsx
@@ -1,0 +1,77 @@
+import type { FC } from 'react';
+
+export type EncounterSummaryProps = {
+  readonly mode: 'single-target' | 'sequence';
+  readonly target: {
+    readonly name: string;
+    readonly detail?: string | null;
+    readonly location?: string | null;
+  };
+  readonly sequence?: {
+    readonly name: string | null;
+    readonly stageLabel?: string | null;
+    readonly progress?: { current: number; total: number } | null;
+  } | null;
+};
+
+const buildTargetMeta = (
+  detail?: string | null,
+  location?: string | null,
+): string | null => {
+  const parts = [detail, location].filter((value): value is string => Boolean(value));
+  return parts.length > 0 ? parts.join(' • ') : null;
+};
+
+const buildSequenceMeta = (
+  stageLabel?: string | null,
+  progress?: { current: number; total: number } | null,
+): string | null => {
+  if (!stageLabel && !progress) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (stageLabel) {
+    parts.push(stageLabel);
+  }
+
+  if (progress) {
+    parts.push(`Stage ${progress.current} of ${progress.total}`);
+  }
+
+  return parts.join(' • ');
+};
+
+export const EncounterSummary: FC<EncounterSummaryProps> = ({
+  mode,
+  target,
+  sequence,
+}) => {
+  const targetMeta = buildTargetMeta(target.detail, target.location);
+  const sequenceName = sequence?.name ?? null;
+  const sequenceMeta = buildSequenceMeta(sequence?.stageLabel, sequence?.progress);
+  const shouldShowSequence = mode === 'sequence';
+
+  return (
+    <div className="encounter-summary" aria-live="polite">
+      <div className="encounter-summary__chip summary-chip summary-chip--toolbar">
+        <span className="encounter-summary__title">Target</span>
+        <span className="encounter-summary__value">{target.name}</span>
+        {targetMeta ? (
+          <span className="encounter-summary__meta">{targetMeta}</span>
+        ) : null}
+      </div>
+      {shouldShowSequence ? (
+        <div className="encounter-summary__chip summary-chip summary-chip--toolbar">
+          <span className="encounter-summary__title">Sequence</span>
+          <span className="encounter-summary__value">
+            {sequenceName ?? 'Select a sequence'}
+          </span>
+          {sequenceMeta ? (
+            <span className="encounter-summary__meta">{sequenceMeta}</span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,11 @@
 export { AppButton } from './AppButton';
 export { BossHealthBar } from './BossHealthBar';
 export { EncounterBrand } from './EncounterBrand';
+export { EncounterSummary } from './EncounterSummary';
 export { Modal } from './Modal';
 export { SurfaceSection } from './SurfaceSection';
 
 export type { BossHealthBarProps } from './BossHealthBar';
 export type { EncounterBrandProps } from './EncounterBrand';
+export type { EncounterSummaryProps } from './EncounterSummary';
 export type { ModalProps } from './Modal';

--- a/src/features/encounter-setup/EncounterSetupPanel.tsx
+++ b/src/features/encounter-setup/EncounterSetupPanel.tsx
@@ -1,8 +1,26 @@
-import type { FC } from 'react';
+import { useEffect, useId, useMemo, useState, type FC } from 'react';
 
 import type { useBuildConfiguration } from '../build-config/useBuildConfiguration';
 import { TargetSelector } from './TargetSelector';
 import { SequenceSelector } from './SequenceSelector';
+
+const SINGLE_TARGET_MODE = 'single-target';
+const SEQUENCE_MODE = 'sequence';
+
+type EncounterMode = typeof SINGLE_TARGET_MODE | typeof SEQUENCE_MODE;
+
+const MODE_COPY: Record<EncounterMode, { title: string; description: string }> = {
+  [SINGLE_TARGET_MODE]: {
+    title: 'Single target practice',
+    description:
+      'Choose any boss or configure a custom HP goal to focus on one encounter at a time.',
+  },
+  [SEQUENCE_MODE]: {
+    title: 'Sequence practice',
+    description:
+      'Run through multi-fight Godhome sequences with automatic stage tracking and conditions.',
+  },
+};
 
 export type EncounterSetupPanelProps = {
   readonly isOpen: boolean;
@@ -50,67 +68,155 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
   activeSequence,
   sequenceConditionValues,
   onConditionToggle,
-}) => (
-  <section
-    id="encounter-setup"
-    className="encounter-setup"
-    aria-label="Encounter setup"
-    hidden={!isOpen}
-  >
-    <div className="encounter-setup__grid">
-      <TargetSelector
-        bosses={bosses}
-        bossSelectValue={bossSelectValue}
-        onBossChange={onBossChange}
-        selectedBoss={selectedBoss}
-        selectedBossId={selectedBossId}
-        onBossVersionChange={onBossVersionChange}
-        selectedTarget={selectedTarget}
-        selectedVersion={selectedVersion}
-        customTargetHp={customTargetHp}
-        onCustomHpChange={onCustomHpChange}
-      />
-      <SequenceSelector
-        bossSequences={bossSequences}
-        sequenceSelectValue={sequenceSelectValue}
-        onSequenceChange={onSequenceChange}
-        sequenceEntries={sequenceEntries}
-        cappedSequenceIndex={cappedSequenceIndex}
-        onStageSelect={onStageSelect}
-      />
-    </div>
-    {activeSequence && activeSequence.conditions.length > 0 ? (
-      <section
-        className="sequence-conditions"
-        aria-label="Sequence conditions"
-        role="group"
-      >
-        <h4 className="sequence-conditions__title">Sequence conditions</h4>
-        <div className="sequence-conditions__grid">
-          {activeSequence.conditions.map((condition) => {
-            const isEnabled = sequenceConditionValues[condition.id];
-            return (
-              <label key={condition.id} className="sequence-conditions__option">
-                <input
-                  type="checkbox"
-                  checked={isEnabled}
-                  onChange={(event) =>
-                    onConditionToggle(condition.id, event.target.checked)
-                  }
-                />
-                <span>
-                  <span className="sequence-conditions__label">{condition.label}</span>
-                  {condition.description ? (
-                    <span className="sequence-conditions__description">
-                      {condition.description}
-                    </span>
-                  ) : null}
-                </span>
-              </label>
-            );
-          })}
+}) => {
+  const [mode, setMode] = useState<EncounterMode>(
+    sequenceSelectValue ? SEQUENCE_MODE : SINGLE_TARGET_MODE,
+  );
+  const singleTargetPanelId = useId();
+  const sequencePanelId = useId();
+  const modeTablistId = useId();
+
+  useEffect(() => {
+    const derivedMode = sequenceSelectValue ? SEQUENCE_MODE : SINGLE_TARGET_MODE;
+    setMode((current) => (current === derivedMode ? current : derivedMode));
+  }, [sequenceSelectValue]);
+
+  const handleModeChange = (nextMode: EncounterMode) => {
+    setMode(nextMode);
+    if (nextMode === SINGLE_TARGET_MODE && sequenceSelectValue !== '') {
+      onSequenceChange('');
+    }
+  };
+
+  const modeTabs = useMemo(
+    () => [
+      {
+        id: `${singleTargetPanelId}-tab`,
+        value: SINGLE_TARGET_MODE as EncounterMode,
+        label: 'Single target',
+        controls: singleTargetPanelId,
+      },
+      {
+        id: `${sequencePanelId}-tab`,
+        value: SEQUENCE_MODE as EncounterMode,
+        label: 'Sequence run',
+        controls: sequencePanelId,
+      },
+    ],
+    [sequencePanelId, singleTargetPanelId],
+  );
+
+  return (
+    <section
+      id="encounter-setup"
+      className="encounter-setup"
+      aria-label="Encounter setup"
+      hidden={!isOpen}
+    >
+      <div className="encounter-setup__mode-toggle">
+        <span id={modeTablistId} className="encounter-setup__mode-label">
+          Practice mode
+        </span>
+        <div
+          className="encounter-setup__mode-segments"
+          role="tablist"
+          aria-labelledby={modeTablistId}
+        >
+          {modeTabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              id={tab.id}
+              role="tab"
+              className="encounter-setup__mode-button"
+              aria-selected={mode === tab.value}
+              aria-controls={tab.controls}
+              onClick={() => handleModeChange(tab.value)}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
-      </section>
-    ) : null}
-  </section>
-);
+      </div>
+
+      <div className="encounter-setup__grid">
+        <section
+          id={singleTargetPanelId}
+          role="tabpanel"
+          aria-labelledby={`${singleTargetPanelId}-tab`}
+          hidden={mode !== SINGLE_TARGET_MODE}
+        >
+          <TargetSelector
+            title={MODE_COPY[SINGLE_TARGET_MODE].title}
+            description={MODE_COPY[SINGLE_TARGET_MODE].description}
+            bosses={bosses}
+            bossSelectValue={bossSelectValue}
+            onBossChange={onBossChange}
+            selectedBoss={selectedBoss}
+            selectedBossId={selectedBossId}
+            onBossVersionChange={onBossVersionChange}
+            selectedTarget={selectedTarget}
+            selectedVersion={selectedVersion}
+            customTargetHp={customTargetHp}
+            onCustomHpChange={onCustomHpChange}
+          />
+        </section>
+
+        <section
+          id={sequencePanelId}
+          role="tabpanel"
+          aria-labelledby={`${sequencePanelId}-tab`}
+          hidden={mode !== SEQUENCE_MODE}
+        >
+          <SequenceSelector
+            title={MODE_COPY[SEQUENCE_MODE].title}
+            description={MODE_COPY[SEQUENCE_MODE].description}
+            placeholder="Select a Godhome sequence"
+            bossSequences={bossSequences}
+            sequenceSelectValue={sequenceSelectValue}
+            onSequenceChange={onSequenceChange}
+            sequenceEntries={sequenceEntries}
+            cappedSequenceIndex={cappedSequenceIndex}
+            onStageSelect={onStageSelect}
+          />
+        </section>
+      </div>
+
+      {mode === SEQUENCE_MODE &&
+      activeSequence &&
+      activeSequence.conditions.length > 0 ? (
+        <section
+          className="sequence-conditions"
+          aria-label="Sequence conditions"
+          role="group"
+        >
+          <h4 className="sequence-conditions__title">Sequence conditions</h4>
+          <div className="sequence-conditions__grid">
+            {activeSequence.conditions.map((condition) => {
+              const isEnabled = sequenceConditionValues[condition.id];
+              return (
+                <label key={condition.id} className="sequence-conditions__option">
+                  <input
+                    type="checkbox"
+                    checked={isEnabled}
+                    onChange={(event) =>
+                      onConditionToggle(condition.id, event.target.checked)
+                    }
+                  />
+                  <span>
+                    <span className="sequence-conditions__label">{condition.label}</span>
+                    {condition.description ? (
+                      <span className="sequence-conditions__description">
+                        {condition.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+};

--- a/src/features/encounter-setup/SequenceSelector.tsx
+++ b/src/features/encounter-setup/SequenceSelector.tsx
@@ -1,8 +1,11 @@
-import type { FC } from 'react';
+import { useId, type FC } from 'react';
 
 import type { useBuildConfiguration } from '../build-config/useBuildConfiguration';
 
 export type SequenceSelectorProps = {
+  readonly title: string;
+  readonly description: string;
+  readonly placeholder: string;
   readonly bossSequences: ReturnType<typeof useBuildConfiguration>['bossSequences'];
   readonly sequenceSelectValue: string;
   readonly onSequenceChange: (value: string) => void;
@@ -12,58 +15,79 @@ export type SequenceSelectorProps = {
 };
 
 export const SequenceSelector: FC<SequenceSelectorProps> = ({
+  title,
+  description,
+  placeholder,
   bossSequences,
   sequenceSelectValue,
   onSequenceChange,
   sequenceEntries,
   cappedSequenceIndex,
   onStageSelect,
-}) => (
-  <section className="sequence-selector" aria-labelledby="sequence-selector-heading">
-    <div className="sequence-selector__header">
-      <h3 id="sequence-selector-heading">Encounter stage</h3>
-    </div>
-    <label className="sequence-selector__field">
-      <span className="sequence-selector__field-label">Mode</span>
-      <select
-        value={sequenceSelectValue}
-        onChange={(event) => onSequenceChange(event.target.value)}
-      >
-        <option value="">Single target practice</option>
-        {bossSequences.map((sequence) => (
-          <option key={sequence.id} value={sequence.id}>
-            {sequence.name}
+}) => {
+  const headingId = useId();
+  const descriptionId = useId();
+  const selectId = useId();
+
+  return (
+    <section
+      className="sequence-selector"
+      aria-labelledby={headingId}
+      aria-describedby={descriptionId}
+    >
+      <div className="sequence-selector__header">
+        <div className="sequence-selector__heading">
+          <h3 id={headingId}>{title}</h3>
+          <p id={descriptionId} className="sequence-selector__description">
+            {description}
+          </p>
+        </div>
+      </div>
+      <label className="sequence-selector__field" htmlFor={selectId}>
+        <span className="sequence-selector__field-label">Sequence</span>
+        <select
+          id={selectId}
+          value={sequenceSelectValue}
+          onChange={(event) => onSequenceChange(event.target.value)}
+        >
+          <option value="" disabled>
+            {placeholder}
           </option>
-        ))}
-      </select>
-    </label>
-    {sequenceEntries.length > 0 ? (
-      <ol className="sequence-selector__stages">
-        {sequenceEntries.map((entry, index) => {
-          const isCurrent = index === cappedSequenceIndex;
-          return (
-            <li key={entry.id}>
-              <button
-                type="button"
-                className="sequence-selector__stage"
-                onClick={() => onStageSelect(index)}
-                aria-current={isCurrent ? 'true' : undefined}
-              >
-                <span className="sequence-selector__stage-index">
-                  {String(index + 1).padStart(2, '0')}
-                </span>
-                <span className="sequence-selector__stage-name">
-                  {entry.target.bossName}
-                </span>
-              </button>
-            </li>
-          );
-        })}
-      </ol>
-    ) : (
-      <p className="sequence-selector__empty" aria-live="polite">
-        Select a Godhome sequence to practice multi-fight runs.
-      </p>
-    )}
-  </section>
-);
+          {bossSequences.map((sequence) => (
+            <option key={sequence.id} value={sequence.id}>
+              {sequence.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {sequenceEntries.length > 0 ? (
+        <ol className="sequence-selector__stages">
+          {sequenceEntries.map((entry, index) => {
+            const isCurrent = index === cappedSequenceIndex;
+            return (
+              <li key={entry.id}>
+                <button
+                  type="button"
+                  className="sequence-selector__stage"
+                  onClick={() => onStageSelect(index)}
+                  aria-current={isCurrent ? 'true' : undefined}
+                >
+                  <span className="sequence-selector__stage-index">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span className="sequence-selector__stage-name">
+                    {entry.target.bossName}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      ) : (
+        <p className="sequence-selector__empty" aria-live="polite">
+          Select a sequence to populate the stage tracker.
+        </p>
+      )}
+    </section>
+  );
+};

--- a/src/features/encounter-setup/TargetSelector.tsx
+++ b/src/features/encounter-setup/TargetSelector.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useEffect, useId, useMemo, useState, type FC } from 'react';
 
 import type { useBuildConfiguration } from '../build-config/useBuildConfiguration';
 import { CUSTOM_BOSS_ID } from '../fight-state/FightStateContext';
 
 export type TargetSelectorProps = {
+  readonly title: string;
+  readonly description: string;
   readonly bosses: ReturnType<typeof useBuildConfiguration>['bosses'];
   readonly bossSelectValue: string;
   readonly onBossChange: (value: string) => void;
@@ -44,6 +46,8 @@ const fuzzyIncludes = (source: string, query: string) => {
 const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
 
 export const TargetSelector: FC<TargetSelectorProps> = ({
+  title,
+  description,
   bosses,
   bossSelectValue,
   onBossChange,
@@ -58,6 +62,8 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
   const [isOptionsOpen, setOptionsOpen] = useState(false);
   const [customHpDraft, setCustomHpDraft] = useState(() => customTargetHp.toString());
   const [searchQuery, setSearchQuery] = useState('');
+  const headingId = useId();
+  const descriptionId = useId();
 
   useEffect(() => {
     if (selectedBossId === CUSTOM_BOSS_ID) {
@@ -97,9 +103,18 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
   };
 
   return (
-    <section className="target-selector" aria-labelledby="target-selector-heading">
+    <section
+      className="target-selector"
+      aria-labelledby={headingId}
+      aria-describedby={descriptionId}
+    >
       <div className="target-selector__header">
-        <h3 id="target-selector-heading">Boss target</h3>
+        <div className="target-selector__heading">
+          <h3 id={headingId}>{title}</h3>
+          <p id={descriptionId} className="target-selector__description">
+            {description}
+          </p>
+        </div>
         <button
           type="button"
           className="target-selector__options-toggle"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -443,7 +443,13 @@ h6 {
   z-index: 1;
 }
 
-.hud-brand {
+.hud-branding {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.4rem, 1.2vw, 0.6rem);
+}
+
+.hud-branding > .hud-brand {
   display: flex;
   align-items: center;
   gap: clamp(0.4rem, 1vw, 0.7rem);
@@ -554,6 +560,35 @@ h6 {
     0 0 0 1px rgb(215 245 255 / 32%),
     inset 0 0 0 1px rgb(255 255 255 / 10%),
     var(--frame-etch);
+}
+
+.encounter-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.35rem, 1vw, 0.55rem);
+}
+
+.encounter-summary__chip {
+  padding: 0.5rem 0.75rem;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.encounter-summary__title {
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.encounter-summary__value {
+  font-weight: 600;
+  font-size: var(--font-size-subhead);
+}
+
+.encounter-summary__meta {
+  font-size: var(--font-size-caption);
+  color: var(--color-muted);
 }
 
 .hud-timeline {
@@ -822,6 +857,64 @@ h6 {
   gap: clamp(0.8rem, 1.6vw, 1.2rem);
 }
 
+.encounter-setup__mode-toggle {
+  display: grid;
+  gap: 0.55rem;
+  align-items: start;
+}
+
+.encounter-setup__mode-label {
+  font-size: var(--font-size-caption);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.encounter-setup__mode-segments {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background-color: rgb(18 26 44 / 78%);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 12%),
+    0 8px 22px rgb(0 0 0 / 55%);
+}
+
+.encounter-setup__mode-button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  background: transparent;
+  color: rgb(240 243 255 / 65%);
+  font-weight: 600;
+  font-size: var(--font-size-body);
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.encounter-setup__mode-button[aria-selected='true'] {
+  color: var(--color-text);
+  background: linear-gradient(140deg, rgb(215 245 255 / 24%), transparent);
+  border-color: rgb(215 245 255 / 35%);
+  box-shadow:
+    0 10px 24px rgb(0 0 0 / 48%),
+    0 0 14px rgb(215 245 255 / 28%),
+    inset 0 0 0 1px rgb(255 255 255 / 14%);
+}
+
+.encounter-setup__mode-button:focus-visible {
+  outline: 2px solid rgb(215 245 255 / 55%);
+  outline-offset: 2px;
+}
+
 .target-selector {
   position: relative;
   clip-path: var(--shape-tablet);
@@ -976,6 +1069,18 @@ h6 {
 .target-selector__boss-empty {
   margin: 0;
   font-size: var(--font-size-body);
+  color: var(--color-muted);
+}
+
+.target-selector__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.target-selector__description {
+  margin: 0;
+  font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
@@ -1211,11 +1316,23 @@ h6 {
   justify-content: space-between;
 }
 
+.sequence-selector__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .sequence-selector h3 {
   margin: 0;
   font-size: var(--font-size-title);
   letter-spacing: 0.02em;
   text-transform: none;
+}
+
+.sequence-selector__description {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  color: var(--color-muted);
 }
 
 .sequence-selector__field {


### PR DESCRIPTION
## Summary
- add a practice mode toggle to the encounter setup panel and scope target/sequence copy to each tab
- surface an encounter summary chip set in the header using the active target/sequence data
- refresh related styles to support the new toggle, descriptions, and header summary

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68e1a95fabc0832fa623b906dd6d4662