### PR TITLE
feat: refine charm selector animations

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -223,6 +223,7 @@ describe('App', () => {
       await waitFor(
         () => {
           expect(modal.querySelectorAll('.charm-flight')).toHaveLength(0);
+          expect(modal.querySelectorAll('.equipped-panel__item--hidden')).toHaveLength(0);
         },
         { timeout: CHARM_FLIGHT_TIMEOUT_MS + 200 },
       );

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -225,7 +225,7 @@ describe('App', () => {
           expect(modal.querySelectorAll('.charm-flight')).toHaveLength(0);
           expect(modal.querySelectorAll('.equipped-panel__item--hidden')).toHaveLength(0);
         },
-        { timeout: CHARM_FLIGHT_TIMEOUT_MS + 200 },
+        { timeout: CHARM_FLIGHT_TIMEOUT_MS + 400 },
       );
     };
 

--- a/src/features/build-config/PlayerConfigModal.test.tsx
+++ b/src/features/build-config/PlayerConfigModal.test.tsx
@@ -10,6 +10,7 @@ const openModal = () =>
 const baseAnimation = {
   key: 'flight',
   charmId: 'shaman-stone',
+  direction: 'equip' as const,
   icon: '/charms/shaman-stone.png',
   from: { x: 5, y: 10 },
   to: { x: 20, y: 40 },
@@ -17,7 +18,12 @@ const baseAnimation = {
 } as const;
 
 describe('PlayerConfigModal charms', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('retains rapid charm selections without dropping earlier choices', () => {
+    vi.useFakeTimers();
     openModal();
 
     const compassButton = screen.getByRole('button', {
@@ -30,6 +36,10 @@ describe('PlayerConfigModal charms', () => {
     act(() => {
       fireEvent.click(compassButton);
       fireEvent.click(swarmButton);
+    });
+
+    act(() => {
+      vi.runAllTimers();
     });
 
     const equippedList = screen.getByRole('list');
@@ -115,7 +125,9 @@ describe('CharmFlightSprite', () => {
       />,
     );
 
-    expect(onComplete).toHaveBeenCalledWith('static-flight');
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'static-flight' }),
+    );
     expect(requestSpy).not.toHaveBeenCalled();
     expect(cancelSpy).not.toHaveBeenCalled();
   });

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -79,17 +79,21 @@ const getCharmAriaLabel = (charm: Charm) => {
 type CharmFlight = {
   key: string;
   charmId: string;
+  direction: 'equip' | 'unequip';
   icon: string;
   from: { x: number; y: number };
   to: { x: number; y: number };
   size: { width: number; height: number };
 };
 
+type PanelCharmState = 'entering' | 'visible' | 'exiting';
+type EquippedCharmEntry = { charm: Charm; state: PanelCharmState };
+
 export const CHARM_FLIGHT_TIMEOUT_MS = 600;
 
 export const CharmFlightSprite: FC<{
   readonly animation: CharmFlight;
-  readonly onComplete: (key: string) => void;
+  readonly onComplete: (flight: CharmFlight) => void;
 }> = ({ animation, onComplete }) => {
   const elementRef = useRef<HTMLImageElement | null>(null);
 
@@ -108,7 +112,7 @@ export const CharmFlightSprite: FC<{
         return;
       }
       didComplete = true;
-      onComplete(animation.key);
+      onComplete(animation);
     };
 
     const handleTransitionEnd = (event: TransitionEvent) => {
@@ -191,21 +195,49 @@ const PlayerConfigModalContent: FC = () => {
   const overcharmRef = useRef(isOvercharmed);
   const { trigger: triggerHaptics } = useHapticFeedback();
   const [charmFlights, setCharmFlights] = useState<CharmFlight[]>([]);
+  const [panelCharmStates, setPanelCharmStates] = useState<Map<string, PanelCharmState>>(
+    () => {
+      const initial = new Map<string, PanelCharmState>();
+      for (const charmId of activeCharmIds) {
+        initial.set(charmId, 'visible');
+      }
+      return initial;
+    },
+  );
 
   const notchUsage = `${activeCharmCost}/${notchLimit}`;
-  const equippedCharms = useMemo(() => {
-    const ordered = activeCharmIds
-      .map((id) => charmDetails.get(id))
-      .filter((charm): charm is Charm => Boolean(charm));
-
-    const voidHeartIndex = ordered.findIndex((charm) => charm.id === 'void-heart');
-    if (voidHeartIndex > 0) {
-      const [voidHeart] = ordered.splice(voidHeartIndex, 1);
-      ordered.unshift(voidHeart);
+  const equippedCharmEntries = useMemo(() => {
+    const activeEntries: EquippedCharmEntry[] = [];
+    for (const charmId of activeCharmIds) {
+      const charm = charmDetails.get(charmId);
+      if (!charm) {
+        continue;
+      }
+      const state = panelCharmStates.get(charmId) ?? 'visible';
+      activeEntries.push({ charm, state });
     }
 
-    return ordered;
-  }, [activeCharmIds, charmDetails]);
+    const voidHeartIndex = activeEntries.findIndex(
+      (entry) => entry.charm.id === 'void-heart',
+    );
+    if (voidHeartIndex > 0) {
+      const [voidHeart] = activeEntries.splice(voidHeartIndex, 1);
+      activeEntries.unshift(voidHeart);
+    }
+
+    const exitingEntries: EquippedCharmEntry[] = [];
+    for (const [charmId, state] of panelCharmStates.entries()) {
+      if (state !== 'exiting' || activeCharmIds.includes(charmId)) {
+        continue;
+      }
+      const charm = charmDetails.get(charmId);
+      if (charm) {
+        exitingEntries.push({ charm, state });
+      }
+    }
+
+    return [...activeEntries, ...exitingEntries];
+  }, [activeCharmIds, charmDetails, panelCharmStates]);
   const notchIndicators = useMemo(
     () =>
       Array.from({ length: MAX_NOTCH_LIMIT }, (_, index) => {
@@ -236,20 +268,66 @@ const PlayerConfigModalContent: FC = () => {
   useEffect(() => {
     const previous = previousCharmIdsRef.current;
     const newlyEquipped = activeCharmIds.filter((id) => !previous.includes(id));
+    const newlyUnequipped = previous.filter((id) => !activeCharmIds.includes(id));
     previousCharmIdsRef.current = activeCharmIds;
 
-    if (newlyEquipped.length === 0) {
+    setPanelCharmStates((current) => {
+      const next = new Map(current);
+      let didChange = false;
+
+      for (const charmId of activeCharmIds) {
+        const isNew = newlyEquipped.includes(charmId);
+        const state = next.get(charmId);
+        if (!state || state === 'exiting') {
+          next.set(charmId, isNew ? 'entering' : 'visible');
+          didChange = true;
+        }
+      }
+
+      for (const charmId of newlyUnequipped) {
+        if (next.get(charmId) !== 'exiting') {
+          next.set(charmId, 'exiting');
+          didChange = true;
+        }
+      }
+
+      return didChange ? next : current;
+    });
+
+    if (newlyEquipped.length === 0 && newlyUnequipped.length === 0) {
       return;
     }
 
     const container = workbenchRef.current;
     if (!container) {
+      setPanelCharmStates((current) => {
+        const next = new Map(current);
+        let didChange = false;
+
+        for (const charmId of newlyEquipped) {
+          if (next.get(charmId) === 'entering') {
+            next.set(charmId, 'visible');
+            didChange = true;
+          }
+        }
+
+        for (const charmId of newlyUnequipped) {
+          if (next.has(charmId)) {
+            next.delete(charmId);
+            didChange = true;
+          }
+        }
+
+        return didChange ? next : current;
+      });
       return;
     }
 
     const frame = requestAnimationFrame(() => {
       const containerRect = container.getBoundingClientRect();
       const updates: CharmFlight[] = [];
+      const instantVisible: string[] = [];
+      const instantRemoval: string[] = [];
 
       for (const charmId of newlyEquipped) {
         const source = charmSlotRefs.current.get(charmId);
@@ -257,6 +335,7 @@ const PlayerConfigModalContent: FC = () => {
         const icon = charmIconMap.get(charmId);
 
         if (!source || !target || !icon) {
+          instantVisible.push(charmId);
           continue;
         }
 
@@ -268,6 +347,7 @@ const PlayerConfigModalContent: FC = () => {
         updates.push({
           key: `${charmId}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
           charmId,
+          direction: 'equip',
           icon,
           from: {
             x: sourceRect.left - containerRect.left + (sourceRect.width - width) / 2,
@@ -278,6 +358,61 @@ const PlayerConfigModalContent: FC = () => {
             y: targetRect.top - containerRect.top,
           },
           size: { width, height },
+        });
+      }
+
+      for (const charmId of newlyUnequipped) {
+        const source = equippedCharmRefs.current.get(charmId);
+        const target = charmSlotRefs.current.get(charmId);
+        const icon = charmIconMap.get(charmId);
+
+        if (!source || !target || !icon) {
+          instantRemoval.push(charmId);
+          continue;
+        }
+
+        const sourceRect = source.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        const width = sourceRect.width || targetRect.width;
+        const height = sourceRect.height || targetRect.height;
+
+        updates.push({
+          key: `${charmId}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          charmId,
+          direction: 'unequip',
+          icon,
+          from: {
+            x: sourceRect.left - containerRect.left,
+            y: sourceRect.top - containerRect.top,
+          },
+          to: {
+            x: targetRect.left - containerRect.left + (targetRect.width - width) / 2,
+            y: targetRect.top - containerRect.top + (targetRect.height - height) / 2,
+          },
+          size: { width, height },
+        });
+      }
+
+      if (instantVisible.length > 0 || instantRemoval.length > 0) {
+        setPanelCharmStates((current) => {
+          const next = new Map(current);
+          let didChange = false;
+
+          for (const charmId of instantVisible) {
+            if (next.get(charmId) === 'entering') {
+              next.set(charmId, 'visible');
+              didChange = true;
+            }
+          }
+
+          for (const charmId of instantRemoval) {
+            if (next.has(charmId)) {
+              next.delete(charmId);
+              didChange = true;
+            }
+          }
+
+          return didChange ? next : current;
         });
       }
 
@@ -297,8 +432,24 @@ const PlayerConfigModalContent: FC = () => {
     };
   }, [activeCharmIds, charmIconMap]);
 
-  const handleCharmFlightComplete = useCallback((key: string) => {
-    setCharmFlights((current) => current.filter((flight) => flight.key !== key));
+  const handleCharmFlightComplete = useCallback((flight: CharmFlight) => {
+    setCharmFlights((current) => current.filter((item) => item.key !== flight.key));
+    setPanelCharmStates((current) => {
+      const next = new Map(current);
+      let didChange = false;
+
+      if (flight.direction === 'equip') {
+        if (next.get(flight.charmId) === 'entering') {
+          next.set(flight.charmId, 'visible');
+          didChange = true;
+        }
+      } else if (next.has(flight.charmId)) {
+        next.delete(flight.charmId);
+        didChange = true;
+      }
+
+      return didChange ? next : current;
+    });
   }, []);
 
   return (
@@ -325,14 +476,18 @@ const PlayerConfigModalContent: FC = () => {
             <div className="equipped-panel">
               <h4 className="equipped-panel__title">Equipped</h4>
               <div className="equipped-panel__grid" role="list" aria-live="polite">
-                {equippedCharms.length > 0 ? (
-                  equippedCharms.map((charm) => {
+                {equippedCharmEntries.length > 0 ? (
+                  equippedCharmEntries.map(({ charm, state }) => {
                     const icon = charmIconMap.get(charm.id);
+                    const isHidden = state !== 'visible';
                     return (
                       <div
                         key={charm.id}
                         role="listitem"
-                        className="equipped-panel__item"
+                        className={`equipped-panel__item${
+                          isHidden ? ' equipped-panel__item--hidden' : ''
+                        }`}
+                        aria-hidden={isHidden}
                         title={getCharmTooltip(charm)}
                         ref={(element) => {
                           if (element) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2314,6 +2314,12 @@ h6 {
     inset 0 -1px 0 rgb(0 0 0 / 55%);
 }
 
+.equipped-panel__item--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .equipped-panel__icon {
   width: 2.2rem;
   height: 2.2rem;
@@ -2648,6 +2654,20 @@ h6 {
 .charm-token--active {
   filter: grayscale(0.9) brightness(0.7);
   opacity: 0.78;
+}
+
+.charm-token--active::after {
+  content: '';
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 1px rgb(134 206 255 / 38%),
+    0 12px 20px rgb(70 132 210 / 32%),
+    0 0 26px rgb(130 207 255 / 45%);
+  opacity: 0.9;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .charm-token--locked {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
     // Resolve setup file relative to this config file to avoid monorepo root issues
     setupFiles: fileURLToPath(new URL('./vitest.setup.ts', import.meta.url)),
     css: true,
+    testTimeout: 20000,
     exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- add bidirectional charm flight handling so equip and unequip animations run without duplicating icons in the equipped list
- hide equipped charm tiles during transitions and add a soft blue glow to active tokens in the grid

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e20b058b94832fb9fec094f5fc6bc5