### PR TITLE
chore: enforce stricter ts lint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,10 +106,6 @@ export default [
         },
       ],
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': [
         'error',
         {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const env = process.env as NodeJS.ProcessEnv;
+const env = process.env;
 
 const isCI = env.CI === 'true' || env.CI === '1';
 const usePreview =

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,8 +31,12 @@ const AppContent: FC = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isSetupOpen, setSetupOpen] = useState(false);
   const [isHelpOpen, setHelpOpen] = useState(false);
-  const handleCloseLoadout = useCallback(() => setModalOpen(false), [setModalOpen]);
-  const handleCloseHelp = useCallback(() => setHelpOpen(false), [setHelpOpen]);
+  const handleCloseLoadout = useCallback(() => {
+    setModalOpen(false);
+  }, [setModalOpen]);
+  const handleCloseHelp = useCallback(() => {
+    setHelpOpen(false);
+  }, [setHelpOpen]);
 
   const {
     bosses,
@@ -96,7 +100,9 @@ const AppContent: FC = () => {
       glowTimeoutRef.current = null;
     }, duration);
     glowTimeoutRef.current = timeoutId;
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
   }, [panelGlow]);
 
   useEffect(
@@ -131,7 +137,9 @@ const AppContent: FC = () => {
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
   }, [
     handleAdvanceSequence,
     handleRewindSequence,
@@ -162,9 +170,15 @@ const AppContent: FC = () => {
         encounterName={encounterName}
         versionLabel={versionLabel}
         arenaLabel={arenaLabel}
-        onToggleSetup={() => setSetupOpen((open) => !open)}
-        onOpenLoadout={() => setModalOpen(true)}
-        onOpenHelp={() => setHelpOpen(true)}
+        onToggleSetup={() => {
+          setSetupOpen((open) => !open);
+        }}
+        onOpenLoadout={() => {
+          setModalOpen(true);
+        }}
+        onOpenHelp={() => {
+          setHelpOpen(true);
+        }}
         isSetupOpen={isSetupOpen}
         stageLabel={stageLabel}
         stageProgress={stageProgress}

--- a/src/app/useVisualViewportCssVars.ts
+++ b/src/app/useVisualViewportCssVars.ts
@@ -33,8 +33,9 @@ export const useVisualViewportCssVars = () => {
     const root = document.documentElement;
 
     const viewport = window.visualViewport;
-    const handleChange = () =>
+    const handleChange = () => {
       updateViewportCssVars(root, window.visualViewport ?? viewport);
+    };
 
     updateViewportCssVars(root, viewport);
 

--- a/src/components/SurfaceSection.tsx
+++ b/src/components/SurfaceSection.tsx
@@ -36,7 +36,7 @@ export const SurfaceSection = <T extends ElementType = 'section'>(
     ...rest
   } = props;
 
-  const Component = (as ?? 'section') as ElementType;
+  const Component: ElementType = as ?? 'section';
 
   return (
     <Component

--- a/src/features/attack-log/attackDefinitionBuilders.ts
+++ b/src/features/attack-log/attackDefinitionBuilders.ts
@@ -93,10 +93,11 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const toNumber = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
 
+const isNumberArray = (value: unknown): value is number[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'number');
+
 const toNumberArray = (value: unknown): number[] | null =>
-  Array.isArray(value) && value.every((item) => typeof item === 'number')
-    ? (value as number[])
-    : null;
+  isNumberArray(value) ? value : null;
 
 const getCharmEffect = (charmId: string, effectType: string) =>
   charmMap.get(charmId)?.effects.find((effect) => effect.type === effectType);
@@ -179,7 +180,9 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
     },
   ];
 
-  const nailArtLabelMap = new Map(NAIL_ARTS.map((art) => [art.id, art.label] as const));
+  const nailArtLabelMap = new Map<string, string>(
+    NAIL_ARTS.map<[string, string]>((art) => [art.id, art.label]),
+  );
 
   const nailArtAttacks: AttackDefinition[] = NAIL_ARTS.map(
     ({ id, label, multiplier, baseDescription }) => {
@@ -213,19 +216,15 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
 
     if (hasFlukenest && spell.id === 'vengeful-spirit') {
       const crestReplacement = hasDefendersCrest
-        ? (getCharmSynergyEffectRecord(
+        ? getCharmSynergyEffectRecord(
             ['flukenest', 'defenders-crest'],
             'spell_replacement',
-          ) as Record<string, unknown> | null)
+          )
         : null;
       const replacements =
-        crestReplacement ??
-        (getCharmEffectRecord('flukenest', 'spell_replacement') as Record<
-          string,
-          unknown
-        > | null);
-      if (replacements && isRecord(replacements[variant.key])) {
-        const replacement = replacements[variant.key] as Record<string, unknown>;
+        crestReplacement ?? getCharmEffectRecord('flukenest', 'spell_replacement');
+      const replacement = replacements?.[variant.key];
+      if (isRecord(replacement)) {
         const totalDamage = toNumber(replacement.totalDamage);
         const projectiles = toNumber(replacement.projectiles);
         const damagePerProjectile = toNumber(replacement.damagePerProjectile);
@@ -389,11 +388,7 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
         break;
       }
       case 'defenders-crest': {
-        const auraData = getCharmEffectRecord('defenders-crest', 'damage_aura') as {
-          minDamage?: unknown;
-          maxDamage?: unknown;
-          tickRateSeconds?: unknown;
-        } | null;
+        const auraData = getCharmEffectRecord('defenders-crest', 'damage_aura');
         if (auraData) {
           const minDamage = toNumber(auraData.minDamage);
           const maxDamage = toNumber(auraData.maxDamage);
@@ -418,17 +413,13 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
       }
       case 'spore-shroom': {
         const crestEnhancedData = hasDefendersCrest
-          ? (getCharmSynergyEffectRecord(
+          ? getCharmSynergyEffectRecord(
               ['spore-shroom', 'defenders-crest'],
               'focus_damage_cloud',
-            ) as { totalDamage?: unknown; durationSeconds?: unknown } | null)
+            )
           : null;
         const sporeData =
-          crestEnhancedData ??
-          (getCharmEffectRecord('spore-shroom', 'focus_damage_cloud') as {
-            totalDamage?: unknown;
-            durationSeconds?: unknown;
-          } | null);
+          crestEnhancedData ?? getCharmEffectRecord('spore-shroom', 'focus_damage_cloud');
         if (sporeData) {
           const totalDamage = toNumber(sporeData.totalDamage);
           const duration = toNumber(sporeData.durationSeconds);
@@ -463,10 +454,7 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
         break;
       }
       case 'glowing-womb': {
-        const wombData = getCharmEffectRecord('glowing-womb', 'minion_summon') as {
-          damage?: unknown;
-          soulCost?: unknown;
-        } | null;
+        const wombData = getCharmEffectRecord('glowing-womb', 'minion_summon');
         if (wombData) {
           const damage = toNumber(wombData.damage);
           const soulCost = toNumber(wombData.soulCost) ?? undefined;
@@ -493,10 +481,7 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
         break;
       }
       case 'weaversong': {
-        const weaverData = getCharmEffectRecord('weaversong', 'minion_summon') as {
-          count?: unknown;
-          damage?: unknown;
-        } | null;
+        const weaverData = getCharmEffectRecord('weaversong', 'minion_summon');
         if (weaverData) {
           const damage = toNumber(weaverData.damage);
           const count = toNumber(weaverData.count);
@@ -520,9 +505,7 @@ export function buildAttackGroups(build: FightState['build']): AttackGroup[] {
         break;
       }
       case 'grimmchild': {
-        const grimmchildData = getCharmEffectRecord('grimmchild', 'minion_summon') as {
-          damagePerLevel?: unknown;
-        } | null;
+        const grimmchildData = getCharmEffectRecord('grimmchild', 'minion_summon');
         if (grimmchildData) {
           const damagePerLevel = toNumberArray(grimmchildData.damagePerLevel);
           if (damagePerLevel) {

--- a/src/features/attack-log/components/AttackLogActions.tsx
+++ b/src/features/attack-log/components/AttackLogActions.tsx
@@ -45,7 +45,9 @@ export const AttackLogActions: FC = () => {
   return (
     <div className="attack-log__actions" role="group" aria-label="Attack log controls">
       <AppButton
-        ref={(element) => registerActionButton('undo', element)}
+        ref={(element) => {
+          registerActionButton('undo', element);
+        }}
         type="button"
         onPointerDown={handlePointerEffect}
         onKeyDown={handleKeyEffect}
@@ -56,7 +58,9 @@ export const AttackLogActions: FC = () => {
         Undo
       </AppButton>
       <AppButton
-        ref={(element) => registerActionButton('redo', element)}
+        ref={(element) => {
+          registerActionButton('redo', element);
+        }}
         type="button"
         onPointerDown={handlePointerEffect}
         onKeyDown={handleKeyEffect}
@@ -67,7 +71,9 @@ export const AttackLogActions: FC = () => {
         Redo
       </AppButton>
       <AppButton
-        ref={(element) => registerActionButton('reset-log', element)}
+        ref={(element) => {
+          registerActionButton('reset-log', element);
+        }}
         type="button"
         onPointerDown={handlePointerEffect}
         onKeyDown={handleKeyEffect}
@@ -82,7 +88,9 @@ export const AttackLogActions: FC = () => {
       </AppButton>
       {showResetSequence ? (
         <AppButton
-          ref={(element) => registerActionButton('reset-sequence', element)}
+          ref={(element) => {
+            registerActionButton('reset-sequence', element);
+          }}
           type="button"
           onPointerDown={handlePointerEffect}
           onKeyDown={handleKeyEffect}
@@ -97,7 +105,9 @@ export const AttackLogActions: FC = () => {
         </AppButton>
       ) : null}
       <AppButton
-        ref={(element) => registerActionButton('end-fight', element)}
+        ref={(element) => {
+          registerActionButton('end-fight', element);
+        }}
         type="button"
         onPointerDown={handlePointerEffect}
         onKeyDown={handleKeyEffect}

--- a/src/features/attack-log/context.tsx
+++ b/src/features/attack-log/context.tsx
@@ -178,7 +178,9 @@ export const AttackLogProvider: FC<AttackLogProviderProps> = ({ children }) => {
   useEffect(
     () => () => {
       const timeouts = activeEffectTimeoutsRef.current;
-      timeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
+      timeouts.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
       timeouts.clear();
     },
     [],

--- a/src/features/attack-log/useAttackLogShortcuts.ts
+++ b/src/features/attack-log/useAttackLogShortcuts.ts
@@ -133,7 +133,9 @@ export const useAttackLogShortcuts = ({
     };
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
   }, [
     canEndFight,
     canResetSequence,

--- a/src/features/build-config/PlayerConfigModal.tsx
+++ b/src/features/build-config/PlayerConfigModal.tsx
@@ -644,7 +644,9 @@ const PlayerConfigModalContent: FC = () => {
                   min={MIN_NOTCH_LIMIT}
                   max={MAX_NOTCH_LIMIT}
                   value={notchLimit}
-                  onChange={(event) => setNotchLimit(Number(event.target.value))}
+                  onChange={(event) => {
+                    setNotchLimit(Number(event.target.value));
+                  }}
                 />
               </label>
               <p className="notch-panel__description">
@@ -806,7 +808,9 @@ const PlayerConfigModalContent: FC = () => {
                   key={preset.id}
                   type="button"
                   className="preset-buttons__button"
-                  onClick={() => applyCharmPreset(preset.charmIds)}
+                  onClick={() => {
+                    applyCharmPreset(preset.charmIds);
+                  }}
                 >
                   {preset.label}
                 </button>
@@ -814,7 +818,9 @@ const PlayerConfigModalContent: FC = () => {
               <button
                 type="button"
                 className="preset-buttons__button"
-                onClick={() => applyCharmPreset([])}
+                onClick={() => {
+                  applyCharmPreset([]);
+                }}
               >
                 Clear charms
               </button>
@@ -837,7 +843,9 @@ const PlayerConfigModalContent: FC = () => {
                   name={`spell-${spell.id}`}
                   value="none"
                   checked={build.spellLevels[spell.id] === 'none'}
-                  onChange={() => setSpellLevel(spell.id, 'none')}
+                  onChange={() => {
+                    setSpellLevel(spell.id, 'none');
+                  }}
                 />
                 <span>Not acquired</span>
               </label>
@@ -847,7 +855,9 @@ const PlayerConfigModalContent: FC = () => {
                   name={`spell-${spell.id}`}
                   value="base"
                   checked={build.spellLevels[spell.id] === 'base'}
-                  onChange={() => setSpellLevel(spell.id, 'base')}
+                  onChange={() => {
+                    setSpellLevel(spell.id, 'base');
+                  }}
                 />
                 <span>{spell.base.name}</span>
               </label>
@@ -858,7 +868,9 @@ const PlayerConfigModalContent: FC = () => {
                     name={`spell-${spell.id}`}
                     value="upgrade"
                     checked={build.spellLevels[spell.id] === 'upgrade'}
-                    onChange={() => setSpellLevel(spell.id, 'upgrade')}
+                    onChange={() => {
+                      setSpellLevel(spell.id, 'upgrade');
+                    }}
                   />
                   <span>{spell.upgrade.name}</span>
                 </label>
@@ -878,7 +890,9 @@ const PlayerConfigModalContent: FC = () => {
             <select
               id="nail-level"
               value={build.nailUpgradeId}
-              onChange={(event) => setNailUpgrade(event.target.value)}
+              onChange={(event) => {
+                setNailUpgrade(event.target.value);
+              }}
             >
               {nailUpgrades.map((upgrade) => (
                 <option key={upgrade.id} value={upgrade.id}>

--- a/src/features/encounter-setup/EncounterSetupPanel.tsx
+++ b/src/features/encounter-setup/EncounterSetupPanel.tsx
@@ -135,7 +135,9 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
               className="encounter-setup__mode-button"
               aria-selected={mode === tab.value}
               aria-controls={tab.controls}
-              onClick={() => handleModeChange(tab.value)}
+              onClick={() => {
+                handleModeChange(tab.value);
+              }}
             >
               {tab.label}
             </button>

--- a/src/features/encounter-setup/SequenceSelector.tsx
+++ b/src/features/encounter-setup/SequenceSelector.tsx
@@ -232,7 +232,9 @@ const SequenceOption: FC<SequenceOptionProps> = ({
                     disabled={!isInteractive}
                     onChange={
                       isInteractive && onConditionToggle
-                        ? (event) => onConditionToggle(condition.id, event.target.checked)
+                        ? (event) => {
+                            onConditionToggle(condition.id, event.target.checked);
+                          }
                         : undefined
                     }
                   />
@@ -267,7 +269,9 @@ const SequenceOption: FC<SequenceOptionProps> = ({
                   <button
                     type="button"
                     className="sequence-selector__stage"
-                    onClick={() => onStageSelect?.(index)}
+                    onClick={() => {
+                      onStageSelect?.(index);
+                    }}
                     aria-current={isCurrent ? 'true' : undefined}
                   >
                     <span className="sequence-selector__stage-index">

--- a/src/features/encounter-setup/TargetSelector.tsx
+++ b/src/features/encounter-setup/TargetSelector.tsx
@@ -118,7 +118,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
         <button
           type="button"
           className="target-selector__options-toggle"
-          onClick={() => setOptionsOpen((open) => !open)}
+          onClick={() => {
+            setOptionsOpen((open) => !open);
+          }}
           aria-expanded={isOptionsOpen}
           aria-controls="target-selector-options"
         >
@@ -133,7 +135,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
             id="boss-search"
             type="search"
             value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
+            onChange={(event) => {
+              setSearchQuery(event.target.value);
+            }}
             placeholder="Search by name"
             autoComplete="off"
             aria-describedby="boss-search-results"
@@ -165,7 +169,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
                     id={optionId}
                     value={boss.id}
                     checked={isSelected}
-                    onChange={() => onBossChange(boss.id)}
+                    onChange={() => {
+                      onBossChange(boss.id);
+                    }}
                   />
                   <span className="target-selector__boss-marker" aria-hidden="true" />
                   <span className="target-selector__boss-copy">
@@ -193,7 +199,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
                   id="boss-target-custom"
                   value={CUSTOM_BOSS_ID}
                   checked={bossSelectValue === CUSTOM_BOSS_ID}
-                  onChange={() => onBossChange(CUSTOM_BOSS_ID)}
+                  onChange={() => {
+                    onBossChange(CUSTOM_BOSS_ID);
+                  }}
                 />
                 <span className="target-selector__boss-marker" aria-hidden="true" />
                 <span className="target-selector__boss-copy">
@@ -220,7 +228,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
             <span className="target-selector__field-label">Boss version</span>
             <select
               value={selectedTarget.id}
-              onChange={(event) => onBossVersionChange(event.target.value)}
+              onChange={(event) => {
+                onBossVersionChange(event.target.value);
+              }}
             >
               {selectedBoss.versions.map((version) => (
                 <option key={version.targetId} value={version.targetId}>
@@ -240,7 +250,9 @@ export const TargetSelector: FC<TargetSelectorProps> = ({
               inputMode="numeric"
               pattern="[0-9]*"
               value={customHpDraft}
-              onChange={(event) => handleCustomHpDraftChange(event.target.value)}
+              onChange={(event) => {
+                handleCustomHpDraftChange(event.target.value);
+              }}
               onBlur={() => {
                 if (customHpDraft === '') {
                   setCustomHpDraft(customTargetHp.toString());

--- a/src/features/fight-state/FightStateContext.tsx
+++ b/src/features/fight-state/FightStateContext.tsx
@@ -193,13 +193,14 @@ export const useFightStateSelector = <Selected,>(
     const previousSelected = selectedRef.current;
     if (
       !hasSnapshotRef.current ||
-      !equalityFnRef.current(previousSelected as Selected, nextSelected)
+      previousSelected === undefined ||
+      !equalityFnRef.current(previousSelected, nextSelected)
     ) {
       hasSnapshotRef.current = true;
       selectedRef.current = nextSelected;
       return nextSelected;
     }
-    return previousSelected as Selected;
+    return previousSelected;
   };
 
   const subscribe = (notify: () => void) =>
@@ -208,7 +209,8 @@ export const useFightStateSelector = <Selected,>(
       const previousSelected = selectedRef.current;
       if (
         !hasSnapshotRef.current ||
-        !equalityFnRef.current(previousSelected as Selected, nextSelected)
+        previousSelected === undefined ||
+        !equalityFnRef.current(previousSelected, nextSelected)
       ) {
         hasSnapshotRef.current = true;
         selectedRef.current = nextSelected;

--- a/src/features/fight-state/store.ts
+++ b/src/features/fight-state/store.ts
@@ -307,14 +307,18 @@ export const createFightStateStore = (
   };
 
   const notifyState = () => {
-    stateListeners.forEach((listener) => listener());
+    stateListeners.forEach((listener) => {
+      listener();
+    });
   };
 
   const notifyDerived = (timestamp?: number) => {
     frameTimestamp = typeof timestamp === 'number' ? timestamp : Date.now();
     const aggregates = ensureAggregateCache();
     derived = calculateDerivedStats(state, frameTimestamp, aggregates);
-    derivedListeners.forEach((listener) => listener());
+    derivedListeners.forEach((listener) => {
+      listener();
+    });
   };
 
   const sequenceCompletionTimestamps = new Map<string, number>();
@@ -495,17 +499,28 @@ export const createFightStateStore = (
   };
 
   const actions: FightActions = {
-    selectBoss: (bossId) => dispatch({ type: 'selectBoss', bossId }),
-    setCustomTargetHp: (hp) => dispatch({ type: 'setCustomTargetHp', hp }),
-    setNailUpgrade: (nailUpgradeId) =>
-      dispatch({ type: 'setNailUpgrade', nailUpgradeId }),
-    setActiveCharms: (charmIds) => dispatch({ type: 'setActiveCharms', charmIds }),
-    updateActiveCharms: (updater) => dispatch({ type: 'updateActiveCharms', updater }),
-    setCharmNotchLimit: (notchLimit) =>
-      dispatch({ type: 'setCharmNotchLimit', notchLimit }),
-    setSpellLevel: (spellId, level) =>
-      dispatch({ type: 'setSpellLevel', spellId, level }),
-    logAttack: ({ id, label, damage, category, soulCost, timestamp }) =>
+    selectBoss: (bossId) => {
+      dispatch({ type: 'selectBoss', bossId });
+    },
+    setCustomTargetHp: (hp) => {
+      dispatch({ type: 'setCustomTargetHp', hp });
+    },
+    setNailUpgrade: (nailUpgradeId) => {
+      dispatch({ type: 'setNailUpgrade', nailUpgradeId });
+    },
+    setActiveCharms: (charmIds) => {
+      dispatch({ type: 'setActiveCharms', charmIds });
+    },
+    updateActiveCharms: (updater) => {
+      dispatch({ type: 'updateActiveCharms', updater });
+    },
+    setCharmNotchLimit: (notchLimit) => {
+      dispatch({ type: 'setCharmNotchLimit', notchLimit });
+    },
+    setSpellLevel: (spellId, level) => {
+      dispatch({ type: 'setSpellLevel', spellId, level });
+    },
+    logAttack: ({ id, label, damage, category, soulCost, timestamp }) => {
       dispatch({
         type: 'logAttack',
         id,
@@ -514,27 +529,49 @@ export const createFightStateStore = (
         category,
         soulCost,
         timestamp: timestamp ?? Date.now(),
-      }),
-    undoLastAttack: () => dispatch({ type: 'undoLastAttack' }),
-    redoLastAttack: () => dispatch({ type: 'redoLastAttack' }),
-    resetLog: () => dispatch({ type: 'resetLog' }),
-    resetSequence: () => dispatch({ type: 'resetSequence' }),
-    startFight: (timestamp) =>
-      dispatch({ type: 'startFight', timestamp: timestamp ?? Date.now() }),
-    endFight: (timestamp) =>
-      dispatch({ type: 'endFight', timestamp: timestamp ?? Date.now() }),
-    startSequence: (sequenceId) => dispatch({ type: 'startSequence', sequenceId }),
-    stopSequence: () => dispatch({ type: 'stopSequence' }),
-    setSequenceStage: (index) => dispatch({ type: 'setSequenceStage', index }),
-    advanceSequenceStage: () => dispatch({ type: 'advanceSequence' }),
-    rewindSequenceStage: () => dispatch({ type: 'rewindSequence' }),
-    setSequenceCondition: (sequenceId, conditionId, enabled) =>
+      });
+    },
+    undoLastAttack: () => {
+      dispatch({ type: 'undoLastAttack' });
+    },
+    redoLastAttack: () => {
+      dispatch({ type: 'redoLastAttack' });
+    },
+    resetLog: () => {
+      dispatch({ type: 'resetLog' });
+    },
+    resetSequence: () => {
+      dispatch({ type: 'resetSequence' });
+    },
+    startFight: (timestamp) => {
+      dispatch({ type: 'startFight', timestamp: timestamp ?? Date.now() });
+    },
+    endFight: (timestamp) => {
+      dispatch({ type: 'endFight', timestamp: timestamp ?? Date.now() });
+    },
+    startSequence: (sequenceId) => {
+      dispatch({ type: 'startSequence', sequenceId });
+    },
+    stopSequence: () => {
+      dispatch({ type: 'stopSequence' });
+    },
+    setSequenceStage: (index) => {
+      dispatch({ type: 'setSequenceStage', index });
+    },
+    advanceSequenceStage: () => {
+      dispatch({ type: 'advanceSequence' });
+    },
+    rewindSequenceStage: () => {
+      dispatch({ type: 'rewindSequence' });
+    },
+    setSequenceCondition: (sequenceId, conditionId, enabled) => {
       dispatch({
         type: 'setSequenceCondition',
         sequenceId,
         conditionId,
         enabled,
-      }),
+      });
+    },
   };
 
   const stateStore = createExternalStore(() => state, stateListeners);


### PR DESCRIPTION
## Summary
- enable the @typescript-eslint safety rules that were previously disabled in the ESLint config
- refactor callbacks and event handlers to avoid returning void expressions and remove unnecessary type assertions
- tighten attack data utilities to validate JSON-derived records before use

## Testing
- pnpm lint:js
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e8af201518832f8b6eb376cfa5b513