### PR TITLE
fix: separate fight state instrumentation from provider

### DIFF
--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -12,11 +12,11 @@ import {
   useFightStateSelector,
 } from './FightStateContext';
 import type { FightState } from './FightStateContext';
-import * as FightStateContextModule from './FightStateContext';
 import { STORAGE_KEY } from './persistence';
 import * as persistenceModule from './persistence';
 import { bossSequenceMap } from '../../data';
 import { PERSIST_FLUSH_EVENT } from '../../utils/persistenceEvents';
+import { __TESTING__ as fightStateInstrumentation } from './fightStateInstrumentation';
 
 describe('FightStateProvider persistence', () => {
   beforeEach(() => {
@@ -604,7 +604,7 @@ describe('derived stats caching', () => {
       return null;
     };
 
-    const instrumentation = FightStateContextModule.__TESTING__;
+    const instrumentation = fightStateInstrumentation;
 
     try {
       window.localStorage.clear();

--- a/src/features/fight-state/fightStateInstrumentation.ts
+++ b/src/features/fight-state/fightStateInstrumentation.ts
@@ -1,0 +1,25 @@
+let aggregateComputationCount = 0;
+let aggregateMismatchCount = 0;
+
+export const incrementAggregateComputationCount = () => {
+  aggregateComputationCount += 1;
+};
+
+export const incrementAggregateMismatchCount = () => {
+  aggregateMismatchCount += 1;
+};
+
+export const resetAggregateComputationCount = () => {
+  aggregateComputationCount = 0;
+  aggregateMismatchCount = 0;
+};
+
+export const getAggregateComputationCount = () => aggregateComputationCount;
+
+export const getAggregateMismatchCount = () => aggregateMismatchCount;
+
+export const __TESTING__ = {
+  getAggregateComputationCount,
+  getAggregateMismatchCount,
+  resetAggregateComputationCount,
+};


### PR DESCRIPTION
## Summary
- extract the fight state instrumentation counters into a dedicated module and reuse them inside `FightStateContext`
- update the fight state tests to consume the shared instrumentation helpers, letting us drop the lint suppression

## Testing
- pnpm lint
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e5bcfb0e40832f816a8be1918da1c5