### PR TITLE
refactor: route encounter setup through loadout modal

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,7 +19,6 @@ import {
 import { HelpModal } from '../features/help/HelpModal';
 import { useVisualViewportCssVars } from './useVisualViewportCssVars';
 import { SurfaceSection } from '../components/SurfaceSection';
-import { EncounterSetupPanel } from '../features/encounter-setup';
 import { HeaderBar } from './components/HeaderBar';
 import { MobilePinnedHud } from './components/MobilePinnedHud';
 import { formatSequenceHeaderLabel } from './formatSequenceHeaderLabel';
@@ -29,7 +28,6 @@ const AppContent: FC = () => {
   useVisualViewportCssVars();
 
   const [isModalOpen, setModalOpen] = useState(false);
-  const [isSetupOpen, setSetupOpen] = useState(false);
   const [isHelpOpen, setHelpOpen] = useState(false);
   const handleCloseLoadout = useCallback(() => {
     setModalOpen(false);
@@ -39,31 +37,15 @@ const AppContent: FC = () => {
   }, [setHelpOpen]);
 
   const {
-    bosses,
-    bossSelectValue,
-    handleBossChange,
-    selectedBoss,
-    selectedBossId,
-    handleBossVersionChange,
     selectedTarget,
     selectedVersion,
-    customTargetHp,
-    handleCustomHpChange,
-    bossSequences,
-    sequenceSelectValue,
-    handleSequenceChange,
     sequenceEntries,
     cappedSequenceIndex,
-    handleSequenceStageChange,
     handleAdvanceSequence,
     handleRewindSequence,
     hasNextSequenceStage,
     hasPreviousSequenceStage,
     activeSequence,
-    sequenceConditionValues,
-    handleSequenceConditionToggle,
-    sequenceBindingValues,
-    handleSequenceBindingToggle,
     currentSequenceEntry,
   } = useBuildConfiguration();
 
@@ -172,16 +154,12 @@ const AppContent: FC = () => {
         encounterName={encounterName}
         versionLabel={versionLabel}
         arenaLabel={arenaLabel}
-        onToggleSetup={() => {
-          setSetupOpen((open) => !open);
-        }}
         onOpenLoadout={() => {
           setModalOpen(true);
         }}
         onOpenHelp={() => {
           setHelpOpen(true);
         }}
-        isSetupOpen={isSetupOpen}
         stageLabel={stageLabel}
         stageProgress={stageProgress}
         onAdvanceStage={handleAdvanceSequence}
@@ -194,31 +172,6 @@ const AppContent: FC = () => {
         encounterName={encounterName}
         arenaLabel={arenaLabel}
       />
-
-      <EncounterSetupPanel
-        isOpen={isSetupOpen}
-        bosses={bosses}
-        bossSelectValue={bossSelectValue}
-        onBossChange={handleBossChange}
-        selectedBoss={selectedBoss}
-        selectedBossId={selectedBossId}
-        onBossVersionChange={handleBossVersionChange}
-        selectedTarget={selectedTarget}
-        selectedVersion={selectedVersion}
-        customTargetHp={customTargetHp}
-        onCustomHpChange={handleCustomHpChange}
-        bossSequences={bossSequences}
-        sequenceSelectValue={sequenceSelectValue}
-        onSequenceChange={handleSequenceChange}
-        sequenceEntries={sequenceEntries}
-        cappedSequenceIndex={cappedSequenceIndex}
-        onStageSelect={handleSequenceStageChange}
-        sequenceConditionValues={sequenceConditionValues}
-        onConditionToggle={handleSequenceConditionToggle}
-        sequenceBindingValues={sequenceBindingValues}
-        onBindingToggle={handleSequenceBindingToggle}
-      />
-
       <main className="app-main">
         <AttackLogProvider>
           <SurfaceSection

--- a/src/app/components/HeaderBar.tsx
+++ b/src/app/components/HeaderBar.tsx
@@ -9,10 +9,8 @@ export type HeaderBarProps = {
   readonly encounterName: string;
   readonly versionLabel: string | null;
   readonly arenaLabel: string | null;
-  readonly onToggleSetup: () => void;
   readonly onOpenLoadout: () => void;
   readonly onOpenHelp: () => void;
-  readonly isSetupOpen: boolean;
   readonly stageLabel: string | null;
   readonly stageProgress: { current: number; total: number } | null;
   readonly onAdvanceStage: () => void;
@@ -26,10 +24,8 @@ export const HeaderBar: FC<HeaderBarProps> = ({
   encounterName,
   versionLabel,
   arenaLabel,
-  onToggleSetup,
   onOpenLoadout,
   onOpenHelp,
-  isSetupOpen,
   stageLabel,
   stageProgress,
   onAdvanceStage,
@@ -55,14 +51,6 @@ export const HeaderBar: FC<HeaderBarProps> = ({
     }
     actions={
       <div className="hud-actions">
-        <AppButton
-          type="button"
-          onClick={onToggleSetup}
-          aria-expanded={isSetupOpen}
-          aria-controls="encounter-setup"
-        >
-          Setup
-        </AppButton>
         <AppButton
           type="button"
           onClick={onOpenLoadout}


### PR DESCRIPTION
## Summary
- remove the header Setup button and drive encounter configuration from the loadout modal
- update application tests and Playwright helpers to open the Boss Fight tab inside the loadout modal
- adjust combat log end-to-end coverage to exercise the modal-based selector

## Testing
- PLAYWRIGHT_USE_PREVIEW=true pnpm test:e2e
- pnpm vitest run src/app/App.test.tsx
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68edc8b84034832f8d2a7b98e26bb4fb