### PR TITLE
feat: restyle target scoreboard layout

### DIFF
--- a/src/app/components/TargetScoreboard.test.tsx
+++ b/src/app/components/TargetScoreboard.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TargetScoreboard, type TargetScoreboardProps } from './TargetScoreboard';
+
+const derivedStats: TargetScoreboardProps['derived'] = {
+  targetHp: 1000,
+  totalDamage: 240,
+  remainingHp: 760,
+  attacksLogged: 12,
+  averageDamage: 20,
+  elapsedMs: 90_000,
+  dps: 85,
+  actionsPerMinute: 48,
+  estimatedTimeRemainingMs: 30_000,
+  fightStartTimestamp: 0,
+  fightEndTimestamp: null,
+  isFightInProgress: true,
+  isFightComplete: false,
+  frameTimestamp: 0,
+};
+
+const defaultProps: TargetScoreboardProps = {
+  derived: derivedStats,
+  stageLabel: 'Opening Phase',
+  stageProgress: { current: 1, total: 3 },
+  onAdvanceStage: vi.fn(),
+  onRewindStage: vi.fn(),
+  hasNextStage: true,
+  hasPreviousStage: false,
+};
+
+describe('TargetScoreboard', () => {
+  it('keeps boss status controls and metrics accessible', () => {
+    render(<TargetScoreboard {...defaultProps} />);
+
+    const scoreboard = screen.getByRole('region', { name: /encounter scoreboard/i });
+    expect(scoreboard).toBeInTheDocument();
+
+    expect(
+      within(scoreboard).getByRole('progressbar', { name: /boss hp/i }),
+    ).toBeVisible();
+
+    const stageNavigation = within(scoreboard).getByRole('group', {
+      name: /stage navigation/i,
+    });
+    expect(
+      within(stageNavigation).getByRole('button', { name: /next stage/i }),
+    ).toBeEnabled();
+    expect(
+      within(stageNavigation).getByRole('button', { name: /previous stage/i }),
+    ).toBeDisabled();
+
+    const metricTerms = within(scoreboard).getAllByRole('term');
+    expect(metricTerms.map((term) => term.textContent)).toEqual(
+      expect.arrayContaining(['Elapsed', 'Est. Remaining', 'DPS', 'Avg Dmg', 'APM']),
+    );
+
+    const metricDefinitions = within(scoreboard).getAllByRole('definition');
+    expect(metricDefinitions).not.toHaveLength(0);
+  });
+});

