### PR TITLE
feat: persist synergy filter preference

### DIFF
--- a/src/components/CharmSynergyList.tsx
+++ b/src/components/CharmSynergyList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, useState, type FC } from 'react';
 
 import type { Charm, CharmSynergy } from '../data';
 
@@ -45,12 +45,49 @@ const getCategoryLabel = (category: string) => {
     .join(' ');
 };
 
+const SYNERGY_FILTER_STORAGE_KEY = 'hkdt.synergyFilter';
+
 export const CharmSynergyList: FC<CharmSynergyListProps> = ({
   statuses,
   charmDetails,
   iconMap,
 }) => {
-  const [showAllSynergies, setShowAllSynergies] = useState(false);
+  const [showAllSynergies, setShowAllSynergies] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+
+    try {
+      const storedPreference = window.sessionStorage.getItem(SYNERGY_FILTER_STORAGE_KEY);
+
+      if (storedPreference === 'active') {
+        return false;
+      }
+
+      if (storedPreference === 'all') {
+        return true;
+      }
+    } catch {
+      // Ignore storage access errors and fall back to default.
+    }
+
+    return true;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        SYNERGY_FILTER_STORAGE_KEY,
+        showAllSynergies ? 'all' : 'active',
+      );
+    } catch {
+      // Ignore storage access errors so the UI continues working.
+    }
+  }, [showAllSynergies]);
 
   const activeCount = useMemo(
     () => statuses.reduce((total, status) => (status.isActive ? total + 1 : total), 0),


### PR DESCRIPTION
## Summary
- default the synergy list to show all entries and hydrate the user preference from sessionStorage
- persist filter changes back to sessionStorage while guarding against storage access failures
- extend CharmSynergyList tests to cover the new default view and sessionStorage-backed persistence

## Testing
- pnpm lint
- pnpm exec vitest run src/components/CharmSynergyList.test.tsx
- pnpm test:unit -- --reporter=dot

------
https://chatgpt.com/codex/tasks/task_e_68ee0944f7dc832f8683e8ef876bd6a9