### PR TITLE
feat: update Pantheon of Hallownest boss data

### DIFF
--- a/src/data/bosses.json
+++ b/src/data/bosses.json
@@ -44,6 +44,10 @@
       {
         "title": "Radiant",
         "health": 1680
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1260
       }
     ]
   },
@@ -68,6 +72,10 @@
       {
         "title": "Radiant",
         "health": 1800
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1260
       }
     ]
   },
@@ -92,6 +100,10 @@
       {
         "title": "Radiant",
         "health": 1165
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 900
       }
     ]
   },
@@ -116,6 +128,10 @@
       {
         "title": "Radiant",
         "health": 1050
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 750
       }
     ]
   },
@@ -164,6 +180,10 @@
       {
         "title": "Radiant",
         "health": 1250
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 700
       }
     ]
   },
@@ -236,6 +256,10 @@
       {
         "title": "Radiant",
         "health": 1250
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1500
       }
     ]
   },
@@ -404,6 +428,10 @@
       {
         "title": "Radiant",
         "health": 1650
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1250
       }
     ]
   },
@@ -476,6 +504,10 @@
       {
         "title": "Radiant",
         "health": 1000
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 850
       }
     ]
   },
@@ -500,6 +532,10 @@
       {
         "title": "Radiant",
         "health": 578
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1500
       }
     ]
   },
@@ -668,6 +704,10 @@
       {
         "title": "Radiant",
         "health": 1800
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1250
       }
     ]
   },
@@ -692,6 +732,10 @@
       {
         "title": "Radiant",
         "health": 1500
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1200
       }
     ]
   },
@@ -740,6 +784,10 @@
       {
         "title": "Radiant",
         "health": 650
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 416
       }
     ]
   },
@@ -764,6 +812,10 @@
       {
         "title": "Radiant",
         "health": 650
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 416
       }
     ]
   },
@@ -860,6 +912,10 @@
       {
         "title": "Radiant",
         "health": 650
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 520
       }
     ]
   },
@@ -908,6 +964,10 @@
       {
         "title": "Radiant",
         "health": 2000
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 2100
       }
     ]
   },
@@ -1004,6 +1064,10 @@
       {
         "title": "Radiant",
         "health": 900
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 3450
       }
     ]
   },
@@ -1039,6 +1103,10 @@
       {
         "title": "Radiant",
         "health": 1750
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 1600
       }
     ]
   },
@@ -1074,6 +1142,10 @@
       {
         "title": "Radiant",
         "health": 2640
+      },
+      {
+        "title": "Pantheon of Hallownest",
+        "health": 2181
       }
     ]
   }

--- a/src/data/phases.ts
+++ b/src/data/phases.ts
@@ -328,4 +328,350 @@ export const bossPhaseData: BossPhaseDefinition[] = [
       phase('phase-5', 'Phase 5 – Final radiance', 840),
     ],
   },
