### PR TITLE
feat: add charm synergy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Hollow Knight Damage Tracker is a responsive companion app for players, co-comme
 ### Stay tactical mid-fight
 
 - **Build-aware damage:** Charms, nail upgrades, and spell levels combine automatically so every button shows the exact hit value left.
+- **Charm synergies:** See every combination at a glance with active-state indicators, updated damage, and quick descriptions for each pairing.
 - **Live analytics:** Remaining HP, DPS, average damage, and actions per minute update in real time with undo/redo support.
 - **Mobile haptics:** Distinct vibration cues for attacks, fight completions, sequence milestones, and overcharm warnings keep mobile logging effortless.
 - **Session persistence:** Loadouts and fight logs survive refreshes, rage quits, and accidental tab closes.

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -229,8 +229,11 @@ describe('App', () => {
       );
     };
 
+    const getEquippedList = () =>
+      within(modal).getByRole('list', { name: /equipped charms/i });
+
     const getEquippedItem = (pattern: RegExp) =>
-      within(modal).queryByRole('listitem', { name: pattern });
+      within(getEquippedList()).queryByRole('listitem', { name: pattern });
 
     await user.click(within(modal).getAllByRole('button', { name: /fragile heart/i })[0]);
     await waitForNoFlights();
@@ -247,7 +250,7 @@ describe('App', () => {
       within(modal).getAllByRole('button', { name: /unbreakable heart/i })[0],
     );
     await waitForNoFlights();
-    expect(within(modal).queryAllByRole('listitem')).toHaveLength(0);
+    expect(within(getEquippedList()).queryAllByRole('listitem')).toHaveLength(0);
   });
 
   it('surfaces sequence conditions in the setup tray when selecting a pantheon', async () => {

--- a/src/components/CharmSynergyList.tsx
+++ b/src/components/CharmSynergyList.tsx
@@ -88,7 +88,7 @@ export const CharmSynergyList: FC<CharmSynergyListProps> = ({
         return (
           <div key={category} className="synergy-section">
             <h5 className="synergy-section__title">{label}</h5>
-            <ul className="synergy-list" role="list">
+            <ul className="synergy-list">
               {sortedItems.map(({ synergy, isActive }) => {
                 const statusClasses = ['synergy-list__item'];
                 if (isActive) {

--- a/src/components/CharmSynergyList.tsx
+++ b/src/components/CharmSynergyList.tsx
@@ -1,0 +1,147 @@
+import type { FC } from 'react';
+
+import type { Charm, CharmSynergy } from '../data';
+
+export type CharmSynergyStatus = {
+  synergy: CharmSynergy;
+  isActive: boolean;
+};
+
+type CharmSynergyListProps = {
+  readonly statuses: CharmSynergyStatus[];
+  readonly charmDetails: Map<string, Charm>;
+  readonly iconMap: Map<string, string>;
+};
+
+const CATEGORY_LABELS = new Map<string, string>([
+  ['movement', 'Movement'],
+  ['combat', 'Combat'],
+  ['healing-defense', 'Healing & Defense'],
+  ['minion', 'Minions'],
+]);
+
+const CATEGORY_ORDER = ['movement', 'combat', 'healing-defense', 'minion'] as const;
+
+const getCategoryLabel = (category: string) => {
+  const preset = CATEGORY_LABELS.get(category);
+  if (preset) {
+    return preset;
+  }
+  return category
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+export const CharmSynergyList: FC<CharmSynergyListProps> = ({
+  statuses,
+  charmDetails,
+  iconMap,
+}) => {
+  if (statuses.length === 0) {
+    return null;
+  }
+
+  const activeCount = statuses.reduce(
+    (total, status) => (status.isActive ? total + 1 : total),
+    0,
+  );
+
+  const grouped = new Map<string, CharmSynergyStatus[]>();
+  for (const status of statuses) {
+    const list = grouped.get(status.synergy.category) ?? [];
+    list.push(status);
+    grouped.set(status.synergy.category, list);
+  }
+
+  const orderedCategories = [
+    ...CATEGORY_ORDER.filter((category) => grouped.has(category)),
+    ...[...grouped.keys()].filter(
+      (category) => !CATEGORY_ORDER.includes(category as (typeof CATEGORY_ORDER)[number]),
+    ),
+  ];
+
+  return (
+    <div className="synergy-panel">
+      <div className="synergy-panel__header">
+        <h4 className="synergy-panel__title">Synergies</h4>
+        <span
+          className="synergy-panel__summary"
+          aria-label={`${activeCount} active synergies`}
+        >
+          {activeCount}/{statuses.length}
+        </span>
+      </div>
+      {orderedCategories.map((category) => {
+        const items = grouped.get(category);
+        if (!items || items.length === 0) {
+          return null;
+        }
+        const sortedItems = [...items].sort((a, b) => {
+          if (a.isActive !== b.isActive) {
+            return a.isActive ? -1 : 1;
+          }
+          return a.synergy.name.localeCompare(b.synergy.name);
+        });
+        const label = getCategoryLabel(category);
+        return (
+          <div key={category} className="synergy-section">
+            <h5 className="synergy-section__title">{label}</h5>
+            <ul className="synergy-list" role="list">
+              {sortedItems.map(({ synergy, isActive }) => {
+                const statusClasses = ['synergy-list__item'];
+                if (isActive) {
+                  statusClasses.push('synergy-list__item--active');
+                }
+                return (
+                  <li key={synergy.id} className={statusClasses.join(' ')}>
+                    <div className="synergy-list__icons" aria-hidden="true">
+                      {synergy.charmIds.map((charmId) => {
+                        const icon = iconMap.get(charmId);
+                        const charm = charmDetails.get(charmId);
+                        if (!icon || !charm) {
+                          return null;
+                        }
+                        const iconClasses = ['synergy-list__icon'];
+                        if (!isActive) {
+                          iconClasses.push('synergy-list__icon--inactive');
+                        }
+                        return (
+                          <img
+                            key={charmId}
+                            src={icon}
+                            alt=""
+                            className={iconClasses.join(' ')}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="synergy-list__body">
+                      <p className="synergy-list__name">{synergy.name}</p>
+                      <p className="synergy-list__description">{synergy.description}</p>
+                    </div>
+                    <div
+                      className="synergy-list__status"
+                      title={isActive ? 'Synergy active' : 'Synergy inactive'}
+                    >
+                      <span
+                        className={`synergy-list__status-dot${
+                          isActive ? ' synergy-list__status-dot--active' : ''
+                        }`}
+                        aria-hidden="true"
+                      />
+                      <span className="visually-hidden">
+                        {isActive ? 'Synergy active' : 'Synergy inactive'}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/data/damage.json
+++ b/src/data/damage.json
@@ -736,6 +736,204 @@
       ]
     }
   ],
+  "charmSynergies": [
+    {
+      "id": "dashmaster-sprintmaster",
+      "name": "Fleetfooted Dash",
+      "category": "movement",
+      "charmIds": ["dashmaster", "sprintmaster"],
+      "description": "Your overall running speed is increased.",
+      "effects": [
+        {
+          "type": "movement_speed_bonus",
+          "effect": "Running speed is increased while both charms are equipped.",
+          "value": null,
+          "notes": "Stacks with Sprintmaster's inherent movement boost."
+        }
+      ]
+    },
+    {
+      "id": "sprintmaster-weaversong",
+      "name": "Weaver Sprint",
+      "category": "movement",
+      "charmIds": ["sprintmaster", "weaversong"],
+      "description": "Your little weaverling companions will move 50% faster.",
+      "effects": [
+        {
+          "type": "minion_speed_multiplier",
+          "effect": "Weaverlings scurry 50% faster.",
+          "value": 1.5,
+          "notes": "Improves both travel speed and attack reach for weaverlings."
+        }
+      ]
+    },
+    {
+      "id": "shape-of-unn-sprintmaster",
+      "name": "Quickened Shedding",
+      "category": "movement",
+      "charmIds": ["shape-of-unn", "sprintmaster"],
+      "description": "You'll move twice as fast when using the Shape of Unn to heal.",
+      "effects": [
+        {
+          "type": "shape_of_unn_focus_speed_multiplier",
+          "effect": "Shape of Unn crawl speed while focusing is doubled.",
+          "value": 2,
+          "notes": "Makes repositioning while healing significantly quicker."
+        }
+      ]
+    },
+    {
+      "id": "dashmaster-sharp-shadow",
+      "name": "Shadow Sprint",
+      "category": "combat",
+      "charmIds": ["dashmaster", "sharp-shadow"],
+      "description": "The damage dealt by your shadow dash is increased to 1.5 times your nail damage.",
+      "effects": [
+        {
+          "type": "shadow_dash_damage_nail_multiplier",
+          "effect": "Shadow dash contact damage scales to 1.5× nail damage.",
+          "value": 1.5,
+          "notes": "Also affects Fury of the Fallen variants."
+        }
+      ]
+    },
+    {
+      "id": "grubberflys-elegy-fury-of-the-fallen",
+      "name": "Last Mask Silence",
+      "category": "combat",
+      "charmIds": ["grubberflys-elegy", "fury-of-the-fallen"],
+      "description": "When you're down to your last mask, the ranged attack from Grubberfly's Elegy is disabled, but you'll still get the damage boost from Fury of the Fallen.",
+      "effects": [
+        {
+          "type": "projectile_disable_low_hp",
+          "effect": "Elegy beams stop firing at 1 HP while Fury is active.",
+          "value": null,
+          "notes": "Use the boosted nail damage from Fury instead."
+        }
+      ]
+    },
+    {
+      "id": "flukenest-defenders-crest",
+      "name": "Dungcharged Fluke",
+      "category": "combat",
+      "charmIds": ["flukenest", "defenders-crest"],
+      "description": "Instead of a swarm of flukes, you'll fire a single, large, volatile fluke that explodes into a damaging cloud of dung.",
+      "effects": [
+        {
+          "type": "spell_replacement",
+          "effect": "Vengeful Spirit becomes a volatile fluke that bursts into a dung cloud.",
+          "value": {
+            "vengefulSpirit": {
+              "projectiles": 1,
+              "damagePerProjectile": 22,
+              "totalDamage": 22
+            },
+            "shadeSoul": {
+              "projectiles": 1,
+              "damagePerProjectile": 22,
+              "totalDamage": 22
+            }
+          },
+          "notes": "The lingering cloud deals about 22 damage, rising to roughly 29 with Shaman Stone."
+        }
+      ]
+    },
+    {
+      "id": "spore-shroom-defenders-crest",
+      "name": "Toxic Bloom",
+      "category": "combat",
+      "charmIds": ["spore-shroom", "defenders-crest"],
+      "description": "The damaging spore cloud you emit when healing will last longer (around 4.1 seconds) and deal more damage (about 40).",
+      "effects": [
+        {
+          "type": "focus_damage_cloud",
+          "effect": "Spore cloud duration holds at ~4.1s and total damage rises to about 40.",
+          "value": {
+            "totalDamage": 40,
+            "durationSeconds": 4.1
+          },
+          "notes": "Damage scales with time spent inside the cloud."
+        }
+      ]
+    },
+    {
+      "id": "glowing-womb-defenders-crest",
+      "name": "Volatile Hatchlings",
+      "category": "minion",
+      "charmIds": ["glowing-womb", "defenders-crest"],
+      "description": "Your hatchlings will now be volatile, exploding on contact with enemies and creating a small damaging cloud.",
+      "effects": [
+        {
+          "type": "minion_explosion",
+          "effect": "Hatchlings explode into a small Defender's Crest cloud on impact.",
+          "value": null,
+          "notes": "Adds lingering area damage to each hatchling detonation."
+        }
+      ]
+    },
+    {
+      "id": "grubsong-grubberflys-elegy",
+      "name": "Grub Resonance",
+      "category": "combat",
+      "charmIds": ["grubsong", "grubberflys-elegy"],
+      "description": "When you take damage, you'll gain 25 SOUL instead of the usual 15.",
+      "effects": [
+        {
+          "type": "soul_gain_on_damage_taken",
+          "effect": "Taking damage grants 25 SOUL.",
+          "value": 25,
+          "notes": "Stacks with other SOUL regen sources."
+        }
+      ]
+    },
+    {
+      "id": "weaversong-grubsong",
+      "name": "Weaver Chorus",
+      "category": "minion",
+      "charmIds": ["weaversong", "grubsong"],
+      "description": "Your weaverlings will now generate SOUL for you when they hit enemies.",
+      "effects": [
+        {
+          "type": "minion_soul_generation",
+          "effect": "Weaverlings generate SOUL on hit.",
+          "value": null,
+          "notes": "Pairs well with Grubsong's damage-triggered SOUL refunds."
+        }
+      ]
+    },
+    {
+      "id": "jonis-blessing-hiveblood",
+      "name": "Lifeblood Reclamation",
+      "category": "healing-defense",
+      "charmIds": ["jonis-blessing", "hiveblood"],
+      "description": "You can now regenerate your Lifeblood masks, though it takes twice as long (20 seconds).",
+      "effects": [
+        {
+          "type": "lifeblood_regeneration",
+          "effect": "Regenerates Lifeblood masks over 20 seconds.",
+          "value": {
+            "cooldownSeconds": 20
+          },
+          "notes": "Regeneration pauses if additional damage is taken."
+        }
+      ]
+    },
+    {
+      "id": "spore-shroom-deep-focus",
+      "name": "Deep Bloom",
+      "category": "healing-defense",
+      "charmIds": ["spore-shroom", "deep-focus"],
+      "description": "The radius of your damaging spore cloud is increased by 35%.",
+      "effects": [
+        {
+          "type": "focus_damage_cloud_radius_multiplier",
+          "effect": "Spore cloud radius increases by 35%.",
+          "value": 1.35,
+          "notes": "Helps the spores tag enemies from a safer distance."
+        }
+      ]
+    }
+  ],
   "nailUpgrades": [
     {
       "id": "old-nail",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -10,6 +10,7 @@ import type {
   BossTarget,
   BossVersion,
   Charm,
+  CharmSynergy,
   NailUpgrade,
   Spell,
   SpellVariant,
@@ -24,6 +25,7 @@ export type {
   BossTarget,
   BossVersion,
   Charm,
+  CharmSynergy,
   NailUpgrade,
   Spell,
   SpellVariant,
@@ -64,6 +66,16 @@ const toNumberEntries = (value: unknown) =>
 
 export const charms = rawDamage.charms as Charm[];
 export const charmMap = new Map(charms.map((charm) => [charm.id, charm]));
+const rawCharmSynergies = (rawDamage.charmSynergies ?? []) as CharmSynergy[];
+export const charmSynergies = rawCharmSynergies;
+export const charmSynergyMap = new Map(
+  charmSynergies.map((synergy) => [synergy.id, synergy]),
+);
+export const getCharmSynergyKey = (charmIds: readonly string[]) =>
+  [...charmIds].slice().sort().join('|');
+export const charmSynergyKeyMap = new Map(
+  charmSynergies.map((synergy) => [getCharmSynergyKey(synergy.charmIds), synergy]),
+);
 export const nailUpgrades = rawDamage.nailUpgrades as NailUpgrade[];
 type RawSpellVariant = Omit<SpellVariant, 'key'>;
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -66,7 +66,9 @@ const toNumberEntries = (value: unknown) =>
 
 export const charms = rawDamage.charms as Charm[];
 export const charmMap = new Map(charms.map((charm) => [charm.id, charm]));
-const rawCharmSynergies = (rawDamage.charmSynergies ?? []) as CharmSynergy[];
+const rawCharmSynergies = Array.isArray(rawDamage.charmSynergies)
+  ? (rawDamage.charmSynergies as CharmSynergy[])
+  : [];
 export const charmSynergies = rawCharmSynergies;
 export const charmSynergyMap = new Map(
   charmSynergies.map((synergy) => [synergy.id, synergy]),

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -14,6 +14,15 @@ export interface Charm {
   effects: CharmEffect[];
 }
 
+export interface CharmSynergy {
+  id: string;
+  name: string;
+  category: string;
+  charmIds: string[];
+  description: string;
+  effects: CharmEffect[];
+}
+
 export interface NailUpgradeCost {
   geo: number;
   pale_ore: number;

--- a/src/features/attack-log/useAttackDefinitions.test.ts
+++ b/src/features/attack-log/useAttackDefinitions.test.ts
@@ -81,6 +81,69 @@ describe('useAttackDefinitions helpers', () => {
     expect(vengefulSpirit?.description).toMatch(/flukenest volley/i);
   });
 
+  it("applies Defender's Crest fluke synergy when both charms are equipped", () => {
+    const state = createFightState({
+      build: {
+        nailUpgradeId: 'old-nail',
+        activeCharmIds: ['flukenest', 'defenders-crest'],
+        spellLevels: DEFAULT_SPELL_LEVELS,
+      },
+    });
+
+    const groups = buildAttackGroups(state.build);
+    const spellsGroup = groups.find((group) => group.id === 'spellcasting');
+    const vengefulSpirit = spellsGroup?.attacks.find(
+      (attack) => attack.id === 'vengeful-spirit-vengefulSpirit',
+    );
+
+    expect(vengefulSpirit).toBeDefined();
+    expect(vengefulSpirit?.damage).toBe(22);
+    expect(vengefulSpirit?.description).toMatch(/volatile fluke/i);
+  });
+
+  it('boosts Sharp Shadow dash damage when Dashmaster is equipped', () => {
+    const state = createFightState({
+      build: {
+        nailUpgradeId: 'old-nail',
+        activeCharmIds: ['sharp-shadow', 'dashmaster'],
+        spellLevels: DEFAULT_SPELL_LEVELS,
+      },
+    });
+
+    const groups = buildAttackGroups(state.build);
+    const charmGroup = groups.find((group) => group.id === 'charm-effects');
+    const sharpShadow = charmGroup?.attacks.find(
+      (attack) => attack.id === 'sharp-shadow',
+    );
+
+    expect(sharpShadow).toBeDefined();
+
+    const oldNailDamage =
+      nailUpgrades.find((upgrade) => upgrade.id === 'old-nail')?.damage ?? 0;
+
+    expect(sharpShadow?.damage).toBe(Math.round(oldNailDamage * 1.5));
+    expect(sharpShadow?.description).toMatch(/dashmaster/i);
+  });
+
+  it("strengthens Spore Shroom's cloud when paired with Defender's Crest and Deep Focus", () => {
+    const state = createFightState({
+      build: {
+        nailUpgradeId: 'old-nail',
+        activeCharmIds: ['spore-shroom', 'defenders-crest', 'deep-focus'],
+        spellLevels: DEFAULT_SPELL_LEVELS,
+      },
+    });
+
+    const groups = buildAttackGroups(state.build);
+    const charmGroup = groups.find((group) => group.id === 'charm-effects');
+    const sporeCloud = charmGroup?.attacks.find((attack) => attack.id === 'spore-shroom');
+
+    expect(sporeCloud).toBeDefined();
+    expect(sporeCloud?.damage).toBe(40);
+    expect(sporeCloud?.description).toMatch(/lingering cloud/i);
+    expect(sporeCloud?.description).toMatch(/35%/);
+  });
+
   it('groups nail arts separately from standard nail attacks', () => {
     const state = createFightState();
 

--- a/src/features/build-config/PlayerConfigModal.test.tsx
+++ b/src/features/build-config/PlayerConfigModal.test.tsx
@@ -49,7 +49,7 @@ describe('PlayerConfigModal charms', () => {
       vi.runAllTimers();
     });
 
-    const equippedList = screen.getByRole('list');
+    const equippedList = screen.getByRole('list', { name: /equipped charms/i });
     const equippedItems = within(equippedList).getAllByRole('listitem');
 
     expect(equippedItems).toHaveLength(2);
@@ -82,7 +82,7 @@ describe('PlayerConfigModal charms', () => {
     expect(modal.querySelectorAll('.charm-flight')).toHaveLength(0);
     expect(modal.querySelectorAll('.equipped-panel__item--hidden')).toHaveLength(0);
 
-    const equippedList = within(modal).getByRole('list');
+    const equippedList = within(modal).getByRole('list', { name: /equipped charms/i });
     const equippedItems = within(equippedList).getAllByRole('listitem');
 
     expect(equippedItems).toHaveLength(1);
@@ -118,7 +118,7 @@ describe('PlayerConfigModal charms', () => {
       expect(modal.querySelectorAll('.charm-flight')).toHaveLength(0);
       expect(modal.querySelectorAll('.equipped-panel__item--hidden')).toHaveLength(0);
     });
-    const equippedList = within(modal).getByRole('list');
+    const equippedList = within(modal).getByRole('list', { name: /equipped charms/i });
     const equippedItems = within(equippedList).getAllByRole('listitem');
     expect(equippedItems).toHaveLength(1);
     expect(equippedItems[0]).toHaveTextContent(/unbreakable heart/i);
@@ -130,7 +130,7 @@ describe('PlayerConfigModal charms', () => {
       expect(modal.querySelectorAll('.equipped-panel__item--hidden')).toHaveLength(0);
     });
     await waitFor(() => {
-      expect(within(modal).queryAllByRole('listitem')).toHaveLength(0);
+      expect(within(equippedList).queryAllByRole('listitem')).toHaveLength(0);
     });
   });
 });

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -7,6 +7,7 @@ import { MAX_NOTCH_LIMIT, MIN_NOTCH_LIMIT } from '../fight-state/fightReducer';
 import { charmGridLayout, useBuildConfiguration } from './useBuildConfiguration';
 import { useHapticFeedback } from '../../utils/haptics';
 import { Modal } from '../../components/Modal';
+import { CharmSynergyList } from '../../components/CharmSynergyList';
 
 const CHARM_PRESETS = [
   {
@@ -183,6 +184,7 @@ const PlayerConfigModalContent: FC = () => {
     spells,
     setSpellLevel,
     charmDetails,
+    charmSynergyStatuses,
     isOvercharmed,
     build,
   } = useBuildConfiguration();
@@ -555,7 +557,12 @@ const PlayerConfigModalContent: FC = () => {
           <div className="charm-workbench__overview">
             <div className="equipped-panel">
               <h4 className="equipped-panel__title">Equipped</h4>
-              <div className="equipped-panel__grid" role="list" aria-live="polite">
+              <div
+                className="equipped-panel__grid"
+                role="list"
+                aria-live="polite"
+                aria-label="Equipped charms"
+              >
                 {equippedCharmEntries.length > 0 ? (
                   equippedCharmEntries.map(({ charm, state }) => {
                     const icon = charmIconMap.get(charm.id);
@@ -639,6 +646,11 @@ const PlayerConfigModalContent: FC = () => {
                 are overcharmed.
               </p>
             </div>
+            <CharmSynergyList
+              statuses={charmSynergyStatuses}
+              charmDetails={charmDetails}
+              iconMap={charmIconMap}
+            />
           </div>
           {isOvercharmed ? (
             <div className="overcharm-banner" role="status" aria-live="assertive">

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -13,6 +13,7 @@ import {
   bosses,
   bossSequences,
   charmMap,
+  charmSynergies,
   nailUpgrades,
   spells,
   supportedCharmIds,
@@ -346,6 +347,14 @@ export const useBuildConfiguration = () => {
     return details;
   }, []);
 
+  const charmSynergyStatuses = useMemo(() => {
+    const activeSet = new Set(activeCharmIds);
+    return charmSynergies.map((synergy) => ({
+      synergy,
+      isActive: synergy.charmIds.every((id) => activeSet.has(id)),
+    }));
+  }, [activeCharmIds]);
+
   return {
     actions,
     selectedBossId,
@@ -388,6 +397,7 @@ export const useBuildConfiguration = () => {
     nailUpgrades,
     spells,
     charmDetails,
+    charmSynergyStatuses,
     isOvercharmed,
   };
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2561,7 +2561,8 @@ h6 {
 
 .equipped-panel,
 .notch-panel,
-.preset-panel {
+.preset-panel,
+.synergy-panel {
   position: relative;
   clip-path: var(--shape-tablet);
   background-color: var(--color-surface);
@@ -2583,7 +2584,8 @@ h6 {
 
 .equipped-panel::before,
 .notch-panel::before,
-.preset-panel::before {
+.preset-panel::before,
+.synergy-panel::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -2597,7 +2599,8 @@ h6 {
 
 .equipped-panel > *,
 .notch-panel > *,
-.preset-panel > * {
+.preset-panel > *,
+.synergy-panel > * {
   position: relative;
   z-index: 1;
 }
@@ -2824,6 +2827,145 @@ h6 {
   margin: 0;
   font-size: var(--font-size-caption);
   color: var(--color-muted);
+}
+
+.synergy-panel {
+  min-height: 0;
+}
+
+.synergy-panel__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.synergy-panel__title {
+  margin: 0;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+
+.synergy-panel__summary {
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  color: var(--color-muted);
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgb(130 207 255 / 12%);
+}
+
+.synergy-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.synergy-section__title {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.synergy-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.synergy-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border-radius: 14px;
+  border: 1px solid var(--color-border-faint);
+  background-color: rgb(10 16 30 / 68%);
+  background-image:
+    linear-gradient(135deg, rgb(255 255 255 / 8%), transparent), var(--texture-vein);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 6%);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.synergy-list__item--active {
+  border-color: rgb(130 207 255 / 65%);
+  box-shadow:
+    0 16px 28px rgb(12 30 60 / 32%),
+    inset 0 0 0 1px rgb(130 207 255 / 45%);
+  transform: translateY(-1px);
+}
+
+.synergy-list__icons {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.synergy-list__icon {
+  width: 1.8rem;
+  height: 1.8rem;
+  object-fit: contain;
+  filter: drop-shadow(0 6px 10px rgb(0 0 0 / 45%));
+}
+
+.synergy-list__icon--inactive {
+  opacity: 0.55;
+  filter: grayscale(60%) drop-shadow(0 2px 6px rgb(0 0 0 / 35%));
+}
+
+.synergy-list__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.synergy-list__name {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgb(214 225 255 / 75%);
+}
+
+.synergy-list__description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgb(210 220 240 / 78%);
+  line-height: 1.25;
+}
+
+.synergy-list__status {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.synergy-list__status-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgb(120 132 158 / 60%);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 15%);
+}
+
+.synergy-list__status-dot--active {
+  background: rgb(130 207 255);
+  box-shadow:
+    0 0 10px rgb(130 207 255 / 55%),
+    inset 0 0 0 1px rgb(255 255 255 / 40%);
 }
 
 .overcharm-banner {


### PR DESCRIPTION
## Summary
- add charm synergy dataset plus parsing helpers and damage interactions
- surface a synergy overview panel in the loadout modal with responsive styling
- exercise the new synergy rules with targeted unit tests and refresh the README

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e49afbe3a8832f8138a72039b3b850