### PR TITLE
feat: add web manifest and Hollow Knight icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hollow Knight Damage Tracker</title>
+    <meta name="application-name" content="Hollow Knight Damage Tracker" />
+    <meta name="theme-color" content="#0b0d1c" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="./icons/favicon.svg" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="HK Damage" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/icons/apple-touch-icon.svg
+++ b/public/icons/apple-touch-icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180" role="img" aria-labelledby="title desc">
+  <title id="title">Hollow Knight Damage Tracker Apple Touch Icon</title>
+  <desc id="desc">Rounded square blue gradient with simplified Hollow Knight mask.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#253673" />
+      <stop offset="100%" stop-color="#070910" />
+    </linearGradient>
+  </defs>
+  <rect width="180" height="180" rx="32" fill="url(#bg)" />
+  <path d="M54 47c8-16 22-24 36-24s28 8 36 24c4 7-3 15-10 8-7-8-13-12-26-12s-19 4-26 12c-7 7-14-1-10-8Z" fill="#eef1ff" />
+  <path d="M50 81c0-18 16-33 40-33s40 15 40 33v16c0 18-11 36-30 44l-10 3-10-3c-19-8-30-26-30-44V81Z" fill="#f7f8ff" />
+  <path d="M60 94a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm50 0a10 10 0 1 1 0 20 10 10 0 0 1 0-20Z" fill="#0c1021" />
+</svg>

--- a/public/icons/favicon.svg
+++ b/public/icons/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-labelledby="title desc">
+  <title id="title">Hollow Knight Damage Tracker Favicon</title>
+  <desc id="desc">Minimalist Hollow Knight mask favicon.</desc>
+  <rect width="48" height="48" rx="10" fill="#0b0d1c" />
+  <path d="M13 11c4-7 11-10 15-10s11 3 15 10c2 4-2 7-5 4-3-3-6-5-10-5s-7 2-10 5c-3 3-7 0-5-4Z" fill="#f2f4ff" />
+  <path d="M12 20c0-6 5-11 11-11h2c6 0 11 5 11 11v5c0 6-3 12-9 14l-3 1-3-1c-6-2-9-8-9-14v-5Z" fill="#f7f8ff" />
+  <circle cx="18" cy="26" r="3" fill="#080b1a" />
+  <circle cx="30" cy="26" r="3" fill="#080b1a" />
+</svg>

--- a/public/icons/hk-icon-192.svg
+++ b/public/icons/hk-icon-192.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192" role="img" aria-labelledby="title desc">
+  <title id="title">Hollow Knight Damage Tracker Icon</title>
+  <desc id="desc">Stylized Hollow Knight mask above a deep blue gradient backdrop.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e2a5c" />
+      <stop offset="100%" stop-color="#080b1a" />
+    </linearGradient>
+    <linearGradient id="horn" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#d8e0ff" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="36" fill="url(#bg)" />
+  <path d="M59 44c9-16 24-24 37-24 13 0 28 8 37 24 4 8-4 16-11 9-7-9-13-13-26-13-13 0-19 4-26 13-7 7-15-1-11-9Z" fill="url(#horn)" />
+  <path d="M53 79c0-20 18-37 43-37s43 17 43 37v18c0 20-11 40-32 48l-11 4-11-4c-21-8-32-28-32-48V79Z" fill="#f7f8ff" />
+  <path d="M64 94c6 0 11 5 11 11s-5 11-11 11-11-5-11-11 5-11 11-11Zm64 0c6 0 11 5 11 11s-5 11-11 11-11-5-11-11 5-11 11-11Z" fill="#101326" />
+  <path d="M70 138c13 10 39 10 52 0 3-2 7 2 5 6-12 22-50 22-62 0-2-4 2-8 5-6Z" fill="#d0d7ff" opacity="0.65" />
+</svg>

--- a/public/icons/hk-icon-512.svg
+++ b/public/icons/hk-icon-512.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Hollow Knight Damage Tracker Icon Large</title>
+  <desc id="desc">Large Hollow Knight inspired emblem with mask silhouette and midnight gradient.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#232f68" />
+      <stop offset="100%" stop-color="#050712" />
+    </linearGradient>
+    <linearGradient id="horn" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.97" />
+      <stop offset="100%" stop-color="#d4dcff" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)" />
+  <path d="M157 128c28-47 75-72 107-72s79 25 107 72c12 24-12 45-32 25-18-24-36-36-75-36s-57 12-75 36c-20 20-44-1-32-25Z" fill="url(#horn)" />
+  <path d="M144 210c0-55 51-102 120-102s120 47 120 102v48c0 55-31 109-89 131l-31 11-31-11c-58-22-89-76-89-131v-48Z" fill="#f7f8ff" />
+  <path d="M173 250c17 0 31 14 31 31s-14 31-31 31-31-14-31-31 14-31 31-31Zm166 0c17 0 31 14 31 31s-14 31-31 31-31-14-31-31 14-31 31-31Z" fill="#0c1021" />
+  <path d="M188 359c36 29 100 29 136 0 9-7 19 6 14 17-32 58-132 58-164 0-5-11 5-24 14-17Z" fill="#d0d7ff" opacity="0.6" />
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Hollow Knight Damage Tracker",
+  "short_name": "HK Damage",
+  "description": "Track Hollow Knight damage values and plan combat strategies on the go.",
+  "start_url": "/hollow-knight-damage-tracker/",
+  "scope": "/hollow-knight-damage-tracker/",
+  "display": "standalone",
+  "background_color": "#0b0d1c",
+  "theme_color": "#0b0d1c",
+  "icons": [
+    {
+      "src": "./icons/hk-icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "./icons/hk-icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a PWA manifest aligned with the GitHub Pages base path and maskable icons
- create Hollow Knight styled SVG icons, including Apple touch and favicon assets
- update the HTML head to reference the manifest, theme color, and Apple mobile metadata

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e1fa6d071c832fb9e4109a7513167d