--- a/src/app/components/TargetScoreboard.tsx
+++ b/src/app/components/TargetScoreboard.tsx
@@ -75,7 +75,7 @@ export const TargetScoreboard: FC<TargetScoreboardProps> = ({
 
   return (
     <section className="hud-scoreboard" aria-label="Encounter scoreboard">
-      <div className="hud-scoreboard__status">
+      <div className="hud-scoreboard__summary">
         <BossHealthBar
           className="hud-health summary-chip summary-chip--accent"
           role="group"
@@ -95,14 +95,24 @@ export const TargetScoreboard: FC<TargetScoreboardProps> = ({
           hasPrevious={hasPreviousStage}
         />
       </div>
-      <dl className="hud-metrics">
+      <dl className="hud-metrics hud-scoreboard__metrics">
         {metrics.map((metric) => (
-          <div key={metric.id} className="hud-metrics__item" data-metric-id={metric.id}>
-            <dt className="hud-metrics__label">{metric.label}</dt>
-            <dd className="hud-metrics__value">
-              <span className="hud-metrics__value-primary">{metric.value}</span>
+          <div
+            key={metric.id}
+            className="hud-metrics__item hud-scoreboard__metric summary-chip"
+            data-metric-id={metric.id}
+          >
+            <dt className="hud-metrics__label hud-scoreboard__metric-label">
+              {metric.label}
+            </dt>
+            <dd className="hud-metrics__value hud-scoreboard__metric-value">
+              <span className="hud-metrics__value-primary hud-scoreboard__metric-value-primary">
+                {metric.value}
+              </span>
               {metric.sublabel ? (
-                <span className="hud-metrics__sublabel">{metric.sublabel}</span>
+                <span className="hud-metrics__sublabel hud-scoreboard__metric-sublabel">
+                  {metric.sublabel}
+                </span>
               ) : null}
             </dd>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -673,18 +673,21 @@ h6 {
 }
 
 .hud-scoreboard {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  gap: clamp(0.6rem, 1.8vw, 1.25rem);
   align-items: center;
-  justify-content: space-between;
-  gap: clamp(0.6rem, 1.6vw, 1rem);
-  flex-wrap: wrap;
 }
 
-.hud-scoreboard__status {
-  display: inline-flex;
+.hud-scoreboard__summary {
+  display: grid;
+  grid-auto-flow: column;
+  gap: clamp(0.45rem, 1.4vw, 1rem);
   align-items: center;
-  gap: clamp(0.45rem, 1.2vw, 0.9rem);
-  flex-wrap: wrap;
+}
+
+.hud-scoreboard__summary > * {
+  min-width: 0;
 }
 
 .hud-health {
@@ -730,22 +733,33 @@ h6 {
   letter-spacing: 0.05em;
 }
 
-.hud-metrics {
-  display: flex;
-  align-items: flex-start;
-  gap: clamp(0.5rem, 1.7vw, 1.1rem);
+.hud-metrics,
+.hud-scoreboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: clamp(0.45rem, 1.5vw, 0.95rem);
   margin: 0;
   padding: 0;
   list-style: none;
-  flex-wrap: wrap;
 }
 
-.hud-metrics__item {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.12rem;
-  min-width: 88px;
+.hud-metrics__item,
+.hud-scoreboard__metric {
+  position: relative;
+  display: grid;
+  gap: 0.18rem;
+  justify-items: end;
+  min-width: 0;
+  padding: clamp(0.3rem, 0.8vw, 0.55rem) clamp(0.35rem, 1.2vw, 0.75rem);
+  text-align: right;
+  clip-path: none;
+  background: none;
+  box-shadow: none;
+}
+
+.hud-scoreboard__metric::before,
+.hud-scoreboard__metric::after {
+  display: none;
 }
 
 .mobile-hud-sentinel {
@@ -818,7 +832,8 @@ h6 {
   white-space: nowrap;
 }
 
-.hud-metrics__label {
+.hud-metrics__label,
+.hud-scoreboard__metric-label {
   font-size: var(--font-size-caption);
   letter-spacing: 0.08em;
   text-transform: none;
@@ -826,7 +841,8 @@ h6 {
   text-align: right;
 }
 
-.hud-metrics__value {
+.hud-metrics__value,
+.hud-scoreboard__metric-value {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -835,7 +851,8 @@ h6 {
   text-align: right;
 }
 
-.hud-metrics__value-primary {
+.hud-metrics__value-primary,
+.hud-scoreboard__metric-value-primary {
   font-family: var(--font-numeric);
   font-size: var(--font-size-title);
   letter-spacing: 0.03em;
@@ -843,12 +860,86 @@ h6 {
   font-feature-settings: 'tnum' 1;
 }
 
-.hud-metrics__sublabel {
+.hud-metrics__sublabel,
+.hud-scoreboard__metric-sublabel {
   font-size: clamp(0.64rem, 1vw, 0.76rem);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: rgb(240 243 255 / 52%);
   line-height: 1;
+}
+
+@media (width <= 720px) {
+  .hud-scoreboard {
+    grid-template-columns: 1fr;
+    gap: clamp(0.75rem, 2vw, 1.25rem);
+    align-items: stretch;
+  }
+
+  .hud-scoreboard__summary {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+    gap: clamp(0.6rem, 2vw, 1rem);
+  }
+
+  .hud-metrics,
+  .hud-scoreboard__metrics {
+    grid-template-columns: 1fr;
+    gap: clamp(0.55rem, 2vw, 0.9rem);
+  }
+
+  .hud-metrics__item,
+  .hud-scoreboard__metric {
+    place-items: start;
+    text-align: left;
+    padding: clamp(0.55rem, 2.6vw, 0.85rem) clamp(0.6rem, 3vw, 1rem);
+    clip-path: var(--shape-tablet);
+    background-color: var(--color-surface);
+    background-image:
+      radial-gradient(circle at 20% 20%, rgb(214 217 231 / 18%), transparent 65%),
+      radial-gradient(circle at 80% 80%, rgb(22 46 88 / 36%), transparent 70%),
+      var(--texture-vein);
+    box-shadow:
+      var(--frame-shadow-raised),
+      var(--frame-outline),
+      var(--frame-highlight),
+      var(--frame-etch);
+  }
+
+  .hud-scoreboard__metric::before,
+  .hud-scoreboard__metric::after {
+    display: block;
+    content: '';
+    position: absolute;
+    inset: 0;
+    clip-path: var(--shape-tablet);
+    pointer-events: none;
+  }
+
+  .hud-scoreboard__metric::before {
+    background-image: var(--texture-noise);
+    background-size: 4px 4px;
+    mix-blend-mode: soft-light;
+    opacity: 0.25;
+  }
+
+  .hud-scoreboard__metric::after {
+    border: 1px solid var(--color-border-faint);
+    box-shadow: inset 0 0 12px rgb(0 0 0 / 55%);
+  }
+
+  .hud-metrics__label,
+  .hud-scoreboard__metric-label {
+    text-align: left;
+    color: rgb(240 243 255 / 72%);
+  }
+
+  .hud-metrics__value,
+  .hud-scoreboard__metric-value {
+    align-items: flex-start;
+    min-width: 0;
+    text-align: left;
+  }
 }
 
 .encounter-setup {


### PR DESCRIPTION
## Summary
- refactor the target scoreboard summary markup so the boss HP bar and stage controls share a dedicated wrapper and metrics render as discrete cards
- convert the scoreboard styles to use CSS grid with a mobile card layout that matches the existing summary-chip treatment
- add a TargetScoreboard component test to keep the HP bar, stage navigation, and metric terms accessible

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2dd8aab80832f93679fbe50ddfa0a