### PR TITLE
refactor: extract fight state store and idle helper

### DIFF
--- a/src/features/fight-state/FightStateContext.test.tsx
+++ b/src/features/fight-state/FightStateContext.test.tsx
@@ -159,6 +159,41 @@ describe('FightStateProvider persistence', () => {
     persistSpy.mockRestore();
     vi.useRealTimers();
   });
+
+  it('flushes pending persistence work when the provider unmounts', () => {
+    vi.useFakeTimers();
+
+    const persistSpy = vi.spyOn(persistenceModule, 'persistStateToStorage');
+
+    const Consumer = () => {
+      const { actions } = useFightState();
+
+      useEffect(() => {
+        actions.setCustomTargetHp(2468);
+      }, [actions]);
+
+      return null;
+    };
+
+    const { unmount } = render(
+      <FightStateProvider>
+        <Consumer />
+      </FightStateProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(persistSpy).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(persistSpy).toHaveBeenCalled();
+
+    persistSpy.mockRestore();
+    vi.useRealTimers();
+  });
 });
 
 describe('boss sequences', () => {

--- a/src/features/fight-state/store.ts
+++ b/src/features/fight-state/store.ts
@@ -1,0 +1,469 @@
+import {
+  DEFAULT_CUSTOM_HP,
+  bossMap,
+  bossPhaseMap,
+  strengthCharmIds,
+} from '../../data';
+import type {
+  AttackInput,
+  DamageLogAggregates,
+  FightAction,
+  FightState,
+  SpellLevel,
+} from './fightReducer';
+import {
+  createInitialState,
+  ensureSequenceState,
+  ensureSpellLevels,
+  fightReducer,
+  isCustomBoss,
+} from './fightReducer';
+import { persistStateToStorage, restorePersistedState } from './persistence';
+import { scheduleIdleTask } from '../../utils/scheduleIdleTask';
+import {
+  incrementAggregateComputationCount,
+  incrementAggregateMismatchCount,
+} from './fightStateInstrumentation';
+
+export type DerivedStats = {
+  targetHp: number;
+  totalDamage: number;
+  remainingHp: number;
+  attacksLogged: number;
+  averageDamage: number | null;
+  elapsedMs: number | null;
+  dps: number | null;
+  actionsPerMinute: number | null;
+  estimatedTimeRemainingMs: number | null;
+  fightStartTimestamp: number | null;
+  fightEndTimestamp: number | null;
+  isFightInProgress: boolean;
+  isFightComplete: boolean;
+  frameTimestamp: number;
+  phaseNumber: number | null;
+  phaseCount: number | null;
+  phaseLabel: string | null;
+  phaseThresholds: number[] | null;
+};
+
+export type FightActions = {
+  selectBoss: (bossId: string) => void;
+  setCustomTargetHp: (hp: number) => void;
+  setNailUpgrade: (nailUpgradeId: string) => void;
+  setActiveCharms: (charmIds: string[]) => void;
+  updateActiveCharms: (updater: (charmIds: string[]) => string[]) => void;
+  setCharmNotchLimit: (notchLimit: number) => void;
+  setSpellLevel: (spellId: string, level: SpellLevel) => void;
+  logAttack: (input: AttackInput) => void;
+  undoLastAttack: () => void;
+  redoLastAttack: () => void;
+  resetLog: () => void;
+  resetSequence: () => void;
+  startFight: (timestamp?: number) => void;
+  endFight: (timestamp?: number) => void;
+  startSequence: (sequenceId: string) => void;
+  stopSequence: () => void;
+  setSequenceStage: (index: number) => void;
+  advanceSequenceStage: () => void;
+  rewindSequenceStage: () => void;
+  setSequenceCondition: (
+    sequenceId: string,
+    conditionId: string,
+    enabled: boolean,
+  ) => void;
+};
+
+type Listener = () => void;
+
+export interface ExternalStore<T> {
+  subscribe: (listener: Listener) => () => void;
+  getSnapshot: () => T;
+}
+
+export interface FightStateStoreApi {
+  stateStore: ExternalStore<FightState>;
+  derivedStore: ExternalStore<DerivedStats>;
+  actions: FightActions;
+  dispatch: (action: FightAction) => void;
+  refreshDerivedStats: (timestamp?: number) => void;
+  flushPersist: () => void;
+  getStateSnapshot: () => FightState;
+}
+
+type DamageLogAggregateCache = {
+  version: number;
+  aggregates: DamageLogAggregates;
+};
+
+const cloneDamageLogAggregates = (
+  aggregates: DamageLogAggregates,
+): DamageLogAggregates => ({
+  totalDamage: aggregates.totalDamage,
+  attacksLogged: aggregates.attacksLogged,
+  firstAttackTimestamp: aggregates.firstAttackTimestamp,
+  lastAttackTimestamp: aggregates.lastAttackTimestamp,
+});
+
+const calculateDerivedStats = (
+  state: FightState,
+  frameTimestamp: number,
+  aggregates: DamageLogAggregates,
+): DerivedStats => {
+  const {
+    selectedBossId,
+    customTargetHp,
+    fightEndTimestamp,
+    fightStartTimestamp: storedFightStartTimestamp,
+  } = state;
+  const damageLog = state.damageLog;
+  const baseTargetHp = isCustomBoss(selectedBossId)
+    ? Math.max(1, Math.round(customTargetHp))
+    : (bossMap.get(selectedBossId)?.hp ?? DEFAULT_CUSTOM_HP);
+  const phaseDefinition = selectedBossId ? bossPhaseMap.get(selectedBossId) : undefined;
+  const phaseTotalHp = phaseDefinition?.phases.length
+    ? phaseDefinition.phases.reduce((sum, phase) => sum + phase.hp, 0)
+    : null;
+  const targetHp = phaseTotalHp && phaseTotalHp > 0 ? phaseTotalHp : baseTargetHp;
+  const { totalDamage, attacksLogged, firstAttackTimestamp } = aggregates;
+  const clampedDamage = Math.max(0, totalDamage);
+
+  let effectiveDamage = Math.min(clampedDamage, targetHp);
+  if (phaseDefinition) {
+    if (phaseDefinition.discardOverkill) {
+      let consumed = 0;
+      let phaseIndex = 0;
+      let phaseRemaining = phaseDefinition.phases.length
+        ? phaseDefinition.phases[phaseIndex].hp
+        : 0;
+
+      for (const event of damageLog) {
+        let damageRemaining = Math.max(0, event.damage);
+        while (damageRemaining > 0 && phaseIndex < phaseDefinition.phases.length) {
+          if (phaseRemaining <= 0) {
+            phaseIndex += 1;
+            if (phaseIndex >= phaseDefinition.phases.length) {
+              break;
+            }
+            phaseRemaining = phaseDefinition.phases[phaseIndex].hp;
+            continue;
+          }
+
+          const applied = Math.min(damageRemaining, phaseRemaining);
+          consumed += applied;
+          phaseRemaining -= applied;
+          damageRemaining -= applied;
+
+          if (phaseRemaining <= 0) {
+            damageRemaining = 0;
+          }
+        }
+
+        if (phaseIndex >= phaseDefinition.phases.length) {
+          break;
+        }
+      }
+
+      effectiveDamage = Math.min(consumed, targetHp);
+    } else {
+      effectiveDamage = Math.min(clampedDamage, targetHp);
+    }
+  }
+
+  const remainingHp = Math.max(0, targetHp - effectiveDamage);
+  const averageDamage = attacksLogged === 0 ? null : totalDamage / attacksLogged;
+
+  let phaseNumber: number | null = null;
+  let phaseCount: number | null = null;
+  let phaseLabel: string | null = null;
+  let phaseThresholds: number[] | null = null;
+
+  if (phaseDefinition && phaseDefinition.phases.length > 0) {
+    phaseCount = phaseDefinition.phases.length;
+    phaseThresholds = [];
+    let accumulated = 0;
+    for (let index = 0; index < phaseDefinition.phases.length; index += 1) {
+      const phase = phaseDefinition.phases[index];
+      accumulated += phase.hp;
+      if (index < phaseDefinition.phases.length - 1) {
+        phaseThresholds.push(Math.max(0, targetHp - accumulated));
+      }
+      if (phaseNumber === null && effectiveDamage < accumulated) {
+        phaseNumber = index + 1;
+        phaseLabel = phase.name;
+      }
+    }
+
+    if (phaseNumber === null) {
+      const lastPhase = phaseDefinition.phases[phaseDefinition.phases.length - 1];
+      phaseNumber = phaseCount;
+      phaseLabel = lastPhase.name;
+    }
+  }
+
+  let fightStartTimestamp = storedFightStartTimestamp;
+  if (fightStartTimestamp === null) {
+    fightStartTimestamp = firstAttackTimestamp;
+  }
+
+  const hasFightStartTimestamp = typeof fightStartTimestamp === 'number';
+
+  let effectiveEndTimestamp = fightEndTimestamp;
+  if (effectiveEndTimestamp === null && hasFightStartTimestamp) {
+    effectiveEndTimestamp = frameTimestamp;
+  }
+
+  const elapsedMs =
+    hasFightStartTimestamp && effectiveEndTimestamp !== null
+      ? Math.max(0, effectiveEndTimestamp - fightStartTimestamp)
+      : null;
+
+  let dps: number | null = null;
+  let actionsPerMinute: number | null = null;
+  if (elapsedMs !== null && elapsedMs > 0) {
+    dps = totalDamage / (elapsedMs / 1000);
+    actionsPerMinute = attacksLogged / (elapsedMs / 60000);
+  }
+
+  let estimatedTimeRemainingMs: number | null;
+  if (remainingHp === 0) {
+    estimatedTimeRemainingMs = 0;
+  } else if (dps !== null && dps > 0) {
+    estimatedTimeRemainingMs = Math.round((remainingHp / dps) * 1000);
+  } else {
+    estimatedTimeRemainingMs = null;
+  }
+
+  const fightHasEnded = fightEndTimestamp !== null;
+  const isFightInProgress = hasFightStartTimestamp && !fightHasEnded;
+  const isFightComplete = hasFightStartTimestamp && fightHasEnded;
+
+  return {
+    targetHp,
+    totalDamage,
+    remainingHp,
+    attacksLogged,
+    averageDamage,
+    elapsedMs,
+    dps,
+    actionsPerMinute,
+    estimatedTimeRemainingMs,
+    fightStartTimestamp,
+    fightEndTimestamp,
+    isFightInProgress,
+    isFightComplete,
+    frameTimestamp,
+    phaseNumber,
+    phaseCount,
+    phaseLabel,
+    phaseThresholds,
+  };
+};
+
+const createInitialFightState = (): FightState =>
+  restorePersistedState(ensureSequenceState(ensureSpellLevels(createInitialState())));
+
+const createExternalStore = <T,>(getSnapshot: () => T, listeners: Set<Listener>) => ({
+  getSnapshot,
+  subscribe: (listener: Listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+});
+
+export const createFightStateStore = (
+  initialState: FightState = createInitialFightState(),
+): FightStateStoreApi => {
+  let state = initialState;
+  let frameTimestamp = Date.now();
+  incrementAggregateComputationCount();
+  let aggregateCache: DamageLogAggregateCache = {
+    version: state.damageLogVersion,
+    aggregates: cloneDamageLogAggregates(state.damageLogAggregates),
+  };
+  let derived = calculateDerivedStats(state, frameTimestamp, aggregateCache.aggregates);
+
+  const stateListeners = new Set<Listener>();
+  const derivedListeners = new Set<Listener>();
+
+  const ensureAggregateCache = (): DamageLogAggregates => {
+    const { damageLogVersion, damageLogAggregates } = state;
+    if (aggregateCache.version !== damageLogVersion) {
+      incrementAggregateMismatchCount();
+      incrementAggregateComputationCount();
+      const aggregates = cloneDamageLogAggregates(damageLogAggregates);
+      aggregateCache = {
+        version: damageLogVersion,
+        aggregates,
+      };
+      return aggregates;
+    }
+
+    return aggregateCache.aggregates;
+  };
+
+  const notifyState = () => {
+    stateListeners.forEach((listener) => listener());
+  };
+
+  const notifyDerived = (timestamp?: number) => {
+    frameTimestamp = typeof timestamp === 'number' ? timestamp : Date.now();
+    const aggregates = ensureAggregateCache();
+    derived = calculateDerivedStats(state, frameTimestamp, aggregates);
+    derivedListeners.forEach((listener) => listener());
+  };
+
+  let persistDebounceTimeoutId: number | null = null;
+  let cancelPersist: (() => void) | null = null;
+  let persistDirty = false;
+  let lastPersistTimestamp = 0;
+  const PERSIST_DEBOUNCE_MS = 900;
+  const PERSIST_IDLE_TIMEOUT_MS = 1500;
+
+  const persistNow = () => {
+    persistStateToStorage(state);
+    lastPersistTimestamp = Date.now();
+    persistDirty = false;
+  };
+
+  const flushPersist = () => {
+    if (typeof window !== 'undefined' && persistDebounceTimeoutId !== null) {
+      window.clearTimeout(persistDebounceTimeoutId);
+      persistDebounceTimeoutId = null;
+    }
+
+    cancelPersist?.();
+    cancelPersist = null;
+
+    if (!persistDirty) {
+      return;
+    }
+
+    persistNow();
+  };
+
+  const schedulePersist = () => {
+    persistDirty = true;
+
+    if (typeof window === 'undefined') {
+      persistNow();
+      return;
+    }
+
+    const scheduleIdle = () => {
+      cancelPersist?.();
+      cancelPersist = scheduleIdleTask(() => {
+        cancelPersist = null;
+
+        if (!persistDirty) {
+          return;
+        }
+
+        const now = Date.now();
+        const hasPersistedBefore = lastPersistTimestamp > 0;
+        const elapsed = hasPersistedBefore
+          ? now - lastPersistTimestamp
+          : Number.POSITIVE_INFINITY;
+        if (hasPersistedBefore && elapsed < PERSIST_DEBOUNCE_MS) {
+          if (persistDebounceTimeoutId === null) {
+            const delay = Math.max(0, PERSIST_DEBOUNCE_MS - elapsed);
+            persistDebounceTimeoutId = window.setTimeout(() => {
+              persistDebounceTimeoutId = null;
+              schedulePersist();
+            }, delay);
+          }
+          return;
+        }
+
+        persistNow();
+      }, { timeout: PERSIST_IDLE_TIMEOUT_MS });
+    };
+
+    if (cancelPersist || persistDebounceTimeoutId !== null) {
+      return;
+    }
+
+    const now = Date.now();
+    const hasPersistedBefore = lastPersistTimestamp > 0;
+    const elapsed = hasPersistedBefore ? now - lastPersistTimestamp : Number.POSITIVE_INFINITY;
+    if (!hasPersistedBefore || elapsed >= PERSIST_DEBOUNCE_MS) {
+      scheduleIdle();
+    } else {
+      const delay = Math.max(0, PERSIST_DEBOUNCE_MS - elapsed);
+      persistDebounceTimeoutId = window.setTimeout(() => {
+        persistDebounceTimeoutId = null;
+        scheduleIdle();
+      }, delay);
+    }
+  };
+
+  const dispatch = (action: FightAction) => {
+    const nextState = fightReducer(state, action);
+    if (nextState === state) {
+      return;
+    }
+
+    state = nextState;
+    notifyState();
+    schedulePersist();
+    notifyDerived();
+  };
+
+  const actions: FightActions = {
+    selectBoss: (bossId) => dispatch({ type: 'selectBoss', bossId }),
+    setCustomTargetHp: (hp) => dispatch({ type: 'setCustomTargetHp', hp }),
+    setNailUpgrade: (nailUpgradeId) => dispatch({ type: 'setNailUpgrade', nailUpgradeId }),
+    setActiveCharms: (charmIds) => dispatch({ type: 'setActiveCharms', charmIds }),
+    updateActiveCharms: (updater) => dispatch({ type: 'updateActiveCharms', updater }),
+    setCharmNotchLimit: (notchLimit) => dispatch({ type: 'setCharmNotchLimit', notchLimit }),
+    setSpellLevel: (spellId, level) =>
+      dispatch({ type: 'setSpellLevel', spellId, level }),
+    logAttack: ({ id, label, damage, category, soulCost, timestamp }) =>
+      dispatch({
+        type: 'logAttack',
+        id,
+        label,
+        damage,
+        category,
+        soulCost,
+        timestamp: timestamp ?? Date.now(),
+      }),
+    undoLastAttack: () => dispatch({ type: 'undoLastAttack' }),
+    redoLastAttack: () => dispatch({ type: 'redoLastAttack' }),
+    resetLog: () => dispatch({ type: 'resetLog' }),
+    resetSequence: () => dispatch({ type: 'resetSequence' }),
+    startFight: (timestamp) =>
+      dispatch({ type: 'startFight', timestamp: timestamp ?? Date.now() }),
+    endFight: (timestamp) =>
+      dispatch({ type: 'endFight', timestamp: timestamp ?? Date.now() }),
+    startSequence: (sequenceId) => dispatch({ type: 'startSequence', sequenceId }),
+    stopSequence: () => dispatch({ type: 'stopSequence' }),
+    setSequenceStage: (index) => dispatch({ type: 'setSequenceStage', index }),
+    advanceSequenceStage: () => dispatch({ type: 'advanceSequence' }),
+    rewindSequenceStage: () => dispatch({ type: 'rewindSequence' }),
+    setSequenceCondition: (sequenceId, conditionId, enabled) =>
+      dispatch({
+        type: 'setSequenceCondition',
+        sequenceId,
+        conditionId,
+        enabled,
+      }),
+  };
+
+  const stateStore = createExternalStore(() => state, stateListeners);
+  const derivedStore = createExternalStore(() => derived, derivedListeners);
+
+  return {
+    stateStore,
+    derivedStore,
+    actions,
+    dispatch,
+    refreshDerivedStats: notifyDerived,
+    flushPersist,
+    getStateSnapshot: () => state,
+  };
+};
+
+export const hasStrengthCharm = (charmIds: string[]) =>
+  charmIds.some((id) => strengthCharmIds.has(id));

--- a/src/utils/scheduleIdleTask.test.ts
+++ b/src/utils/scheduleIdleTask.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { scheduleIdleTask } from './scheduleIdleTask';
+
+describe('scheduleIdleTask', () => {
+  const globalAny = globalThis as typeof globalThis & { window?: Window & Record<string, unknown> };
+  let originalWindow: typeof window | undefined;
+
+  beforeEach(() => {
+    originalWindow = globalAny.window;
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete globalAny.window;
+    } else {
+      globalAny.window = originalWindow;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('invokes the callback immediately when no window is available', () => {
+    delete globalAny.window;
+    const spy = vi.fn();
+
+    const cancel = scheduleIdleTask(spy);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    cancel();
+  });
+
+  it('uses requestIdleCallback when available', () => {
+    const cancelIdleCallback = vi.fn();
+    const requestIdleCallback = vi.fn().mockImplementation((cb: () => void) => {
+      cb();
+      return 7;
+    });
+
+    globalAny.window = {
+      ...originalWindow,
+      requestIdleCallback,
+      cancelIdleCallback,
+    } as Window & typeof cancelIdleCallback;
+
+    const spy = vi.fn();
+
+    const cancel = scheduleIdleTask(spy, { timeout: 123 });
+
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 123 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    cancel();
+    expect(cancelIdleCallback).toHaveBeenCalledWith(7);
+  });
+
+  it('falls back to setTimeout when idle callbacks are unavailable', () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const spy = vi.fn();
+
+    const cancel = scheduleIdleTask(spy, { timeout: 50 });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(spy, 50);
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    cancel();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/src/utils/scheduleIdleTask.ts
+++ b/src/utils/scheduleIdleTask.ts
@@ -1,0 +1,37 @@
+export type IdleCallbackOptions = { timeout?: number };
+export type IdleDeadline = { didTimeout: boolean; timeRemaining: () => number };
+export type IdleCallback = (deadline: IdleDeadline) => void;
+
+interface IdleCallbackGlobal {
+  requestIdleCallback?: (callback: IdleCallback, options?: IdleCallbackOptions) => number;
+  cancelIdleCallback?: (handle: number) => void;
+}
+
+export const scheduleIdleTask = (
+  callback: () => void,
+  options?: IdleCallbackOptions,
+): (() => void) => {
+  if (typeof window === 'undefined') {
+    callback();
+    return () => {};
+  }
+
+  const idleWindow = window as Window & IdleCallbackGlobal;
+
+  if (typeof idleWindow.requestIdleCallback === 'function') {
+    const handle = idleWindow.requestIdleCallback(() => {
+      callback();
+    }, options);
+
+    return () => {
+      if (typeof idleWindow.cancelIdleCallback === 'function') {
+        idleWindow.cancelIdleCallback(handle);
+      }
+    };
+  }
+
+  const timeoutId = window.setTimeout(callback, options?.timeout ?? 200);
+  return () => {
+    window.clearTimeout(timeoutId);
+  };
+};


### PR DESCRIPTION
## Summary
- extract the idle task scheduler into a shared utility with dedicated unit coverage
- introduce a fight state store module that owns derived stat computation, caching, persistence, and actions
- refactor the fight state provider to consume the new store and extend persistence tests for unmount flushing

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c69bad2c832fa8af1b44af5bc27b