+  {
+    targetId: 'false-knight__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase(
+        'armor-1',
+        'Armor Stage 1',
+        360,
+        'Break the armor shell to expose the maggot.',
+      ),
+      phase(
+        'maggot-1',
+        'Maggot Stage 1',
+        60,
+        'Punish the maggot before the armor reforms.',
+      ),
+      phase('armor-2', 'Armor Stage 2', 360, 'Repeat the duel against the armor.'),
+      phase('maggot-2', 'Maggot Stage 2', 40, 'Second stagger window on the maggot.'),
+      phase('armor-3', 'Armor Stage 3', 360, 'Final armor phase prior to the escape.'),
+      phase('maggot-3', 'Maggot Stage 3', 40, 'Chase the exposed maggot again.'),
+      phase(
+        'maggot-4',
+        'Maggot Stage 4',
+        40,
+        'Finish the fleeing maggot once the armor is shattered.',
+      ),
+    ],
+  },
+  {
+    targetId: 'failed-champion__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase(
+        'armor-1',
+        'Armor Stage 1',
+        360,
+        'Shatter the armor to reveal the enraged maggot.',
+      ),
+      phase(
+        'maggot-1',
+        'Maggot Stage 1',
+        60,
+        'Strike the exposed maggot before it reclaims the armor.',
+      ),
+      phase(
+        'armor-2',
+        'Armor Stage 2',
+        360,
+        'Second armor phase with increased aggression.',
+      ),
+      phase('maggot-2', 'Maggot Stage 2', 40, 'Brief stagger window against the maggot.'),
+      phase(
+        'armor-3',
+        'Armor Stage 3',
+        360,
+        'Final armor phase before the maggot erupts.',
+      ),
+      phase('maggot-3', 'Maggot Stage 3', 40, 'Penultimate stagger against the maggot.'),
+      phase(
+        'maggot-4',
+        'Maggot Stage 4',
+        40,
+        'Chase down the maggot one last time to end the fight.',
+      ),
+    ],
+  },
+  {
+    targetId: 'gorb__pantheon-of-hallownest',
+    phases: [
+      phase('phase-1', 'Phase 1 – Opening chants', 125, 'Single spear rings.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Dual volleys',
+        125,
+        'At 70% HP, Gorb fires two alternating waves.',
+      ),
+      phase(
+        'phase-3',
+        'Phase 3 – Triple barrages',
+        166,
+        'At 40% HP, Gorb fires three waves of spears.',
+      ),
+    ],
+  },
+  {
+    targetId: 'brothers-oro-mato__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase('phase-1', "Phase 1 – Oro's duel", 500, 'Face Oro alone.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Brothers united',
+        1600,
+        'Oro returns with 600 HP and Mato joins with 1000 HP.',
+      ),
+    ],
+  },
+  {
+    targetId: 'soul-master__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase('phase-1', 'Phase 1 – Aerial assault', 900, 'Floating spell barrages.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Ground slam',
+        600,
+        'The arena collapses and the battle continues below.',
+      ),
+    ],
+  },
+  {
+    targetId: 'oblobbles__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase('phase-1', 'Phase 1 – Twin volley', 750, 'Both Oblobbles attack together.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Frenzied survivor',
+        750,
+        'The surviving Oblobble enrages after its partner falls.',
+      ),
+    ],
+  },
+  {
+    targetId: 'sisters-of-battle__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Solo sister',
+        600,
+        'Duel a lone sister to open the fight.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Battle chorus',
+        2850,
+        'All three sisters join with the remaining trio of health pools.',
+      ),
+    ],
+  },
+  {
+    targetId: 'galien__pantheon-of-hallownest',
+    phases: [
+      phase('phase-1', 'Phase 1 – Great scythe', 156, 'Galien fights alone.'),
+      phase(
+        'phase-2',
+        'Phase 2 – One orbiting scythe',
+        156,
+        'At 70% HP, a small scythe appears.',
+      ),
+      phase(
+        'phase-3',
+        'Phase 3 – Dual orbiting scythes',
+        208,
+        'At 40% HP, a second scythe joins.',
+      ),
+    ],
+  },
+  {
+    targetId: 'paintmaster-sheo__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Tight canvas',
+        237,
+        'The arena has limited paint coverage.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Expanding palette',
+        238,
+        'At 75% HP, attacks paint more of the arena.',
+      ),
+      phase(
+        'phase-3',
+        'Phase 3 – Saturated canvas',
+        475,
+        'At 50% HP, the paintable area expands further.',
+      ),
+    ],
+  },
+  {
+    targetId: 'hive-knight__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Opening charges',
+        301,
+        'Standard attacks before the swarm.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Swarm release',
+        549,
+        'At 549 HP remaining, Hive Knight begins using Swarm Release.',
+      ),
+    ],
+  },
+  {
+    targetId: 'the-collector__attuned',
+    notes: 'After its HP reaches 0, 15 additional hits are required to free the jars.',
+    phases: [
+      phase('phase-1', 'Phase 1 – Trickle of jars', 450, 'Drops 1–2 jars at a time.'),
+      phase('phase-2', 'Phase 2 – Chaotic hoard', 450, 'Drops 2–3 jars at a time.'),
+    ],
+  },
+  {
+    targetId: 'winged-nosk__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Ground pursuit',
+        375,
+        'Standard attacks before the downpour.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Downpour assault',
+        375,
+        'At 50% HP, Winged Nosk adds the Downpour attack.',
+      ),
+    ],
+  },
+  {
+    targetId: 'hornet-sentinel__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Agile duel',
+        320,
+        'Standard arsenal of slashes and throws.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Sting shard traps',
+        480,
+        'At 480 HP remaining, Hornet deploys spike traps.',
+      ),
+    ],
+  },
+  {
+    targetId: 'lost-kin__pantheon-of-hallownest',
+    phases: [
+      phase('phase-1', 'Phase 1 – Opening flurry', 100, 'Standard balloon spawn rate.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Aggressive infection',
+        1150,
+        'At 1150 HP remaining, Infected Balloons spawn more frequently.',
+      ),
+    ],
+  },
+  {
+    targetId: 'no-eyes__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Lamenting spirits',
+        420,
+        'Spirits spawn every 2.25 seconds.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Rising chorus',
+        60,
+        'At 150 HP, spirits spawn every 1.75 seconds.',
+      ),
+      phase(
+        'phase-3',
+        'Phase 3 – Haunting crescendo',
+        90,
+        'At 90 HP, spirits spawn every 1.25 seconds.',
+      ),
+    ],
+  },
+  {
+    targetId: 'soul-tyrant__attuned',
+    discardOverkill: true,
+    phases: [
+      phase('phase-1', 'Phase 1 – Relentless barrage', 900, 'Floating spell assault.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Pursuit of the past',
+        350,
+        'After the first phase, the fight resumes with 350 HP.',
+      ),
+    ],
+  },
+  {
+    targetId: 'markoth__attuned',
+    phases: [
+      phase(
+        'phase-1',
+        'Phase 1 – Lone shield',
+        325,
+        'Single rotating shield with nail storms.',
+      ),
+      phase(
+        'phase-2',
+        'Phase 2 – Twin shields',
+        325,
+        'At 50% HP, a second shield appears and attack rate increases.',
+      ),
+    ],
+  },
+  {
+    targetId: 'pure-vessel__pantheon-of-hallownest',
+    phases: [
+      phase('phase-1', 'Phase 1 – Bladed ritual', 544, 'Standard moveset.'),
+      phase(
+        'phase-2',
+        'Phase 2 – Focused ascension',
+        528,
+        'At 66% HP, gains the Soul Pillar attack.',
+      ),
+      phase(
+        'phase-3',
+        'Phase 3 – Void cascade',
+        528,
+        'At 33% HP, adds the exploding orb attack.',
+      ),
+    ],
+  },
+  {
+    targetId: 'absolute-radiance__pantheon-of-hallownest',
+    discardOverkill: true,
+    phases: [
+      phase('phase-1', 'Phase 1 – Ground assault', 400),
+      phase('phase-2', 'Phase 2 – Spike floor', 450),
+      phase('phase-3', 'Phase 3 – Platform dance', 300),
+      phase('phase-4', 'Phase 4 – Winged barrage', 750),
+      phase(
+        'phase-5',
+        'Phase 5 – Climb',
+        280,
+        'Ascend the vertical shaft with beam attacks.',
+      ),
+      phase(
+        'phase-6',
+        'Phase 6 – Final strike',
+        1,
+        'Deliver the last hit after the climb.',
+      ),
+    ],
+  },
 ];

