### PR TITLE
feat: add pantheon bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Hollow Knight Damage Tracker is a responsive companion app for players, co-comme
 ### Track every encounter
 
 - **Sequence flow:** Queue Godhome pantheons, the Black Egg Temple rush, and other multi-boss runs while the tracker advances the moment a boss hits zero masks.
+- **Pantheon bindings:** Toggle Nail, Shell, Charms, and Soul bindings for Godhome runs—damage calculations adapt automatically when the Nail binding or disabled charms would change the math.
 - **Boss presets & custom pools:** Jump between Attuned, Ascended, and Radiant variants—or punch in a custom HP target for drills.
 - **Keyboard-first logging:** Number-row + QWERTY shortcuts (plus <kbd>Esc</kbd> / <kbd>Shift</kbd>+<kbd>Esc</kbd>) keep spectators and co-op partners quick on the draw.
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,8 @@ const AppContent: FC = () => {
     activeSequence,
     sequenceConditionValues,
     handleSequenceConditionToggle,
+    sequenceBindingValues,
+    handleSequenceBindingToggle,
     currentSequenceEntry,
   } = useBuildConfiguration();
 
@@ -213,6 +215,8 @@ const AppContent: FC = () => {
         onStageSelect={handleSequenceStageChange}
         sequenceConditionValues={sequenceConditionValues}
         onConditionToggle={handleSequenceConditionToggle}
+        sequenceBindingValues={sequenceBindingValues}
+        onBindingToggle={handleSequenceBindingToggle}
       />
 
       <main className="app-main">

--- a/src/data/sequences.json
+++ b/src/data/sequences.json
@@ -4,6 +4,32 @@
     "name": "Pantheon of the Master",
     "category": "Godhome Pantheons",
     "conditions": [],
+    "bindings": [
+      {
+        "id": "nail-binding",
+        "label": "Nail Binding",
+        "description": "Reduce Nail damage to 80% (capped at 13). Nail Arts scale from the bound damage.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "shell-binding",
+        "label": "Shell Binding",
+        "description": "Limit the Knight to four Masks. Lifeblood and Heart-granted masks remain available.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "charms-binding",
+        "label": "Charms Binding",
+        "description": "Disable all charm effects for this run.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "soul-binding",
+        "label": "Soul Binding",
+        "description": "Cap SOUL at 33 and disable additional Soul Vessels.",
+        "defaultEnabled": false
+      }
+    ],
     "entries": [
       {
         "boss": "Vengefly King",
@@ -52,6 +78,32 @@
     "name": "Pantheon of the Artist",
     "category": "Godhome Pantheons",
     "conditions": [],
+    "bindings": [
+      {
+        "id": "nail-binding",
+        "label": "Nail Binding",
+        "description": "Reduce Nail damage to 80% (capped at 13). Nail Arts scale from the bound damage.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "shell-binding",
+        "label": "Shell Binding",
+        "description": "Limit the Knight to four Masks. Lifeblood and Heart-granted masks remain available.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "charms-binding",
+        "label": "Charms Binding",
+        "description": "Disable all charm effects for this run.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "soul-binding",
+        "label": "Soul Binding",
+        "description": "Cap SOUL at 33 and disable additional Soul Vessels.",
+        "defaultEnabled": false
+      }
+    ],
     "entries": [
       {
         "boss": "Xero",
@@ -104,6 +156,84 @@
         "id": "include-grey-prince-zote",
         "label": "Include Grey Prince Zote",
         "description": "Enable if you rescued Zote and unlocked his Godhome fight.",
+        "defaultEnabled": false
+      }
+    ],
+    "bindings": [
+      {
+        "id": "nail-binding",
+        "label": "Nail Binding",
+        "description": "Reduce Nail damage to 80% (capped at 13). Nail Arts scale from the bound damage.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "shell-binding",
+        "label": "Shell Binding",
+        "description": "Limit the Knight to four Masks. Lifeblood and Heart-granted masks remain available.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "charms-binding",
+        "label": "Charms Binding",
+        "description": "Disable all charm effects for this run.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "soul-binding",
+        "label": "Soul Binding",
+        "description": "Cap SOUL at 33 and disable additional Soul Vessels.",
+        "defaultEnabled": false
+      }
+    ],
+    "bindings": [
+      {
+        "id": "nail-binding",
+        "label": "Nail Binding",
+        "description": "Reduce Nail damage to 80% (capped at 13). Nail Arts scale from the bound damage.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "shell-binding",
+        "label": "Shell Binding",
+        "description": "Limit the Knight to four Masks. Lifeblood and Heart-granted masks remain available.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "charms-binding",
+        "label": "Charms Binding",
+        "description": "Disable all charm effects for this run.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "soul-binding",
+        "label": "Soul Binding",
+        "description": "Cap SOUL at 33 and disable additional Soul Vessels.",
+        "defaultEnabled": false
+      }
+    ],
+    "bindings": [
+      {
+        "id": "nail-binding",
+        "label": "Nail Binding",
+        "description": "Reduce Nail damage to 80% (capped at 13). Nail Arts scale from the bound damage.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "shell-binding",
+        "label": "Shell Binding",
+        "description": "Limit the Knight to four Masks. Lifeblood and Heart-granted masks remain available.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "charms-binding",
+        "label": "Charms Binding",
+        "description": "Disable all charm effects for this run.",
+        "defaultEnabled": false
+      },
+      {
+        "id": "soul-binding",
+        "label": "Soul Binding",
+        "description": "Cap SOUL at 33 and disable additional Soul Vessels.",
         "defaultEnabled": false
       }
     ],

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -117,10 +117,18 @@ export interface BossSequenceEntry {
   condition?: BossSequenceEntryCondition;
 }
 
+export interface BossSequenceBinding {
+  id: string;
+  label: string;
+  description?: string;
+  defaultEnabled: boolean;
+}
+
 export interface BossSequence {
   id: string;
   name: string;
   category: string;
   entries: BossSequenceEntry[];
   conditions: BossSequenceCondition[];
+  bindings: BossSequenceBinding[];
 }

--- a/src/features/attack-log/context.tsx
+++ b/src/features/attack-log/context.tsx
@@ -116,6 +116,7 @@ export const AttackLogProvider: FC<AttackLogProviderProps> = ({ children }) => {
   const { groupsWithMetadata, shortcutMap } = useAttackDefinitions(
     state,
     derived.remainingHp,
+    sequenceContext.sequenceBindingValues,
   );
 
   const panelRef = useRef<HTMLDivElement | null>(null);

--- a/src/features/attack-log/useAttackDefinitions.ts
+++ b/src/features/attack-log/useAttackDefinitions.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
 
 import type { FightState } from '../fight-state/FightStateContext';
-import { buildAttackGroups, buildAttackMetadata } from './attackDefinitionBuilders';
+import {
+  buildAttackGroups,
+  buildAttackMetadata,
+  type AttackGroupOptions,
+} from './attackDefinitionBuilders';
 
 export {
   FURY_MULTIPLIER,
@@ -17,8 +21,15 @@ export type {
   AttackWithMetadata,
 } from './attackDefinitionBuilders';
 
-export const useAttackDefinitions = ({ build }: FightState, remainingHp: number) => {
-  const baseGroups = useMemo(() => buildAttackGroups(build), [build]);
+export const useAttackDefinitions = (
+  { build }: FightState,
+  remainingHp: number,
+  bindings?: AttackGroupOptions['bindings'],
+) => {
+  const baseGroups = useMemo(
+    () => buildAttackGroups(build, { bindings }),
+    [build, bindings],
+  );
 
   return useMemo(
     () => buildAttackMetadata(baseGroups, remainingHp),

--- a/src/features/build-config/useBuildConfiguration.ts
+++ b/src/features/build-config/useBuildConfiguration.ts
@@ -105,6 +105,7 @@ export const useBuildConfiguration = () => {
     activeSequence,
     sequenceEntries,
     sequenceConditionValues,
+    sequenceBindingValues,
     cappedSequenceIndex,
     currentSequenceEntry,
     isSequenceActive,
@@ -298,6 +299,16 @@ export const useBuildConfiguration = () => {
     [actions, activeSequence],
   );
 
+  const handleSequenceBindingToggle = useCallback(
+    (bindingId: string, enabled: boolean) => {
+      if (!activeSequence) {
+        return;
+      }
+      actions.setSequenceBinding(activeSequence.id, bindingId, enabled);
+    },
+    [actions, activeSequence],
+  );
+
   const handleBossChange = useCallback(
     (bossId: string) => {
       if (bossId === CUSTOM_BOSS_ID) {
@@ -364,6 +375,7 @@ export const useBuildConfiguration = () => {
     activeSequence,
     sequenceEntries,
     sequenceConditionValues,
+    sequenceBindingValues,
     hasNextSequenceStage,
     hasPreviousSequenceStage,
     sequenceSelectValue,
@@ -372,6 +384,7 @@ export const useBuildConfiguration = () => {
     handleAdvanceSequence,
     handleRewindSequence,
     handleSequenceConditionToggle,
+    handleSequenceBindingToggle,
     currentSequenceEntry,
     cappedSequenceIndex,
     selectedTarget,

--- a/src/features/encounter-setup/EncounterSetupPanel.tsx
+++ b/src/features/encounter-setup/EncounterSetupPanel.tsx
@@ -44,6 +44,10 @@ export type EncounterSetupPanelProps = {
     typeof useBuildConfiguration
   >['sequenceConditionValues'];
   readonly onConditionToggle: (conditionId: string, enabled: boolean) => void;
+  readonly sequenceBindingValues: ReturnType<
+    typeof useBuildConfiguration
+  >['sequenceBindingValues'];
+  readonly onBindingToggle: (bindingId: string, enabled: boolean) => void;
 };
 
 export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
@@ -66,6 +70,8 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
   onStageSelect,
   sequenceConditionValues,
   onConditionToggle,
+  sequenceBindingValues,
+  onBindingToggle,
 }) => {
   const [mode, setMode] = useState<EncounterMode>(
     sequenceSelectValue ? SEQUENCE_MODE : SINGLE_TARGET_MODE,
@@ -186,6 +192,8 @@ export const EncounterSetupPanel: FC<EncounterSetupPanelProps> = ({
             onStageSelect={onStageSelect}
             sequenceConditionValues={sequenceConditionValues}
             onConditionToggle={onConditionToggle}
+            sequenceBindingValues={sequenceBindingValues}
+            onBindingToggle={onBindingToggle}
           />
         </section>
       </div>

--- a/src/features/fight-state/fightReducer.ts
+++ b/src/features/fight-state/fightReducer.ts
@@ -436,6 +436,19 @@ export const fightReducer = (state: FightState, action: FightAction): FightState
 
       return ensureSequenceState(clearedLogsState);
     }
+    case 'setSequenceBinding': {
+      const existing = state.sequenceBindings[action.sequenceId] ?? {};
+      return {
+        ...state,
+        sequenceBindings: {
+          ...state.sequenceBindings,
+          [action.sequenceId]: {
+            ...existing,
+            [action.bindingId]: action.enabled,
+          },
+        },
+      };
+    }
     case 'setSequenceStage':
       return state.activeSequenceId
         ? loadSequenceStage(

--- a/src/features/fight-state/persistence.test.ts
+++ b/src/features/fight-state/persistence.test.ts
@@ -137,6 +137,13 @@ describe('fight-state persistence', () => {
           },
           broken: 'nope',
         },
+        sequenceBindings: {
+          'pantheon-of-the-sage': {
+            'nail-binding': 'true',
+            bogus: 'maybe',
+          },
+          broken: 'nope',
+        },
         fightEndTimestamp: 'not-a-number',
         fightManuallyEnded: 'nope',
         sequenceFightEndTimestamps: {
@@ -191,6 +198,9 @@ describe('fight-state persistence', () => {
     ).toBe(true);
     const sageConditions = merged.sequenceConditions['pantheon-of-the-sage'] ?? {};
     expect(Object.prototype.hasOwnProperty.call(sageConditions, 'bogus')).toBe(false);
+    expect(merged.sequenceBindings['pantheon-of-the-sage']?.['nail-binding']).toBe(true);
+    const sageBindings = merged.sequenceBindings['pantheon-of-the-sage'] ?? {};
+    expect(Object.prototype.hasOwnProperty.call(sageBindings, 'bogus')).toBe(false);
   });
 
   it('restores persisted state from localStorage when payloads are valid', () => {
@@ -214,6 +224,7 @@ describe('fight-state persistence', () => {
         sequenceLogs: {},
         sequenceRedoStacks: {},
         sequenceConditions: {},
+        sequenceBindings: {},
         fightEndTimestamp: null,
         fightManuallyEnded: false,
         sequenceFightEndTimestamps: {},

--- a/src/features/fight-state/reducer/build.ts
+++ b/src/features/fight-state/reducer/build.ts
@@ -73,6 +73,7 @@ export const createInitialState = (): FightState => ({
   sequenceLogAggregates: {},
   sequenceRedoStacks: {},
   sequenceConditions: {},
+  sequenceBindings: {},
   fightStartTimestamp: null,
   fightManuallyStarted: false,
   fightEndTimestamp: null,

--- a/src/features/fight-state/reducer/types.ts
+++ b/src/features/fight-state/reducer/types.ts
@@ -42,6 +42,7 @@ export interface FightState {
   sequenceLogAggregates: Partial<Record<string, DamageLogAggregates>>;
   sequenceRedoStacks: Partial<Record<string, AttackEvent[]>>;
   sequenceConditions: Partial<Record<string, Record<string, boolean>>>;
+  sequenceBindings: Partial<Record<string, Record<string, boolean>>>;
   fightStartTimestamp: number | null;
   fightManuallyStarted: boolean;
   fightEndTimestamp: number | null;
@@ -96,6 +97,12 @@ export type FightAction =
       type: 'setSequenceCondition';
       sequenceId: string;
       conditionId: string;
+      enabled: boolean;
+    }
+  | {
+      type: 'setSequenceBinding';
+      sequenceId: string;
+      bindingId: string;
       enabled: boolean;
     };
 

--- a/src/features/fight-state/store.ts
+++ b/src/features/fight-state/store.ts
@@ -74,6 +74,7 @@ export type FightActions = {
     conditionId: string,
     enabled: boolean,
   ) => void;
+  setSequenceBinding: (sequenceId: string, bindingId: string, enabled: boolean) => void;
 };
 
 type Listener = () => void;
@@ -569,6 +570,14 @@ export const createFightStateStore = (
         type: 'setSequenceCondition',
         sequenceId,
         conditionId,
+        enabled,
+      });
+    },
+    setSequenceBinding: (sequenceId, bindingId, enabled) => {
+      dispatch({
+        type: 'setSequenceBinding',
+        sequenceId,
+        bindingId,
         enabled,
       });
     },

--- a/src/features/fight-state/useSequenceContext.test.tsx
+++ b/src/features/fight-state/useSequenceContext.test.tsx
@@ -40,6 +40,13 @@ describe('useSequenceContext', () => {
     expect(result.current.context.currentSequenceEntry?.id).toBe(
       masterSequence.entries[0]?.id,
     );
+    const expectedBindingDefaults = masterSequence.bindings.reduce<
+      Record<string, boolean>
+    >((acc, binding) => {
+      acc[binding.id] = binding.defaultEnabled;
+      return acc;
+    }, {});
+    expect(result.current.context.sequenceBindingValues).toEqual(expectedBindingDefaults);
     expect(result.current.context.labels?.sequenceName).toBe(masterSequence.name);
     expect(result.current.context.labels?.stageNumber).toBe(1);
     expect(result.current.context.labels?.stageLabel).toBe(
@@ -107,6 +114,7 @@ describe('useSequenceContext', () => {
         'replace-mantis-lords',
       ),
     ).toBe(false);
+    expect(result.current.context.sequenceBindingValues['nail-binding']).toBeUndefined();
 
     act(() => {
       result.current.actions.setSequenceCondition(
@@ -125,5 +133,11 @@ describe('useSequenceContext', () => {
         (entry) => entry.target.bossName === 'Grey Prince Zote',
       ),
     ).toBe(true);
+
+    act(() => {
+      result.current.actions.setSequenceBinding(hallownest.id, 'nail-binding', true);
+    });
+
+    expect(result.current.context.sequenceBindingValues['nail-binding']).toBe(true);
   });
 });

--- a/src/features/fight-state/useSequenceContext.ts
+++ b/src/features/fight-state/useSequenceContext.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import {
   bossSequenceMap,
+  getSequenceBindingValues,
   getSequenceConditionValues,
   resolveSequenceEntries,
   type BossSequence,
@@ -21,6 +22,7 @@ export interface SequenceContextValue {
   sequenceIndex: number;
   sequenceEntries: BossSequenceEntry[];
   sequenceConditionValues: Record<string, boolean>;
+  sequenceBindingValues: Record<string, boolean>;
   cappedSequenceIndex: number;
   currentSequenceEntry: BossSequenceEntry | undefined;
   labels: SequenceLabels | null;
@@ -47,6 +49,7 @@ export const useSequenceContext = (): SequenceContextValue => {
   const activeSequenceId = useFightStateSelector((state) => state.activeSequenceId);
   const sequenceIndex = useFightStateSelector((state) => state.sequenceIndex);
   const sequenceConditions = useFightStateSelector((state) => state.sequenceConditions);
+  const sequenceBindings = useFightStateSelector((state) => state.sequenceBindings);
 
   return useMemo<SequenceContextValue>(() => {
     if (!activeSequenceId) {
@@ -56,6 +59,7 @@ export const useSequenceContext = (): SequenceContextValue => {
         sequenceIndex,
         sequenceEntries: [],
         sequenceConditionValues: {},
+        sequenceBindingValues: {},
         cappedSequenceIndex: 0,
         currentSequenceEntry: undefined,
         labels: null,
@@ -73,6 +77,7 @@ export const useSequenceContext = (): SequenceContextValue => {
         sequenceIndex,
         sequenceEntries: [],
         sequenceConditionValues: {},
+        sequenceBindingValues: {},
         cappedSequenceIndex: 0,
         currentSequenceEntry: undefined,
         labels: null,
@@ -82,9 +87,17 @@ export const useSequenceContext = (): SequenceContextValue => {
       } satisfies SequenceContextValue;
     }
 
-    const overrides = sequenceConditions[activeSequenceId] ?? undefined;
-    const sequenceEntries = resolveSequenceEntries(activeSequence, overrides);
-    const sequenceConditionValues = getSequenceConditionValues(activeSequence, overrides);
+    const conditionOverrides = sequenceConditions[activeSequenceId] ?? undefined;
+    const bindingOverrides = sequenceBindings[activeSequenceId] ?? undefined;
+    const sequenceEntries = resolveSequenceEntries(activeSequence, conditionOverrides);
+    const sequenceConditionValues = getSequenceConditionValues(
+      activeSequence,
+      conditionOverrides,
+    );
+    const sequenceBindingValues = getSequenceBindingValues(
+      activeSequence,
+      bindingOverrides,
+    );
     const cappedSequenceIndex = sequenceEntries.length
       ? Math.min(Math.max(sequenceIndex, 0), sequenceEntries.length - 1)
       : 0;
@@ -98,6 +111,7 @@ export const useSequenceContext = (): SequenceContextValue => {
       sequenceIndex,
       sequenceEntries,
       sequenceConditionValues,
+      sequenceBindingValues,
       cappedSequenceIndex,
       currentSequenceEntry,
       labels,
@@ -105,5 +119,5 @@ export const useSequenceContext = (): SequenceContextValue => {
       hasPreviousSequenceStage: cappedSequenceIndex > 0,
       hasNextSequenceStage: cappedSequenceIndex < sequenceEntries.length - 1,
     } satisfies SequenceContextValue;
-  }, [activeSequenceId, sequenceConditions, sequenceIndex]);
+  }, [activeSequenceId, sequenceBindings, sequenceConditions, sequenceIndex]);
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1659,6 +1659,11 @@ h6 {
   gap: 0.45rem;
 }
 
+.sequence-selector__option-conditions-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
 .sequence-selector__option-conditions-title {
   font-size: var(--font-size-caption);
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- avoid unnecessary boolean conversions when applying pantheon binding flags in the attack definition builder
- expand the sequence selector bindings test to cover an additional pantheon and assert disabled toggles correctly
- update sequence context tests to expect binding defaults when a pantheon is active

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e8ba9e5024832fb8d3e80e5ced4ec6