### PR TITLE
feat: redesign sequence selector

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -214,15 +214,18 @@ describe('App', () => {
     await user.click(screen.getByRole('button', { name: /setup/i }));
     await user.click(screen.getByRole('tab', { name: /sequence run/i }));
     const sequencePanel = screen.getByRole('tabpanel', { name: /sequence run/i });
-    await user.selectOptions(
-      within(sequencePanel).getByRole('combobox', { name: /sequence/i }),
-      'pantheon-of-the-sage',
+    await user.click(
+      within(sequencePanel).getByLabelText(/pantheon of the sage/i, { exact: false }),
     );
 
-    const conditionsGroup = await screen.findByRole('group', {
-      name: /sequence conditions/i,
+    const selectedOption = within(sequencePanel)
+      .getByText(/pantheon of the sage/i)
+      .closest('.sequence-selector__option');
+    expect(selectedOption).not.toBeNull();
+
+    const checkbox = within(selectedOption as HTMLElement).getByRole('checkbox', {
+      name: /include grey prince zote/i,
     });
-    const checkbox = within(conditionsGroup).getByLabelText(/include grey prince zote/i);
     expect(checkbox).not.toBeChecked();
 
     await user.click(checkbox);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -217,7 +217,6 @@ const AppContent: FC = () => {
         sequenceEntries={sequenceEntries}
         cappedSequenceIndex={cappedSequenceIndex}
         onStageSelect={handleSequenceStageChange}
-        activeSequence={activeSequence}
         sequenceConditionValues={sequenceConditionValues}
         onConditionToggle={handleSequenceConditionToggle}
       />

--- a/src/features/encounter-setup/EncounterSetupPanel.tsx
+++ b/src/features/encounter-setup/EncounterSetupPanel.tsx
@@ -40,7 +40,6 @@ export type EncounterSetupPanelProps = {
   readonly sequenceEntries: ReturnType<typeof useBuildConfiguration>['sequenceEntries'];
   readonly cappedSequenceIndex: number;
   readonly onStageSelect: (index: number) => void;
-  readonly activeSequence: ReturnType<typeof useBuildConfiguration>['activeSequence'];
   readonly sequenceConditionValues: ReturnType<
     typeof useBuildConfiguration
   >['sequenceConditionValues'];
@@ -65,7 +64,6 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
   sequenceEntries,
   cappedSequenceIndex,
   onStageSelect,
-  activeSequence,
   sequenceConditionValues,
   onConditionToggle,
 }) => {
@@ -178,45 +176,11 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
             sequenceEntries={sequenceEntries}
             cappedSequenceIndex={cappedSequenceIndex}
             onStageSelect={onStageSelect}
+            sequenceConditionValues={sequenceConditionValues}
+            onConditionToggle={onConditionToggle}
           />
         </section>
       </div>
-
-      {mode === SEQUENCE_MODE &&
-      activeSequence &&
-      activeSequence.conditions.length > 0 ? (
-        <section
-          className="sequence-conditions"
-          aria-label="Sequence conditions"
-          role="group"
-        >
-          <h4 className="sequence-conditions__title">Sequence conditions</h4>
-          <div className="sequence-conditions__grid">
-            {activeSequence.conditions.map((condition) => {
-              const isEnabled = sequenceConditionValues[condition.id];
-              return (
-                <label key={condition.id} className="sequence-conditions__option">
-                  <input
-                    type="checkbox"
-                    checked={isEnabled}
-                    onChange={(event) =>
-                      onConditionToggle(condition.id, event.target.checked)
-                    }
-                  />
-                  <span>
-                    <span className="sequence-conditions__label">{condition.label}</span>
-                    {condition.description ? (
-                      <span className="sequence-conditions__description">
-                        {condition.description}
-                      </span>
-                    ) : null}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </section>
-      ) : null}
     </section>
   );
 };

--- a/src/features/encounter-setup/SequenceSelector.test.tsx
+++ b/src/features/encounter-setup/SequenceSelector.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { BossSequenceEntry, BossTarget } from '../../data/types';
+import { SequenceSelector, type SequenceSelectorProps } from './SequenceSelector';
+
+const createTarget = (id: string, bossName: string): BossTarget => ({
+  id,
+  bossId: id,
+  bossName,
+  location: 'Godhome',
+  description: `${bossName} encounter`,
+  hp: 1000,
+  version: {
+    id: `${id}-version`,
+    title: bossName,
+    hp: 1000,
+    type: 'godhome',
+    targetId: id,
+  },
+});
+
+const createEntry = (id: string, bossName: string): BossSequenceEntry => ({
+  id,
+  target: createTarget(id, bossName),
+});
+
+describe('SequenceSelector', () => {
+  const pantheonSequence: SequenceSelectorProps['bossSequences'][number] = {
+    id: 'pantheon-1',
+    name: 'Pantheon of the Master',
+    category: 'Pantheons',
+    entries: [
+      createEntry('p1-vengefly', 'Vengefly King'),
+      createEntry('p1-gruz', 'Gruz Mother'),
+    ],
+    conditions: [
+      {
+        id: 'include-grey-prince',
+        label: 'Include Grey Prince Zote',
+        description: 'Adds Zote as the final fight.',
+        defaultEnabled: false,
+      },
+    ],
+  };
+
+  const trialSequence: SequenceSelectorProps['bossSequences'][number] = {
+    id: 'trial-1',
+    name: 'Trial of the Warrior',
+    category: 'Trials',
+    entries: [createEntry('trial-1', 'Massive Moss Charger')],
+    conditions: [
+      {
+        id: 'double-damage',
+        label: 'Double damage mode',
+        description: 'Take twice the damage per hit.',
+        defaultEnabled: true,
+      },
+    ],
+  };
+
+  const renderSelector = (overrides: Partial<SequenceSelectorProps> = {}) => {
+    const defaultProps: SequenceSelectorProps = {
+      title: 'Sequence run',
+      description: 'Configure a full Godhome run.',
+      placeholder: 'Select a Godhome sequence',
+      bossSequences: [pantheonSequence, trialSequence],
+      sequenceSelectValue: '',
+      onSequenceChange: vi.fn(),
+      sequenceEntries: [],
+      cappedSequenceIndex: 0,
+      onStageSelect: vi.fn(),
+      sequenceConditionValues: {},
+      onConditionToggle: vi.fn(),
+      ...overrides,
+    };
+
+    const user = userEvent.setup();
+    return {
+      user,
+      onSequenceChange: defaultProps.onSequenceChange,
+      onStageSelect: defaultProps.onStageSelect,
+      onConditionToggle: defaultProps.onConditionToggle,
+      ...render(<SequenceSelector {...defaultProps} />),
+    };
+  };
+
+  it('groups sequences by category and renders headings', () => {
+    renderSelector();
+
+    expect(
+      screen.getByRole('heading', { name: 'Pantheons', level: 4 }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Trials', level: 4 })).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/Select a Godhome sequence/i)).toBeChecked();
+  });
+
+  it('exposes sequence conditions while disabling unselected options', async () => {
+    const { user, onConditionToggle } = renderSelector({
+      sequenceSelectValue: pantheonSequence.id,
+      sequenceEntries: pantheonSequence.entries,
+      sequenceConditionValues: {
+        'include-grey-prince': true,
+        'double-damage': false,
+      },
+    });
+
+    const pantheonToggle = screen.getByRole('checkbox', {
+      name: /Include Grey Prince Zote/i,
+    });
+    expect(pantheonToggle).toBeEnabled();
+    expect(pantheonToggle).toBeChecked();
+
+    await user.click(pantheonToggle);
+    expect(onConditionToggle).toHaveBeenCalledWith('include-grey-prince', false);
+
+    const trialOption = screen
+      .getByText('Trial of the Warrior')
+      .closest('.sequence-selector__option');
+    expect(trialOption).not.toBeNull();
+
+    const trialToggle = within(trialOption as HTMLElement).getByRole('checkbox', {
+      name: /Double damage mode/i,
+    });
+    expect(trialToggle).toBeDisabled();
+    expect(trialToggle).toBeChecked();
+  });
+
+  it('shows the selected sequence preview using resolved entries', async () => {
+    const onStageSelect = vi.fn();
+    const { user, onSequenceChange } = renderSelector({
+      sequenceSelectValue: pantheonSequence.id,
+      sequenceEntries: pantheonSequence.entries,
+      cappedSequenceIndex: 1,
+      onStageSelect,
+    });
+
+    const stageButton = screen.getByRole('button', {
+      name: /Gruz Mother/i,
+    });
+    expect(stageButton).toHaveAttribute('aria-current', 'true');
+
+    await user.click(stageButton);
+    expect(onStageSelect).toHaveBeenCalledWith(1);
+
+    await user.click(screen.getByLabelText(/Trial of the Warrior/i));
+    expect(onSequenceChange).toHaveBeenCalledWith('trial-1');
+
+    expect(
+      screen.queryByRole('button', { name: /Massive Moss Charger/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/encounter-setup/SequenceSelector.tsx
+++ b/src/features/encounter-setup/SequenceSelector.tsx
@@ -1,4 +1,4 @@
-import { useId, type FC } from 'react';
+import { useId, useMemo, type FC } from 'react';
 
 import type { useBuildConfiguration } from '../build-config/useBuildConfiguration';
 
@@ -12,6 +12,10 @@ export type SequenceSelectorProps = {
   readonly sequenceEntries: ReturnType<typeof useBuildConfiguration>['sequenceEntries'];
   readonly cappedSequenceIndex: number;
   readonly onStageSelect: (index: number) => void;
+  readonly sequenceConditionValues: ReturnType<
+    typeof useBuildConfiguration
+  >['sequenceConditionValues'];
+  readonly onConditionToggle: (conditionId: string, enabled: boolean) => void;
 };
 
 export const SequenceSelector: FC<SequenceSelectorProps> = ({
@@ -24,10 +28,31 @@ export const SequenceSelector: FC<SequenceSelectorProps> = ({
   sequenceEntries,
   cappedSequenceIndex,
   onStageSelect,
+  sequenceConditionValues,
+  onConditionToggle,
 }) => {
   const headingId = useId();
   const descriptionId = useId();
-  const selectId = useId();
+  const radioName = useId();
+
+  const groupedSequences = useMemo(() => {
+    type BossSequence = SequenceSelectorProps['bossSequences'][number];
+    const groups: Array<{ category: string; sequences: BossSequence[] }> = [];
+    const categoryMap = new Map<string, BossSequence[]>();
+
+    for (const sequence of bossSequences) {
+      const category = sequence.category;
+      let group = categoryMap.get(category);
+      if (!group) {
+        group = [];
+        categoryMap.set(category, group);
+        groups.push({ category, sequences: group });
+      }
+      group.push(sequence);
+    }
+
+    return groups;
+  }, [bossSequences]);
 
   return (
     <section
@@ -43,51 +68,191 @@ export const SequenceSelector: FC<SequenceSelectorProps> = ({
           </p>
         </div>
       </div>
-      <label className="sequence-selector__field" htmlFor={selectId}>
-        <span className="sequence-selector__field-label">Sequence</span>
-        <select
-          id={selectId}
-          value={sequenceSelectValue}
-          onChange={(event) => onSequenceChange(event.target.value)}
-        >
-          <option value="" disabled>
-            {placeholder}
-          </option>
-          {bossSequences.map((sequence) => (
-            <option key={sequence.id} value={sequence.id}>
-              {sequence.name}
-            </option>
-          ))}
-        </select>
-      </label>
-      {sequenceEntries.length > 0 ? (
-        <ol className="sequence-selector__stages">
-          {sequenceEntries.map((entry, index) => {
-            const isCurrent = index === cappedSequenceIndex;
-            return (
-              <li key={entry.id}>
-                <button
-                  type="button"
-                  className="sequence-selector__stage"
-                  onClick={() => onStageSelect(index)}
-                  aria-current={isCurrent ? 'true' : undefined}
-                >
-                  <span className="sequence-selector__stage-index">
-                    {String(index + 1).padStart(2, '0')}
-                  </span>
-                  <span className="sequence-selector__stage-name">
-                    {entry.target.bossName}
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ol>
-      ) : (
-        <p className="sequence-selector__empty" aria-live="polite">
-          Select a sequence to populate the stage tracker.
-        </p>
-      )}
+      <div
+        className="sequence-selector__options"
+        role="radiogroup"
+        aria-labelledby={headingId}
+        aria-describedby={descriptionId}
+      >
+        <SequenceOption
+          id={`${radioName}-none`}
+          name={radioName}
+          title={placeholder}
+          description="Preview Pantheons and Trials before committing to a run."
+          value=""
+          isSelected={sequenceSelectValue === ''}
+          onSelect={onSequenceChange}
+        />
+        {groupedSequences.map((group, groupIndex) => (
+          <div key={group.category} className="sequence-selector__group">
+            <h4 className="sequence-selector__group-title">{group.category}</h4>
+            <div className="sequence-selector__group-options">
+              {group.sequences.map((sequence, sequenceIndex) => {
+                const optionId = `${radioName}-${groupIndex}-${sequenceIndex}`;
+                const isSelected = sequenceSelectValue === sequence.id;
+                return (
+                  <SequenceOption
+                    key={sequence.id}
+                    id={optionId}
+                    name={radioName}
+                    title={sequence.name}
+                    description={`${sequence.entries.length} stage${
+                      sequence.entries.length === 1 ? '' : 's'
+                    }`}
+                    value={sequence.id}
+                    isSelected={isSelected}
+                    onSelect={onSequenceChange}
+                    conditions={sequence.conditions}
+                    conditionValues={sequenceConditionValues}
+                    onConditionToggle={onConditionToggle}
+                    isInteractive={isSelected}
+                    entries={isSelected ? sequenceEntries : undefined}
+                    cappedSequenceIndex={cappedSequenceIndex}
+                    onStageSelect={onStageSelect}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
     </section>
+  );
+};
+
+type SequenceOptionProps = {
+  readonly id: string;
+  readonly name: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly value: string;
+  readonly isSelected: boolean;
+  readonly onSelect: (value: string) => void;
+  readonly conditions?: SequenceSelectorProps['bossSequences'][number]['conditions'];
+  readonly conditionValues?: SequenceSelectorProps['sequenceConditionValues'];
+  readonly onConditionToggle?: SequenceSelectorProps['onConditionToggle'];
+  readonly isInteractive?: boolean;
+  readonly entries?: SequenceSelectorProps['sequenceEntries'];
+  readonly cappedSequenceIndex?: number;
+  readonly onStageSelect?: SequenceSelectorProps['onStageSelect'];
+};
+
+const SequenceOption: FC<SequenceOptionProps> = ({
+  id,
+  name,
+  title,
+  description,
+  value,
+  isSelected,
+  onSelect,
+  conditions,
+  conditionValues,
+  onConditionToggle,
+  isInteractive = false,
+  entries,
+  cappedSequenceIndex,
+  onStageSelect,
+}) => {
+  const handleChange = () => {
+    onSelect(value);
+  };
+
+  const hasConditions = Boolean(conditions && conditions.length > 0);
+  const resolvedConditionValues = conditionValues ?? {};
+
+  return (
+    <div
+      className="sequence-selector__option"
+      data-selected={isSelected ? 'true' : undefined}
+    >
+      <input
+        id={id}
+        className="sr-only"
+        type="radio"
+        name={name}
+        value={value}
+        checked={isSelected}
+        onChange={handleChange}
+      />
+      <label className="sequence-selector__option-header" htmlFor={id}>
+        <span className="sequence-selector__option-title">{title}</span>
+        {description ? (
+          <span className="sequence-selector__option-description">{description}</span>
+        ) : null}
+      </label>
+      {hasConditions ? (
+        <div className="sequence-selector__option-conditions" role="group">
+          <span className="sequence-selector__option-conditions-title">
+            Sequence modifiers
+          </span>
+          <div className="sequence-selector__option-conditions-grid">
+            {conditions?.map((condition) => {
+              const isEnabled = isInteractive
+                ? resolvedConditionValues[condition.id]
+                : condition.defaultEnabled;
+              return (
+                <label key={condition.id} className="sequence-selector__condition-option">
+                  <input
+                    type="checkbox"
+                    checked={isEnabled}
+                    disabled={!isInteractive}
+                    onChange={
+                      isInteractive && onConditionToggle
+                        ? (event) => onConditionToggle(condition.id, event.target.checked)
+                        : undefined
+                    }
+                  />
+                  <span>
+                    <span className="sequence-selector__condition-label">
+                      {condition.label}
+                    </span>
+                    {condition.description ? (
+                      <span className="sequence-selector__condition-description">
+                        {condition.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {!isInteractive ? (
+            <p className="sequence-selector__option-conditions-note">
+              Select this sequence to adjust modifiers.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+      {isInteractive && entries ? (
+        entries.length > 0 ? (
+          <ol className="sequence-selector__stages">
+            {entries.map((entry, index) => {
+              const isCurrent = index === cappedSequenceIndex;
+              return (
+                <li key={entry.id}>
+                  <button
+                    type="button"
+                    className="sequence-selector__stage"
+                    onClick={() => onStageSelect?.(index)}
+                    aria-current={isCurrent ? 'true' : undefined}
+                  >
+                    <span className="sequence-selector__stage-index">
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <span className="sequence-selector__stage-name">
+                      {entry.target.bossName}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        ) : (
+          <p className="sequence-selector__empty" aria-live="polite">
+            Select a sequence to populate the stage tracker.
+          </p>
+        )
+      ) : null}
+    </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1349,6 +1349,134 @@ h6 {
   color: var(--color-muted);
 }
 
+.sequence-selector__options {
+  display: grid;
+  gap: clamp(0.6rem, 1.2vw, 0.9rem);
+}
+
+.sequence-selector__group {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.sequence-selector__group-title {
+  margin: 0;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--color-muted);
+}
+
+.sequence-selector__group-options {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.sequence-selector__option {
+  position: relative;
+  display: grid;
+  gap: 0.6rem;
+  padding: clamp(0.65rem, 1.6vw, 0.95rem);
+  border-radius: 12px;
+  border: 1px solid var(--color-border-faint);
+  background-color: var(--color-surface-muted);
+  background-image:
+    linear-gradient(140deg, rgb(255 255 255 / 12%), transparent),
+    radial-gradient(circle at 80% 35%, rgb(30 52 90 / 34%), transparent 70%),
+    var(--texture-vein);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 10%),
+    inset 0 -1px 0 rgb(0 0 0 / 48%);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.sequence-selector__option:hover,
+.sequence-selector__option:focus-within {
+  border-color: rgb(180 225 255 / 60%);
+  box-shadow:
+    0 12px 20px rgb(0 0 0 / 45%),
+    0 0 18px rgb(215 245 255 / 30%),
+    inset 0 0 0 1px rgb(255 255 255 / 18%);
+  transform: translateY(-1px);
+}
+
+.sequence-selector__option[data-selected='true'] {
+  border-color: rgb(180 225 255 / 75%);
+  box-shadow:
+    0 16px 26px rgb(0 0 0 / 55%),
+    0 0 22px rgb(215 245 255 / 35%),
+    inset 0 0 0 1px rgb(255 255 255 / 22%);
+}
+
+.sequence-selector__option-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.sequence-selector__option-title {
+  font-weight: 600;
+  font-size: var(--font-size-subhead);
+}
+
+.sequence-selector__option-description {
+  font-size: var(--font-size-caption);
+  color: var(--color-muted);
+}
+
+.sequence-selector__option-conditions {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.sequence-selector__option-conditions-title {
+  font-size: var(--font-size-caption);
+  color: var(--color-muted);
+  letter-spacing: 0.05em;
+  text-transform: none;
+}
+
+.sequence-selector__option-conditions-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sequence-selector__condition-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  align-items: start;
+  font-size: var(--font-size-body);
+}
+
+.sequence-selector__condition-option input[type='checkbox'] {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: rgb(130 207 255 / 80%);
+}
+
+.sequence-selector__condition-label {
+  font-weight: 600;
+}
+
+.sequence-selector__condition-description {
+  display: block;
+  color: var(--color-muted);
+  font-size: var(--font-size-caption);
+  margin-top: 0.15rem;
+}
+
+.sequence-selector__option-conditions-note {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  color: var(--color-muted);
+}
+
 .sequence-selector__stages {
   display: grid;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary
- redesign the sequence selector into grouped radio options with inline stage previews and condition toggles
- pass condition state through the encounter setup panel and refresh the app test for the new interaction model
- style the new layout and add focused tests for sequence grouping, previews, and condition toggles

## Testing
- pnpm lint
- pnpm test:unit src/features/encounter-setup/SequenceSelector.test.tsx
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e1e9e566c0832fb751a2d8b69eaa4e