### PR TITLE
fix: remove duplicate target summary from header

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -141,43 +141,6 @@ const AppContent: FC = () => {
       }
     : null;
   const stageLabel = currentSequenceEntry ? currentSequenceEntry.target.bossName : null;
-  const encounterMode: 'single-target' | 'sequence' = activeSequence
-    ? 'sequence'
-    : 'single-target';
-  const targetSummaryName =
-    encounterMode === 'sequence' && currentSequenceEntry
-      ? currentSequenceEntry.target.bossName
-      : encounterName;
-  const stageVersionTitle = currentSequenceEntry?.target.version.title ?? null;
-  const stageLocation = currentSequenceEntry?.target.location ?? null;
-  const customTargetLabel = `${customTargetHp.toLocaleString()} HP`;
-  let targetSummaryDetail: string | null = null;
-  if (encounterMode === 'sequence') {
-    targetSummaryDetail = stageVersionTitle;
-  } else if (selectedVersion?.title) {
-    targetSummaryDetail = selectedVersion.title;
-  } else if (!selectedTarget) {
-    targetSummaryDetail = customTargetLabel;
-  }
-  const targetSummaryLocation = encounterMode === 'sequence' ? stageLocation : arenaLabel;
-  const sequenceSummary =
-    encounterMode === 'sequence'
-      ? {
-          name: activeSequence?.name ?? null,
-          stageLabel,
-          progress: stageProgress,
-        }
-      : null;
-  const encounterSummary = {
-    mode: encounterMode,
-    target: {
-      name: targetSummaryName,
-      detail: targetSummaryDetail,
-      location: targetSummaryLocation,
-    },
-    sequence: sequenceSummary,
-  } as const;
-
   return (
     <div className="app-shell">
       <HeaderBar
@@ -195,7 +158,6 @@ const AppContent: FC = () => {
         onRewindStage={handleRewindSequence}
         hasNextStage={hasNextSequenceStage}
         hasPreviousStage={hasPreviousSequenceStage}
-        encounterSummary={encounterSummary}
       />
       <MobilePinnedHud derived={derived} encounterName={encounterName} />
 

--- a/src/app/components/HeaderBar.tsx
+++ b/src/app/components/HeaderBar.tsx
@@ -1,12 +1,6 @@
 import type { FC } from 'react';
 
-import {
-  AppButton,
-  EncounterBrand,
-  EncounterSummary,
-  SurfaceSection,
-  type EncounterSummaryProps,
-} from '../../components';
+import { AppButton, EncounterBrand, SurfaceSection } from '../../components';
 import type { useFightDerivedStats } from '../../features/fight-state/FightStateContext';
 import { TargetScoreboard } from './TargetScoreboard';
 
@@ -25,7 +19,6 @@ export type HeaderBarProps = {
   readonly onRewindStage: () => void;
   readonly hasNextStage: boolean;
   readonly hasPreviousStage: boolean;
-  readonly encounterSummary: EncounterSummaryProps;
 };
 
 export const HeaderBar: FC<HeaderBarProps> = ({
@@ -43,7 +36,6 @@ export const HeaderBar: FC<HeaderBarProps> = ({
   onRewindStage,
   hasNextStage,
   hasPreviousStage,
-  encounterSummary,
 }) => (
   <SurfaceSection
     as="header"
@@ -59,7 +51,6 @@ export const HeaderBar: FC<HeaderBarProps> = ({
           versionLabel={versionLabel}
           arenaLabel={arenaLabel}
         />
-        <EncounterSummary {...encounterSummary} />
       </div>
     }
     actions={


### PR DESCRIPTION
## Summary
- remove the duplicate target summary chip from the header brand section
- simplify App header props now that the summary widget is gone

## Testing
- pnpm test
- CI=1 pnpm lint:css
- CI=1 pnpm lint:js

------
https://chatgpt.com/codex/tasks/task_e_68e1eedaf148832fabe5750a0a6bd15e