### PR TITLE
feat: add loadout synergy visibility toggle

### DIFF
--- a/src/components/CharmSynergyList.test.tsx
+++ b/src/components/CharmSynergyList.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Charm, CharmSynergy } from '../data';
+import { CharmSynergyList, type CharmSynergyStatus } from './CharmSynergyList';
+
+const createCharm = (overrides: Partial<Charm>): Charm => ({
+  id: 'charm-id',
+  name: 'Example Charm',
+  cost: 1,
+  description: 'Example description',
+  origin: 'Test',
+  effects: [],
+  ...overrides,
+});
+
+const createSynergy = (overrides: Partial<CharmSynergy>): CharmSynergy => ({
+  id: 'synergy-id',
+  name: 'Example Synergy',
+  category: 'movement',
+  charmIds: ['charm-a'],
+  description: 'Example synergy description',
+  effects: [],
+  ...overrides,
+});
+
+const charmDetails = new Map<string, Charm>([
+  [
+    'charm-a',
+    createCharm({
+      id: 'charm-a',
+      name: 'Dashmaster',
+    }),
+  ],
+  [
+    'charm-b',
+    createCharm({
+      id: 'charm-b',
+      name: 'Sharp Shadow',
+    }),
+  ],
+]);
+
+const iconMap = new Map<string, string>([
+  ['charm-a', '/icons/dashmaster.png'],
+  ['charm-b', '/icons/sharp-shadow.png'],
+]);
+
+const statuses: CharmSynergyStatus[] = [
+  {
+    synergy: createSynergy({
+      id: 'movement-synergy',
+      name: 'Fleet Footed',
+      category: 'movement',
+      charmIds: ['charm-a'],
+      description: 'Dashmaster boosts movement speed.',
+    }),
+    isActive: true,
+  },
+  {
+    synergy: createSynergy({
+      id: 'combat-synergy',
+      name: 'Shadow Clash',
+      category: 'combat',
+      charmIds: ['charm-a', 'charm-b'],
+      description: 'Dashmaster and Sharp Shadow combine for extra damage.',
+    }),
+    isActive: false,
+  },
+];
+
+describe('CharmSynergyList', () => {
+  it('hides inactive synergies and category headings by default', () => {
+    render(
+      <CharmSynergyList
+        statuses={statuses}
+        charmDetails={charmDetails}
+        iconMap={iconMap}
+      />,
+    );
+
+    expect(screen.getByText('Fleet Footed')).toBeInTheDocument();
+    expect(screen.queryByText('Shadow Clash')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Movement' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Combat' })).not.toBeInTheDocument();
+    expect(screen.getByText('1/2')).toBeInTheDocument();
+
+    const toggleButton = screen.getByRole('button', { name: 'Show all synergies' });
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('reveals inactive synergies and headings when toggled', () => {
+    render(
+      <CharmSynergyList
+        statuses={statuses}
+        charmDetails={charmDetails}
+        iconMap={iconMap}
+      />,
+    );
+
+    const toggleButton = screen.getByRole('button', { name: 'Show all synergies' });
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+    expect(toggleButton).toHaveTextContent('Show active synergies');
+    expect(screen.getByText('Shadow Clash')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Movement' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Combat' })).toBeInTheDocument();
+  });
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2840,6 +2840,12 @@ h6 {
   gap: 0.5rem;
 }
 
+.synergy-panel__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .synergy-panel__title {
   margin: 0;
   font-size: var(--font-size-subhead);
@@ -2854,6 +2860,38 @@ h6 {
   padding: 0.1rem 0.5rem;
   border-radius: 999px;
   background: rgb(130 207 255 / 12%);
+}
+
+.synergy-panel__toggle {
+  font-size: var(--font-size-caption);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+  padding: 0.1rem 0.75rem;
+  border: 1px solid rgb(130 207 255 / 28%);
+  border-radius: 999px;
+  background: rgb(130 207 255 / 8%);
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease;
+}
+
+.synergy-panel__toggle:hover {
+  color: var(--color-foreground);
+  border-color: rgb(130 207 255 / 45%);
+}
+
+.synergy-panel__toggle[aria-pressed='true'] {
+  color: var(--color-foreground);
+  background: rgb(130 207 255 / 16%);
+  border-color: rgb(130 207 255 / 45%);
+}
+
+.synergy-panel__toggle:focus-visible {
+  outline: 2px solid rgb(130 207 255 / 65%);
+  outline-offset: 2px;
 }
 
 .synergy-section {


### PR DESCRIPTION
## Summary
- add a toggle on the loadout synergy panel so inactive synergies are hidden by default
- adjust synergy header styling to host the new control without changing the list layout
- cover the new behaviour with unit tests for CharmSynergyList

## Testing
- pnpm lint
- pnpm test:unit -- src/components/CharmSynergyList.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4ba839fd0832fa7fe2085594cae53