--- a/src/data/sequences.json
+++ b/src/data/sequences.json
@@ -208,12 +208,6 @@
     "category": "Godhome Pantheons",
     "conditions": [
       {
-        "id": "replace-mantis-lords",
-        "label": "Sisters of Battle unlocked",
-        "description": "Swap to the Sisters of Battle variant after completing their encounter in Godhome.",
-        "defaultEnabled": false
-      },
-      {
         "id": "include-grey-prince-zote",
         "label": "Include Grey Prince Zote",
         "description": "Enable if you rescued Zote and unlocked his Godhome fight.",
@@ -223,7 +217,7 @@
     "entries": [
       {
         "boss": "Vengefly King",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Gruz Mother",
@@ -231,7 +225,7 @@
       },
       {
         "boss": "False Knight",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Massive Moss Charger",
@@ -239,11 +233,11 @@
       },
       {
         "boss": "Hornet (Protector)",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Gorb",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Dung Defender",
@@ -255,15 +249,15 @@
       },
       {
         "boss": "Brooding Mawlek",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Brothers Oro & Mato",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Xero",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Crystal Guardian",
@@ -271,23 +265,15 @@
       },
       {
         "boss": "Soul Master",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Oblobbles",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
-        "boss": "Mantis Lords",
-        "version": "Attuned",
-        "condition": {
-          "id": "replace-mantis-lords",
-          "mode": "replace",
-          "replacement": {
-            "boss": "Sisters of Battle",
-            "version": "Attuned"
-          }
-        }
+        "boss": "Sisters of Battle",
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Marmu",
@@ -323,7 +309,7 @@
       },
       {
         "boss": "God Tamer",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Troupe Master Grimm",
@@ -331,11 +317,11 @@
       },
       {
         "boss": "Galien",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Grey Prince Zote",
-        "version": "Attuned",
+        "version": "Pantheon of Hallownest",
         "condition": {
           "id": "include-grey-prince-zote",
           "mode": "include"
@@ -359,7 +345,7 @@
       },
       {
         "boss": "Lost Kin",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "No Eyes",
@@ -387,19 +373,19 @@
       },
       {
         "boss": "Failed Champion",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Nightmare King Grimm",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Pure Vessel",
-        "version": "Attuned"
+        "version": "Pantheon of Hallownest"
       },
       {
         "boss": "Absolute Radiance",
-        "version": "Final Boss"
+        "version": "Pantheon of Hallownest"
       }
     ]
   },

--- a/src/features/fight-state/useSequenceContext.test.tsx
+++ b/src/features/fight-state/useSequenceContext.test.tsx
@@ -67,17 +67,17 @@ describe('useSequenceContext', () => {
     expect(result.current.context.hasPreviousSequenceStage).toBe(true);
   });
 
-  it('resolves conditional sequence entries and replacement targets', () => {
+  it('resolves optional sequence entries and Pantheon-specific targets', () => {
     const hallownest = bossSequenceMap.get('pantheon-of-hallownest');
     if (!hallownest) {
       throw new Error('Missing pantheon sequence fixture for tests');
     }
 
-    const mantisIndex = hallownest.entries.findIndex(
-      (entry) => entry.condition?.id === 'replace-mantis-lords',
+    const sistersIndex = hallownest.entries.findIndex(
+      (entry) => entry.target.bossName === 'Sisters of Battle',
     );
-    if (mantisIndex === -1) {
-      throw new Error('Failed to locate Mantis Lords stage in test data');
+    if (sistersIndex === -1) {
+      throw new Error('Failed to locate Sisters of Battle stage in test data');
     }
 
     const { result } = renderHook(
@@ -90,33 +90,23 @@ describe('useSequenceContext', () => {
 
     act(() => {
       result.current.actions.startSequence(hallownest.id);
-      result.current.actions.setSequenceStage(mantisIndex);
+      result.current.actions.setSequenceStage(sistersIndex);
     });
 
-    expect(result.current.context.sequenceEntries[mantisIndex]?.target.bossName).toBe(
-      'Mantis Lords',
-    );
-    expect(result.current.context.labels?.stageLabel).toBe('Mantis Lords');
-    const initialLength = result.current.context.sequenceEntries.length;
-    expect(result.current.context.sequenceConditionValues['replace-mantis-lords']).toBe(
-      false,
-    );
-
-    act(() => {
-      result.current.actions.setSequenceCondition(
-        hallownest.id,
-        'replace-mantis-lords',
-        true,
-      );
-    });
-
-    expect(result.current.context.sequenceEntries[mantisIndex]?.target.bossName).toBe(
+    expect(result.current.context.sequenceEntries[sistersIndex]?.target.bossName).toBe(
       'Sisters of Battle',
     );
+    expect(
+      result.current.context.sequenceEntries[sistersIndex]?.target.version.title,
+    ).toBe('Pantheon of Hallownest');
     expect(result.current.context.labels?.stageLabel).toBe('Sisters of Battle');
-    expect(result.current.context.sequenceConditionValues['replace-mantis-lords']).toBe(
-      true,
-    );
+    const initialLength = result.current.context.sequenceEntries.length;
+    expect(
+      Object.hasOwn(
+        result.current.context.sequenceConditionValues,
+        'replace-mantis-lords',
+      ),
+    ).toBe(false);
 
     act(() => {
       result.current.actions.setSequenceCondition(


### PR DESCRIPTION
## Summary
- add Pantheon of Hallownest-specific boss versions with updated health pools in the data set
- define Pantheon-specific phase breakdowns and notes for affected fights
- update the Pantheon sequence mapping and related tests for the Sisters of Battle default

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e865707bdc832fa444dfdb276b0ea0