### PR TITLE
feat: redesign player notch overview

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2620,21 +2620,12 @@ h6 {
   border-radius: 999px;
 }
 
-@media (width >= 900px) {
-  .charm-workbench__overview {
-    grid-template-columns: minmax(0, 1.1fr) minmax(240px, 0.9fr);
-    align-items: stretch;
-  }
-}
-
 @media (width >= 1280px) {
   .charm-workbench__grid {
     --charm-size: 4.9rem;
   }
 }
 
-.equipped-panel,
-.notch-panel,
 .preset-panel,
 .synergy-panel {
   position: relative;
@@ -2656,8 +2647,6 @@ h6 {
   overflow: hidden;
 }
 
-.equipped-panel::before,
-.notch-panel::before,
 .preset-panel::before,
 .synergy-panel::before {
   content: '';
@@ -2671,16 +2660,12 @@ h6 {
   pointer-events: none;
 }
 
-.equipped-panel > *,
-.notch-panel > *,
 .preset-panel > *,
 .synergy-panel > * {
   position: relative;
   z-index: 1;
 }
 
-.equipped-panel__title,
-.notch-panel__title,
 .preset-panel__title {
   margin: 0;
   font-size: var(--font-size-subhead);
@@ -2689,201 +2674,128 @@ h6 {
   color: var(--color-muted);
 }
 
-.equipped-panel__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(48px, 1fr));
-  gap: 0.45rem;
-}
-
-.equipped-panel__item {
-  display: grid;
-  place-items: center;
-  padding: 0.45rem;
-  border-radius: 12px;
-  border: 1px solid var(--color-border-faint);
-  background-color: var(--color-surface-muted);
-  background-image:
-    linear-gradient(145deg, rgb(255 255 255 / 12%), transparent), var(--texture-vein);
-  box-shadow:
-    inset 0 0 0 1px rgb(255 255 255 / 8%),
-    inset 0 -1px 0 rgb(0 0 0 / 55%);
-}
-
-.equipped-panel__item--hidden {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.equipped-panel__icon {
-  width: 2.2rem;
-  height: 2.2rem;
-  object-fit: contain;
-}
-
-.equipped-panel__empty {
+.preset-panel__description {
   margin: 0;
   font-size: var(--font-size-caption);
   color: var(--color-muted);
 }
 
-.notch-panel {
-  position: relative;
-  overflow: hidden;
+.equipped-overview {
+  display: grid;
+  gap: 1rem;
 }
 
-.notch-panel__header {
+@media (width >= 900px) {
+  .equipped-overview {
+    grid-template-columns: minmax(0, 1fr) minmax(220px, auto);
+    align-items: start;
+    gap: 1.25rem;
+  }
+}
+
+.equipped-overview__body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.equipped-overview__header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.notch-panel__usage {
-  font-weight: 600;
+.equipped-overview__title {
+  margin: 0;
+  font-size: var(--font-size-subhead);
+  letter-spacing: 0.04em;
+  text-transform: none;
   color: var(--color-muted);
 }
 
-.notch-panel__bracelet {
-  --notch-size: clamp(1.2rem, 3vw, 1.6rem);
-
-  display: flex;
-  flex-wrap: nowrap;
-  gap: clamp(0.45rem, 0.9vw, 0.6rem);
-  align-items: center;
-  padding: clamp(0.6rem, 1.4vw, 0.85rem) clamp(0.85rem, 2.2vw, 1.2rem);
-  border-radius: 999px;
-  border: 1px solid var(--color-border-soft);
-  background-color: #12192b;
-  background-image:
-    linear-gradient(120deg, rgb(255 255 255 / 14%), transparent),
-    radial-gradient(circle at 10% 50%, rgb(214 217 231 / 12%), transparent 65%),
-    radial-gradient(circle at 90% 50%, rgb(24 38 66 / 75%), transparent 75%);
-  box-shadow:
-    inset 0 0 0 1px rgb(255 255 255 / 12%),
-    inset 0 -3px 4px rgb(0 0 0 / 70%),
-    0 16px 28px rgb(0 0 0 / 58%);
-  position: relative;
-  overflow-x: auto;
-  scrollbar-width: thin;
+.equipped-overview__usage {
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
 }
 
-.notch-panel__bracelet::-webkit-scrollbar {
-  height: 0.35rem;
+.equipped-overview--overcharmed .equipped-overview__usage {
+  color: var(--color-overcharm);
 }
 
-.notch-panel__bracelet::-webkit-scrollbar-thumb {
-  background: rgb(215 245 255 / 28%);
-  border-radius: 999px;
+.equipped-overview__slots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 0.5rem;
 }
 
-.notch-panel__bracelet::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: clamp(0.75rem, 2vw, 1.35rem);
-  right: clamp(0.75rem, 2vw, 1.35rem);
-  height: clamp(0.55rem, 1.2vw, 0.75rem);
-  transform: translateY(-50%);
-  border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    rgb(215 245 255 / 18%),
-    rgb(11 18 32 / 92%),
-    rgb(215 245 255 / 18%)
-  );
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 25%),
-    inset 0 -2px 2px rgb(0 0 0 / 80%);
-  pointer-events: none;
-}
-
-.notch-dot {
-  position: relative;
-  z-index: 1;
-  flex: 0 0 auto;
-  width: var(--notch-size);
-  height: var(--notch-size);
-  border-radius: 50%;
-  border: 2px solid rgb(214 217 231 / 55%);
-  background: radial-gradient(circle at 50% 60%, rgb(18 28 48 / 90%), rgb(5 8 16 / 92%));
-  box-shadow:
-    inset 0 0 8px rgb(0 0 0 / 75%),
-    0 4px 8px rgb(0 0 0 / 55%);
+.equipped-overview__slot {
+  display: grid;
+  place-items: center;
+  min-height: 48px;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  border: 1px solid var(--color-border-faint);
+  background-color: var(--color-surface-muted);
   transition:
-    transform 160ms ease,
+    border-color 160ms ease,
     box-shadow 160ms ease,
-    border-color 160ms ease;
+    background-color 160ms ease;
 }
 
-.notch-dot::before {
-  content: '';
-  position: absolute;
-  inset: 24%;
-  border-radius: 50%;
-  border: 1px solid rgb(255 255 255 / 18%);
-  background: radial-gradient(
-    circle at 50% 65%,
-    rgb(36 52 82 / 70%),
-    rgb(10 16 30 / 92%)
-  );
-  box-shadow: inset 0 0 6px rgb(0 0 0 / 75%);
-  pointer-events: none;
+.equipped-overview__slot--filled {
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 12%);
 }
 
-.notch-dot--available {
-  border-color: rgb(214 217 231 / 65%);
+.equipped-overview__slot--free {
+  border-style: dashed;
+  border-color: rgb(214 217 231 / 55%);
 }
 
-.notch-dot--available::before {
-  background: radial-gradient(
-    circle at 50% 45%,
-    rgb(105 142 198 / 45%),
-    rgb(12 20 34 / 88%)
-  );
+.equipped-overview__slot--empty {
+  background: none;
+  border-style: dashed;
 }
 
-.notch-dot--filled {
-  transform: scale(1.1);
-  border-color: rgb(215 245 255 / 75%);
-  box-shadow:
-    0 8px 16px rgb(0 0 0 / 60%),
-    0 0 24px rgb(215 245 255 / 35%),
-    inset 0 0 12px rgb(215 245 255 / 25%);
-}
-
-.notch-dot--filled::before {
-  background: radial-gradient(
-    circle at 50% 45%,
-    rgb(215 245 255 / 85%),
-    rgb(110 154 208 / 55%),
-    transparent 78%
-  );
-  border-color: rgb(215 245 255 / 55%);
-  box-shadow:
-    inset 0 0 10px rgb(215 245 255 / 45%),
-    0 0 18px rgb(215 245 255 / 35%);
-}
-
-.notch-dot--locked {
-  opacity: 0.25;
-}
-
-.notch-dot--overfill {
+.equipped-overview__slot--overflow {
   border-color: var(--color-overcharm);
   box-shadow:
-    0 10px 20px rgb(0 0 0 / 60%),
-    0 0 26px var(--color-overcharm-glow),
-    inset 0 0 10px rgb(255 220 240 / 45%);
+    0 0 0 1px var(--color-overcharm),
+    0 0 18px rgb(255 110 219 / 25%);
+  background-color: rgb(255 110 219 / 12%);
 }
 
-.notch-panel__slider {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+.equipped-overview__slot--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
-.notch-panel__slider-label {
+.equipped-overview__icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  object-fit: contain;
+}
+
+.equipped-overview__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.equipped-overview__slider {
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+}
+
+@media (width >= 900px) {
+  .equipped-overview__slider {
+    align-self: start;
+  }
+}
+
+.equipped-overview__slider-label {
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -2891,16 +2803,9 @@ h6 {
   color: var(--color-muted);
 }
 
-.notch-panel__slider input[type='range'] {
+.equipped-overview__slider input[type='range'] {
   width: 100%;
   accent-color: var(--color-accent);
-}
-
-.notch-panel__description,
-.preset-panel__description {
-  margin: 0;
-  font-size: var(--font-size-caption);
-  color: var(--color-muted);
 }
 
 .synergy-panel {
@@ -3127,29 +3032,6 @@ h6 {
 .overcharm-banner__message {
   font-size: 0.88rem;
   color: rgb(255 221 246 / 85%);
-}
-
-.notch-panel--overcharmed {
-  box-shadow:
-    var(--elevation-layer-1),
-    0 18px 48px rgb(255 110 219 / 25%),
-    inset 0 0 0 1px rgb(255 110 219 / 38%);
-}
-
-.notch-panel--overcharmed::after {
-  content: '';
-  position: absolute;
-  inset: -60% -10%;
-  background:
-    linear-gradient(135deg, transparent 45%, rgb(255 110 219 / 45%) 50%, transparent 55%),
-    linear-gradient(45deg, transparent 40%, rgb(255 110 219 / 35%) 46%, transparent 52%);
-  opacity: 0.65;
-  pointer-events: none;
-}
-
-.notch-panel--overcharmed .notch-panel__title,
-.notch-panel--overcharmed .notch-panel__usage {
-  color: var(--color-overcharm);
 }
 
 .charm-grid {


### PR DESCRIPTION
## Summary
- replace the notch bracelet display with a unified equipped overview that renders filled, empty, and overflow notch slots alongside the notch limit slider
- streamline the workbench stylesheet by removing the old panel chrome and introducing new `equipped-overview` utilities
- update PlayerConfigModal tests to cover empty placeholders, filled slots, and slider adjustments

## Testing
- pnpm vitest run src/features/build-config/PlayerConfigModal.test.tsx
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68edf99f48c4832f938af0a410c5fca9