### PR TITLE
fix: stabilize charm flight animations

### DIFF
--- a/src/features/build-config/PlayerConfigModal.test.tsx
+++ b/src/features/build-config/PlayerConfigModal.test.tsx
@@ -1,11 +1,20 @@
-import { act, fireEvent, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithFightProvider } from '../../test-utils/renderWithFightProvider';
-import { PlayerConfigModal } from './PlayerConfigModal';
+import { CharmFlightSprite, PlayerConfigModal } from './PlayerConfigModal';
 
 const openModal = () =>
   renderWithFightProvider(<PlayerConfigModal isOpen onClose={() => {}} />);
+
+const baseAnimation = {
+  key: 'flight',
+  charmId: 'shaman-stone',
+  icon: '/charms/shaman-stone.png',
+  from: { x: 5, y: 10 },
+  to: { x: 20, y: 40 },
+  size: { width: 32, height: 32 },
+} as const;
 
 describe('PlayerConfigModal charms', () => {
   it('retains rapid charm selections without dropping earlier choices', () => {
@@ -29,5 +38,85 @@ describe('PlayerConfigModal charms', () => {
     expect(equippedItems).toHaveLength(2);
     expect(equippedItems[0]).toHaveTextContent(/wayward compass/i);
     expect(equippedItems[1]).toHaveTextContent(/gathering swarm/i);
+  });
+});
+
+describe('CharmFlightSprite', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('waits for a second animation frame before moving to the destination', () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    const requestSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback);
+        return rafCallbacks.length;
+      });
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+    const onComplete = vi.fn();
+
+    const { container, unmount } = render(
+      <CharmFlightSprite animation={baseAnimation} onComplete={onComplete} />,
+    );
+
+    const element = container.querySelector('.charm-flight') as HTMLImageElement;
+    const rectSpy = vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      width: baseAnimation.size.width,
+      height: baseAnimation.size.height,
+      top: 10,
+      left: 20,
+      bottom: 42,
+      right: 52,
+      x: 20,
+      y: 10,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    expect(rafCallbacks).toHaveLength(1);
+    expect(element.style.transform).toBe('translate(5px, 10px)');
+
+    act(() => {
+      rafCallbacks[0](0);
+    });
+
+    expect(rectSpy).toHaveBeenCalledTimes(1);
+    expect(rafCallbacks).toHaveLength(2);
+
+    act(() => {
+      rafCallbacks[1](16);
+    });
+
+    expect(element.style.transform).toBe('translate(20px, 40px)');
+    expect(onComplete).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    expect(cancelSpy).toHaveBeenCalledWith(1);
+    expect(cancelSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('completes immediately when no movement is needed', () => {
+    const requestSpy = vi.spyOn(window, 'requestAnimationFrame');
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+    const onComplete = vi.fn();
+
+    render(
+      <CharmFlightSprite
+        animation={{
+          ...baseAnimation,
+          key: 'static-flight',
+          from: { x: 12, y: 18 },
+          to: { x: 12, y: 18 },
+        }}
+        onComplete={onComplete}
+      />,
+    );
+
+    expect(onComplete).toHaveBeenCalledWith('static-flight');
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(cancelSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure charm equip flights schedule their transform on a follow-up animation frame after forcing layout so transitions run reliably on slower devices
- export the CharmFlightSprite helper and cover its timing behaviour while keeping the existing charm selection regression test

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e20371d1a0832f91cedd0f128d28e3