### PR TITLE
feat: add vertical tabs to player loadout modal

### DIFF
--- a/src/features/attack-log/AttackLogPanel.test.tsx
+++ b/src/features/attack-log/AttackLogPanel.test.tsx
@@ -120,6 +120,8 @@ describe('AttackLogPanel', () => {
       </AttackLogProvider>,
     );
 
+    await user.click(screen.getByRole('tab', { name: /spells/i }));
+
     await user.click(
       screen.getByRole('radio', {
         name: /shade soul/i,

--- a/src/features/build-config/PlayerConfigModal.test.tsx
+++ b/src/features/build-config/PlayerConfigModal.test.tsx
@@ -24,6 +24,60 @@ const baseAnimation = {
   size: { width: 32, height: 32 },
 } as const;
 
+describe('PlayerConfigModal tabs', () => {
+  it('activates the requested panel when its tab is selected', async () => {
+    const user = userEvent.setup();
+    openModal();
+    await Promise.resolve();
+
+    const spellsTab = screen.getByRole('tab', { name: /spells/i });
+    const charmsTab = screen.getByRole('tab', { name: /charms/i });
+    await user.click(spellsTab);
+
+    await waitFor(() => {
+      expect(spellsTab).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(charmsTab).toHaveAttribute('aria-selected', 'false');
+
+    const tabPanels = screen.getAllByRole('tabpanel', { hidden: true });
+    const findPanelByTab = (tabId: string | null) =>
+      tabPanels.find((panel) => panel.getAttribute('aria-labelledby') === tabId);
+
+    const spellsPanel = findPanelByTab(spellsTab.id);
+    expect(spellsPanel).toBeDefined();
+    expect(spellsPanel).not.toHaveAttribute('hidden');
+
+    const charmsPanel = findPanelByTab(charmsTab.id);
+    expect(charmsPanel).toBeDefined();
+    expect(charmsPanel).toHaveAttribute('hidden');
+  });
+
+  it('supports roving focus and selection via keyboard navigation', async () => {
+    const user = userEvent.setup();
+    openModal();
+    await Promise.resolve();
+
+    const charmsTab = screen.getByRole('tab', { name: /charms/i });
+    charmsTab.focus();
+    expect(charmsTab).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    const synergiesTab = screen.getByRole('tab', { name: /charm synergies/i });
+    expect(synergiesTab).toHaveFocus();
+    expect(synergiesTab).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{End}');
+    const bossTab = screen.getByRole('tab', { name: /boss fight/i });
+    expect(bossTab).toHaveFocus();
+    expect(bossTab).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowUp}');
+    const spellsTab = screen.getByRole('tab', { name: /spells/i });
+    expect(spellsTab).toHaveFocus();
+    expect(spellsTab).toHaveAttribute('aria-selected', 'true');
+  });
+});
+
 describe('PlayerConfigModal charms', () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2448,9 +2448,101 @@ h6 {
 }
 
 .modal__body {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 1.75rem;
+}
+
+@media (width >= 900px) {
+  .modal__body {
+    grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.modal-tabs {
+  display: contents;
+}
+
+.modal-tabs__nav {
+  align-self: start;
+}
+
+.modal-tabs__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.modal-tabs__item {
+  margin: 0;
+}
+
+.modal-tabs__button {
+  width: 100%;
+  border: 1px solid var(--color-border-faint);
+  background:
+    linear-gradient(140deg, rgb(255 255 255 / 6%), transparent),
+    var(--color-surface-muted);
+  color: inherit;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-align: left;
+  cursor: pointer;
+  clip-path: var(--shape-tablet);
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.modal-tabs__button:hover,
+.modal-tabs__button:focus-visible {
+  outline: none;
+  color: var(--color-accent);
+  transform: translateY(-1px);
+  box-shadow:
+    0 12px 24px rgb(0 0 0 / 55%),
+    0 0 18px rgb(181 227 255 / 22%),
+    inset 0 0 0 1px rgb(181 227 255 / 28%);
+}
+
+.modal-tabs__button--active {
+  background:
+    linear-gradient(135deg, rgb(130 207 255 / 26%), transparent 65%), var(--color-surface);
+  border-color: rgb(181 227 255 / 55%);
+  color: var(--color-text);
+  box-shadow:
+    0 16px 32px rgb(0 0 0 / 58%),
+    0 0 24px rgb(181 227 255 / 26%),
+    inset 0 0 0 1px rgb(181 227 255 / 38%);
+}
+
+.modal-tabs__separator {
+  height: 1px;
+  background: var(--color-border-faint);
+  margin: 0.6rem 0;
+  border-radius: 999px;
+}
+
+.modal-tabs__panels {
+  display: grid;
+  gap: 1.75rem;
+  min-width: 0;
+}
+
+.modal-tabs__panel {
+  min-width: 0;
+}
+
+@media (width < 600px) {
+  .modal-tabs__button {
+    padding-inline: 0.85rem;
+  }
 }
 
 .modal-section {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -267,7 +267,10 @@ test.describe('Landing page', () => {
     const modal = page.getByRole('dialog', { name: 'Player Loadout' });
     await expect(modal).toBeVisible();
 
+    await modal.getByRole('tab', { name: 'Nail' }).click();
     await modal.locator('#nail-level').selectOption('pure-nail');
+
+    await modal.getByRole('tab', { name: 'Charms' }).click();
     await modal.getByRole('button', { name: 'Strength & Quick Slash' }).click();
 
     await modal.getByRole('button', { name: 'Close', exact: true }).click();
@@ -307,7 +310,10 @@ test.describe('Landing page', () => {
     const reopenedModal = page.getByRole('dialog', { name: 'Player Loadout' });
     await expect(reopenedModal).toBeVisible();
 
+    await reopenedModal.getByRole('tab', { name: 'Nail' }).click();
     await expect(reopenedModal.locator('#nail-level')).toHaveValue('pure-nail');
+
+    await reopenedModal.getByRole('tab', { name: 'Charms' }).click();
     await expect(
       reopenedModal.getByRole('button', { name: /^Unbreakable Strength/ }),
     ).toHaveAttribute('aria-pressed', 'true');


### PR DESCRIPTION
## Summary
- refactor the player loadout modal to use vertical tabs with accessible keyboard interactions and dedicated panels for charms, synergies, nail, spells, and boss fight setup
- restyle the modal body into a responsive grid with tab navigation treatments and separator accents
- cover the new tab behavior with unit tests and adjust attack log tests to select the spells panel before interacting with options

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68edaf135134832fafae18e7cfb12d03